### PR TITLE
Use cfg_if crate (#47)

### DIFF
--- a/opte-core/src/arp.rs
+++ b/opte-core/src/arp.rs
@@ -9,10 +9,13 @@ use core::convert::TryFrom;
 use core::fmt::{self, Display};
 use core::mem;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::vec::Vec;
+    } else {
+        use std::vec::Vec;
+    }
+}
 
 use serde::{Deserialize, Serialize};
 

--- a/opte-core/src/ether.rs
+++ b/opte-core/src/ether.rs
@@ -4,14 +4,15 @@ use core::mem;
 use core::result;
 use core::str::FromStr;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::string::String;
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-#[cfg(any(feature = "std", test))]
-use std::string::String;
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::string::String;
+        use alloc::vec::Vec;
+    } else {
+        use std::string::String;
+        use std::vec::Vec;
+    }
+}
 
 use serde::{Deserialize, Serialize};
 use zerocopy::{AsBytes, FromBytes, LayoutVerified, Unaligned};

--- a/opte-core/src/flow_table.rs
+++ b/opte-core/src/flow_table.rs
@@ -1,17 +1,17 @@
 use core::fmt;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::string::{String, ToString};
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-#[cfg(all(not(feature = "std"), not(test)))]
-use illumos_ddi_dki::{gethrtime, hrtime_t};
-#[cfg(any(feature = "std", test))]
-use std::string::{String, ToString};
-#[cfg(any(feature = "std", test))]
-use std::time::{Duration, Instant};
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::string::{String, ToString};
+        use alloc::vec::Vec;
+        use illumos_ddi_dki::{gethrtime, hrtime_t};
+    } else {
+        use std::string::{String, ToString};
+        use std::time::{Duration, Instant};
+        use std::vec::Vec;
+        use illumos_ddi_dki::c_char;
+    }
+}
 
 use serde::{Deserialize, Serialize};
 
@@ -19,8 +19,6 @@ use crate::layer::InnerFlowId;
 use crate::rule::flow_id_sdt_arg;
 use crate::CString;
 
-#[cfg(any(feature = "std", test))]
-use illumos_ddi_dki::c_char;
 use illumos_ddi_dki::uintptr_t;
 
 pub const FLOW_DEF_EXPIRE_SECS: u32 = 60;

--- a/opte-core/src/geneve.rs
+++ b/opte-core/src/geneve.rs
@@ -2,14 +2,15 @@ use core::convert::TryFrom;
 use core::mem;
 use core::str::FromStr;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::string::{String, ToString};
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-#[cfg(any(feature = "std", test))]
-use std::string::{String, ToString};
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::string::{String, ToString};
+        use alloc::vec::Vec;
+    } else {
+        use std::string::{String, ToString};
+        use std::vec::Vec;
+    }
+}
 
 use serde::{Deserialize, Serialize};
 use zerocopy::{AsBytes, FromBytes, LayoutVerified, Unaligned};

--- a/opte-core/src/headers.rs
+++ b/opte-core/src/headers.rs
@@ -1,9 +1,12 @@
 use core::fmt;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::vec::Vec;
+    } else {
+        use std::vec::Vec;
+    }
+}
 
 use serde::{Deserialize, Serialize};
 use zerocopy::LayoutVerified;

--- a/opte-core/src/ioctl.rs
+++ b/opte-core/src/ioctl.rs
@@ -1,24 +1,19 @@
 //! The ioctl interface.
 use core::convert::TryFrom;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::string::String;
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::sync::Arc;
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-#[cfg(any(feature = "std", test))]
-use std::string::String;
-#[cfg(any(feature = "std", test))]
-use std::sync::Arc;
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::string::String;
+        use alloc::sync::Arc;
+        use alloc::vec::Vec;
+    } else {
+        use std::string::String;
+        use std::sync::Arc;
+        use std::vec::Vec;
+    }
+}
 
-#[cfg(all(not(feature = "std"), not(test)))]
 use illumos_ddi_dki::{c_int, datalink_id_t, size_t};
