### PR TITLE
Set outer src/dst MAC to zero

### DIFF
--- a/opte-core/src/int_test.rs
+++ b/opte-core/src/int_test.rs
@@ -208,11 +208,6 @@ fn overlay_guest_to_guest() {
     g1_cfg.overlay = Some(OverlayCfg {
         boundary_services: bs.clone(),
         vni: Vni::new(99u32).unwrap(),
-        // Chelsio NIC
-        phys_mac_src: EtherAddr::from([0x00, 0x07, 0x43, 0xF7, 0x00, 0x01]),
-        // Tofino port
-        phys_mac_dst: EtherAddr::from([0xF8, 0x1D, 0x78, 0xDF, 0x00, 0x01]),
-        // Site 0xF7, Rack 1, Sled 1, Interface 1
         phys_ip_src: Ipv6Addr::from([
             0xFD00, 0x0000, 0x00F7, 0x0101, 0x0000, 0x0000, 0x0000, 0x0001,
         ]),
@@ -221,10 +216,6 @@ fn overlay_guest_to_guest() {
     g2_cfg.overlay = Some(OverlayCfg {
         boundary_services: bs.clone(),
         vni: Vni::new(99u32).unwrap(),
-        // Chelsio NIC
-        phys_mac_src: EtherAddr::from([0x00, 0x07, 0x43, 0xF7, 0x00, 0x22]),
-        // Tofino port
-        phys_mac_dst: EtherAddr::from([0xF8, 0x1D, 0x78, 0xDF, 0x00, 0x22]),
         // Site 0xF7, Rack 1, Sled 22, Interface 1
         phys_ip_src: Ipv6Addr::from([
             0xFD00, 0x0000, 0x00F7, 0x0116, 0x0000, 0x0000, 0x0000, 0x0001,
@@ -324,17 +315,8 @@ fn overlay_guest_to_guest() {
     let meta = g1_pkt.meta();
     match meta.outer.ether.as_ref() {
         Some(eth) => {
-            assert_eq!(eth.src, g1_cfg.overlay.as_ref().unwrap().phys_mac_src);
-            // XXX See the note in overlay.rs about the outer ethernet
-            // destination. For the time being we use the guest's VNIC
-            // MAC address to avoid needing underlay routing.
-            //
-            // assert_eq!(
-            //     eth.dst,
-            //     g1_cfg.overlay.as_ref().unwrap().phys_mac_dst
-            // );
-
-            assert_eq!(eth.dst, g2_cfg.private_mac);
+            assert_eq!(eth.src, Default::default());
+            assert_eq!(eth.dst, Default::default());
         }
 
         None => panic!("no outer ether header"),
@@ -476,10 +458,6 @@ fn overlay_guest_to_internet() {
     g1_cfg.overlay = Some(OverlayCfg {
         boundary_services: bs.clone(),
         vni: Vni::new(99u32).unwrap(),
-        // Chelsio NIC
-        phys_mac_src: EtherAddr::from([0x00, 0x07, 0x43, 0xF7, 0x00, 0x01]),
-        // Tofino port
-        phys_mac_dst: EtherAddr::from([0xF8, 0x1D, 0x78, 0xDF, 0x00, 0x01]),
         // Site 0xF7, Rack 1, Sled 1, Interface 1
         phys_ip_src: Ipv6Addr::from([
             0xFD00, 0x0000, 0x00F7, 0x0101, 0x0000, 0x0000, 0x0000, 0x0001,
@@ -540,17 +518,8 @@ fn overlay_guest_to_internet() {
     let meta = g1_pkt.meta();
     match meta.outer.ether.as_ref() {
         Some(eth) => {
-            assert_eq!(eth.src, g1_cfg.overlay.as_ref().unwrap().phys_mac_src);
-            // XXX See the note in overlay.rs about the outer ethernet
-            // destination. For the time being we use the guest's VNIC
-            // MAC address to avoid needing underlay routing.
-            //
-            // assert_eq!(
-            //     eth.dst,
-            //     g1_cfg.overlay.as_ref().unwrap().phys_mac_dst
-            // );
-
-            assert_eq!(eth.dst, bs.ether);
+            assert_eq!(eth.src, Default::default());
+            assert_eq!(eth.dst, Default::default());
         }
 
         None => panic!("no outer ether header"),

--- a/opteadm/src/main.rs
+++ b/opteadm/src/main.rs
@@ -124,12 +124,6 @@ struct SetOverlay {
     vni: u32,
 
     #[structopt(long)]
-    mac_src: EtherAddr,
-
-    #[structopt(long)]
-    mac_dst: EtherAddr,
-
-    #[structopt(long)]
     ip: Ipv6Addr,
 }
 
@@ -164,8 +158,6 @@ impl From<SetOverlay> for overlay::SetOverlayReq {
                     req.boundary_services,
                 ),
                 vni: geneve::Vni::new(req.vni).unwrap(),
-                phys_mac_src: req.mac_src,
-                phys_mac_dst: req.mac_dst,
                 phys_ip_src: opte_ip6::Ipv6Addr::from(req.ip.octets()),
             },
         }


### PR DESCRIPTION
The current plan is to have the upcoming xde device perform the IRE
query and fill out the outer src/dst MAC addresses.

In the future this could be moved into OPTE, but it would require a
new hook to run post UFT (as the UFT's job is to cache transformations
for active flows, but the physical routing needs to be dynamic).