-#[cfg(any(feature = "std", test))]
-use illumos_ddi_dki::{c_int, datalink_id_t, size_t};
-
 use serde::{Deserialize, Serialize};
 
 use crate::ether::EtherAddr;

--- a/opte-core/src/ip4.rs
+++ b/opte-core/src/ip4.rs
@@ -5,14 +5,15 @@ use core::num::ParseIntError;
 use core::result;
 use core::str::FromStr;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::string::{String, ToString};
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-#[cfg(any(feature = "std", test))]
-use std::string::{String, ToString};
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::string::{String, ToString};
+        use alloc::vec::Vec;
+    } else {
+        use std::string::{String, ToString};
+        use std::vec::Vec;
+    }
+}
 
 // A fixed-size Vec.
 use heapless::Vec as FVec;

--- a/opte-core/src/ip6.rs
+++ b/opte-core/src/ip6.rs
@@ -2,10 +2,13 @@ use core::convert::TryFrom;
 use core::fmt;
 use core::mem::size_of;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::vec::Vec;
+    } else {
+        use std::vec::Vec;
+    }
+}
 
 use serde::{Deserialize, Serialize};
 use zerocopy::{AsBytes, FromBytes, LayoutVerified, Unaligned};

--- a/opte-core/src/layer.rs
+++ b/opte-core/src/layer.rs
@@ -3,18 +3,19 @@ use core::fmt::{self, Display};
 use core::mem;
 use core::result;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::string::{String, ToString};
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::sync::Arc;
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-#[cfg(any(feature = "std", test))]
-use std::string::{String, ToString};
-#[cfg(any(feature = "std", test))]
-use std::sync::Arc;
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::string::{String, ToString};
+        use alloc::sync::Arc;
+        use alloc::vec::Vec;
+        use illumos_ddi_dki::hrtime_t;
+    } else {
+        use std::string::{String, ToString};
+        use std::sync::Arc;
+        use std::time::Instant;
+        use std::vec::Vec;
+    }
+}
 
 use serde::{Deserialize, Serialize};
 
@@ -32,11 +33,6 @@ use crate::sync::{KMutex, KMutexType};
 use crate::{CString, Direction, ExecCtx, LogLevel};
 
 use illumos_ddi_dki::{c_char, uintptr_t};
-
-#[cfg(all(not(feature = "std"), not(test)))]
-use illumos_ddi_dki::hrtime_t;
-#[cfg(any(feature = "std", test))]
-use std::time::Instant;
 
 #[derive(Debug)]
 pub enum LayerError {

--- a/opte-core/src/lib.rs
+++ b/opte-core/src/lib.rs
@@ -12,6 +12,11 @@
 #![deny(unreachable_patterns)]
 #![deny(unused_must_use)]
 
+use core::fmt::{self, Display};
+use core::num::ParseIntError;
+use core::str::FromStr;
+
+// NOTE: Things get weird if you move the extern crate into cfg_if!.
 #[cfg(any(feature = "std", test))]
 #[macro_use]
 extern crate std;
@@ -23,23 +28,17 @@ extern crate alloc;
 #[macro_use]
 extern crate cfg_if;
 
-use core::fmt::{self, Display};
-use core::num::ParseIntError;
-use core::str::FromStr;
-
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::boxed::Box;
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::string::{String, ToString};
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-#[cfg(any(feature = "std", test))]
-use std::boxed::Box;
-#[cfg(any(feature = "std", test))]
-use std::string::String;
-
-#[cfg(all(not(feature = "std"), not(test)))]
-use illumos_ddi_dki as ddi;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::boxed::Box;
+        use alloc::string::{String, ToString};
+        use alloc::vec::Vec;
+        use illumos_ddi_dki as ddi;
+    } else {
+        use std::boxed::Box;
+        use std::string::String;
+    }
+}
 
 // TODO Not sure reexporting makes sense, but felt like trying it on
 // for size.

--- a/opte-core/src/nat.rs
+++ b/opte-core/src/nat.rs
@@ -1,22 +1,19 @@
 use core::fmt;
 use core::ops::Range;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::collections::btree_map::BTreeMap;
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::string::ToString;
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::sync::Arc;
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-#[cfg(any(feature = "std", test))]
-use std::collections::btree_map::BTreeMap;
-#[cfg(any(feature = "std", test))]
-use std::string::ToString;
-#[cfg(any(feature = "std", test))]
-use std::sync::Arc;
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::collections::btree_map::BTreeMap;
+        use alloc::string::ToString;
+        use alloc::sync::Arc;
+        use alloc::vec::Vec;
+    } else {
+        use std::collections::btree_map::BTreeMap;
+        use std::string::ToString;
+        use std::sync::Arc;
+        use std::vec::Vec;
+    }
+}
 
 use crate::headers::{UlpGenericModify, UlpHeaderAction, UlpMetaModify};
 use crate::ip4::{Ipv4Addr, Ipv4Meta};

--- a/opte-core/src/oxide_net/arp.rs
+++ b/opte-core/src/oxide_net/arp.rs
@@ -1,7 +1,10 @@
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::sync::Arc;
-#[cfg(any(feature = "std", test))]
-use std::sync::Arc;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::sync::Arc;
+    } else {
+        use std::sync::Arc;
+    }
+}
 
 use crate::arp::{ArpOp, ArpReply};
 use crate::ether::{EtherAddr, ETHER_TYPE_ARP, ETHER_TYPE_IPV4};

--- a/opte-core/src/oxide_net/dhcp4.rs
+++ b/opte-core/src/oxide_net/dhcp4.rs
@@ -11,15 +11,15 @@
 use core::fmt::{self, Display};
 use core::result::Result;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::sync::Arc;
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-
-#[cfg(any(feature = "std", test))]
-use std::sync::Arc;
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::sync::Arc;
+        use alloc::vec::Vec;
+    } else {
+        use std::sync::Arc;
+        use std::vec::Vec;
+    }
+}
 
 use smoltcp::wire::{DhcpPacket, DhcpRepr, EthernetAddress, Ipv4Address};
 

--- a/opte-core/src/oxide_net/dyn_nat4.rs
+++ b/opte-core/src/oxide_net/dyn_nat4.rs
@@ -1,11 +1,12 @@
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::boxed::Box;
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::sync::Arc;
-#[cfg(any(feature = "std", test))]
-use std::boxed::Box;
-#[cfg(any(feature = "std", test))]
-use std::sync::Arc;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::boxed::Box;
+        use alloc::sync::Arc;
+    } else {
+        use std::boxed::Box;
+        use std::sync::Arc;
+    }
+}
 
 use crate::ip4::{self, Protocol};
 use crate::layer::Layer;

--- a/opte-core/src/oxide_net/firewall.rs
+++ b/opte-core/src/oxide_net/firewall.rs
@@ -2,18 +2,17 @@ use core::fmt::{self, Display};
 use core::result;
 use core::str::FromStr;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::string::{String, ToString};
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::sync::Arc;
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-#[cfg(any(feature = "std", test))]
-use std::string::{String, ToString};
-#[cfg(any(feature = "std", test))]
-use std::sync::Arc;
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::string::{String, ToString};
+        use alloc::sync::Arc;
+        use alloc::vec::Vec;
+    } else {
+        use std::string::{String, ToString};
+        use std::sync::Arc;
+        use std::vec::Vec;
+    }
+}
 
 use serde::{Deserialize, Serialize};
 

--- a/opte-core/src/oxide_net/icmp.rs
+++ b/opte-core/src/oxide_net/icmp.rs
@@ -1,14 +1,14 @@
 use core::fmt::{self, Display};
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::sync::Arc;
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-
-#[cfg(any(feature = "std", test))]
-use std::sync::Arc;
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::sync::Arc;
+        use alloc::vec::Vec;
+    } else {
+        use std::sync::Arc;
+        use std::vec::Vec;
+    }
+}
 
 use smoltcp::phy::{Checksum, ChecksumCapabilities as Csum};
 use smoltcp::wire::{Icmpv4Packet, Icmpv4Repr};

--- a/opte-core/src/oxide_net/overlay.rs
+++ b/opte-core/src/oxide_net/overlay.rs
@@ -3,18 +3,17 @@
 //! This implements the Oxide Network VPC Overlay.
 use core::fmt;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::collections::btree_map::BTreeMap;
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::string::{String, ToString};
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::sync::Arc;
-#[cfg(any(feature = "std", test))]
-use std::collections::btree_map::BTreeMap;
-#[cfg(any(feature = "std", test))]
-use std::string::{String, ToString};
-#[cfg(any(feature = "std", test))]
-use std::sync::Arc;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::collections::btree_map::BTreeMap;
+        use alloc::string::{String, ToString};
+        use alloc::sync::Arc;
+    } else {
+        use std::collections::btree_map::BTreeMap;
+        use std::string::{String, ToString};
+        use std::sync::Arc;
+    }
+}
 
 use serde::{Deserialize, Serialize};
 

--- a/opte-core/src/oxide_net/router.rs
+++ b/opte-core/src/oxide_net/router.rs
@@ -5,14 +5,15 @@
 use core::fmt;
 use core::str::FromStr;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::string::{String, ToString};
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::sync::Arc;
-#[cfg(any(feature = "std", test))]
-use std::string::{String, ToString};
-#[cfg(any(feature = "std", test))]
-use std::sync::Arc;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::string::{String, ToString};
+        use alloc::sync::Arc;
+    } else {
+        use std::string::{String, ToString};
+        use std::sync::Arc;
+    }
+}
 
 use serde::{Deserialize, Serialize};
 

--- a/opte-core/src/packet.rs
+++ b/opte-core/src/packet.rs
@@ -14,17 +14,17 @@ use core::ptr;
 use core::result;
 use core::slice;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::string::String;
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-#[cfg(any(feature = "std", test))]
-use std::string::String;
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
-
-#[cfg(any(feature = "std", test))]
-use std::boxed::Box;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::string::String;
+        use alloc::vec::Vec;
+        use illumos_ddi_dki as ddi;
+    } else {
+        use std::boxed::Box;
+        use std::string::String;
+        use std::vec::Vec;
+    }
+}
 
 use serde::{Deserialize, Serialize};
 
@@ -39,9 +39,6 @@ use crate::ip4::{Ipv4Hdr, Ipv4HdrError, Ipv4Meta, Protocol, IPV4_HDR_SZ};
 use crate::ip6::{Ipv6Hdr, Ipv6HdrError, Ipv6Meta, IPV6_HDR_SZ};
 use crate::tcp::{TcpHdr, TcpHdrError, TcpMeta};
 use crate::udp::{UdpHdr, UdpHdrError, UdpMeta, UDP_HDR_SZ};
-
-#[cfg(all(not(feature = "std"), not(test)))]
-use illumos_ddi_dki as ddi;
 
 use illumos_ddi_dki::{c_uchar, dblk_t, mblk_t};
 

--- a/opte-core/src/port.rs
+++ b/opte-core/src/port.rs
@@ -1,24 +1,20 @@
+/// A virtual switch port.
 use core::convert::TryFrom;
 use core::result;
 
-/// A virtual switch port.
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::string::{String, ToString};
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::sync::Arc;
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-#[cfg(any(feature = "std", test))]
-use std::string::{String, ToString};
-#[cfg(any(feature = "std", test))]
-use std::sync::Arc;
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
-
-#[cfg(all(not(feature = "std"), not(test)))]
-use illumos_ddi_dki::hrtime_t;
-#[cfg(any(feature = "std", test))]
-use std::time::Instant;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::string::{String, ToString};
+        use alloc::sync::Arc;
+        use alloc::vec::Vec;
+        use illumos_ddi_dki::hrtime_t;
+    } else {
+        use std::string::{String, ToString};
+        use std::sync::Arc;
+        use std::time::Instant;
+        use std::vec::Vec;
+    }
+}
 
 use serde::{Deserialize, Serialize};
 

--- a/opte-core/src/rule.rs
+++ b/opte-core/src/rule.rs
@@ -1,21 +1,18 @@
 use core::fmt::{self, Display};
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::boxed::Box;
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::string::{String, ToString};
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::sync::Arc;
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-#[cfg(any(feature = "std", test))]
-use std::boxed::Box;
-#[cfg(any(feature = "std", test))]
-use std::string::{String, ToString};
-#[cfg(any(feature = "std", test))]
-use std::sync::Arc;
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::boxed::Box;
+        use alloc::string::{String, ToString};
+        use alloc::sync::Arc;
+        use alloc::vec::Vec;
+    } else {
+        use std::boxed::Box;
+        use std::string::{String, ToString};
+        use std::sync::Arc;
+        use std::vec::Vec;
+    }
+}
 
 use crate::arp::{
     ArpEth4Payload, ArpEth4PayloadRaw, ArpMeta, ArpOp, ARP_HTYPE_ETHERNET,

--- a/opte-core/src/sync.rs
+++ b/opte-core/src/sync.rs
@@ -4,19 +4,20 @@
 //! crate. But for now just let it live here.
 use core::ops::{Deref, DerefMut};
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use core::cell::UnsafeCell;
-#[cfg(all(not(feature = "std"), not(test)))]
-use core::ptr;
-#[cfg(any(feature = "std", test))]
-use std::sync::Mutex;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use core::cell::UnsafeCell;
+        use core::ptr;
+        use illumos_ddi_dki::{
+            kmutex_t, krw_t, krw_type_t, krwlock_t, mutex_enter, mutex_exit,
+            mutex_init, rw_enter, rw_exit, rw_init,
+        };
+    } else {
+        use std::sync::Mutex;
+    }
+}
 
 use illumos_ddi_dki::kmutex_type_t;
-#[cfg(all(not(feature = "std"), not(test)))]
-use illumos_ddi_dki::{
-    kmutex_t, krw_t, krw_type_t, krwlock_t, mutex_enter, mutex_exit,
-    mutex_init, rw_enter, rw_exit, rw_init,
-};
 
 /// Exposes the illumos mutex(9F) API in a safe manner. We name it
 /// `KMutex` (Kernel Mutex) on purpose. The API for a kernel mutex

--- a/opte-core/src/tcp.rs
+++ b/opte-core/src/tcp.rs
@@ -2,10 +2,13 @@ use core::convert::TryFrom;
 use core::fmt::{self, Display};
 use core::mem;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::vec::Vec;
+    } else {
+        use std::vec::Vec;
+    }
+}
 
 use serde::{Deserialize, Serialize};
 use zerocopy::{AsBytes, FromBytes, LayoutVerified, Unaligned};

--- a/opte-core/src/tcp_state.rs
+++ b/opte-core/src/tcp_state.rs
@@ -1,9 +1,12 @@
 use core::fmt::{self, Display};
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::string::String;
-#[cfg(any(feature = "std", test))]
-use std::string::String;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::string::String;
+    } else {
+        use std::string::String;
+    }
+}
 
 use serde::{Deserialize, Serialize};
 

--- a/opte-core/src/udp.rs
+++ b/opte-core/src/udp.rs
@@ -1,10 +1,13 @@
 use core::convert::TryFrom;
 use core::mem;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::vec::Vec;
-#[cfg(any(feature = "std", test))]
-use std::vec::Vec;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::vec::Vec;
+    } else {
+        use std::vec::Vec;
+    }
+}
 
 use serde::{Deserialize, Serialize};
 use zerocopy::{AsBytes, FromBytes, LayoutVerified, Unaligned};

--- a/opte-core/src/vpc.rs
+++ b/opte-core/src/vpc.rs
@@ -15,10 +15,13 @@ use core::convert::TryFrom;
 use core::result;
 use core::str::FromStr;
 
-#[cfg(all(not(feature = "std"), not(test)))]
-use alloc::string::String;
-#[cfg(any(feature = "std", test))]
-use std::string::String;
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::string::String;
+    } else {
+        use std::string::String;
+    }
+}
 
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
Rewrote all the opte-core module imports with `cfg_if!`. I'd say this is easier on the eyes than repeating the cfg attribute each time.