### PR TITLE
clarify dump-v2p language a bit

### DIFF
--- a/opte-core/src/oxide_net/overlay.rs
+++ b/opte-core/src/oxide_net/overlay.rs
@@ -269,8 +269,8 @@ pub struct Virt2Phys {
     // that makes use of this virtual destination (for all Ports).
     // That means updating the generation number of all Ports anytme
     // an entry is **MODIFIED**.
-    pub ip4: KMutex<BTreeMap<Ipv4Addr, PhysNet>>,
-    pub ip6: KMutex<BTreeMap<Ipv6Addr, PhysNet>>,
+    ip4: KMutex<BTreeMap<Ipv4Addr, PhysNet>>,
+    ip6: KMutex<BTreeMap<Ipv6Addr, PhysNet>>,
 }
 
 pub const VIRT_2_PHYS_NAME: &'static str = "Virt2Phys";
@@ -280,6 +280,13 @@ impl Virt2Phys {
         match vip {
             IpAddr::Ip4(ip4) => self.ip4.lock().get(ip4).cloned(),
             IpAddr::Ip6(ip6) => self.ip6.lock().get(ip6).cloned(),
+        }
+    }
+
+    pub fn dump(&self) -> DumpVirt2PhysResp {
+        DumpVirt2PhysResp {
+            ip4: self.ip4.lock().clone(),
+            ip6: self.ip6.lock().clone(),
         }
     }
 

--- a/opteadm/src/main.rs
+++ b/opteadm/src/main.rs
@@ -106,9 +106,9 @@ enum Command {
 
     /// Set a virtual-to-physical mapping
     SetV2P {
-        vip4: Ipv4Addr,
-        phys_ether: EtherAddr,
-        phys_ip: std::net::Ipv6Addr,
+        vpc_ip4: Ipv4Addr,
+        vpc_ether: EtherAddr,
+        underlay_ip: std::net::Ipv6Addr,
         vni: geneve::Vni,
     },
 
@@ -425,15 +425,15 @@ fn print_list_layers(resp: &api::ListLayersResp) {
 
 fn print_v2p_header() {
     println!(
-        "{:<15} {:<8} {:<20} {:<20}",
-        "SOURCE", "VNI", "DEST ETH", "DEST IP"
+        "{:<24} {:<8} {:<17} {}",
+        "VPC IP", "VNI", "VPC MAC ADDR", "UNDERLAY IP"
     );
 }
 
 fn print_v2p_ip4((src, phys): (&Ipv4Addr, &overlay::PhysNet)) {
     let eth = format!("{}", phys.ether);
     println!(
-        "{:<15} {:<8} {:<20} {:<20}",
+        "{:<24} {:<8} {:<17} {}",
         std::net::Ipv4Addr::from(src.to_be_bytes()),
         phys.vni.value(),
         eth,
@@ -444,7 +444,7 @@ fn print_v2p_ip4((src, phys): (&Ipv4Addr, &overlay::PhysNet)) {
 fn print_v2p_ip6((src, phys): (&Ipv6Addr, &overlay::PhysNet)) {
     let eth = format!("{}", phys.ether);
     println!(
-        "{:<15} {:<8} {:<20} {:<20}",
+        "{:<24} {:<8} {:<17} {}",
         std::net::Ipv6Addr::from(src.to_bytes()),
         phys.vni.value(),
         eth,
@@ -636,12 +636,12 @@ fn main() {
             hdl.remove_firewall_rule(&request).unwrap_or_die();
         }
 
-        Command::SetV2P { vip4, phys_ether, phys_ip, vni } => {
+        Command::SetV2P { vpc_ip4, vpc_ether, underlay_ip, vni } => {
             let hdl = opteadm::OpteAdm::open(OpteAdm::DLD_CTL).unwrap_or_die();
-            let vip = IpAddr::Ip4(vip4);
+            let vip = IpAddr::Ip4(vpc_ip4);
             let phys = overlay::PhysNet {
-                ether: phys_ether,
-                ip: Ipv6Addr::from(phys_ip),
+                ether: vpc_ether,
+                ip: Ipv6Addr::from(underlay_ip),
                 vni,
             };
             let req = overlay::SetVirt2PhysReq { vip, phys };

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -310,7 +310,7 @@ unsafe extern "C" fn xde_dld_ioc_opte_cmd(
         }
 
         OpteCmd::DumpVirt2Phys => {
-            let resp = list_v2p_hdlr(&mut env);
+            let resp = dump_v2p_hdlr(&mut env);
             hdlr_resp(&mut env, resp)
         }
 
@@ -1727,15 +1727,12 @@ fn set_v2p_hdlr(env: &mut IoctlEnvelope) -> Result<NoResp, OpteError> {
 }
 
 #[no_mangle]
-fn list_v2p_hdlr(
+fn dump_v2p_hdlr(
     env: &mut IoctlEnvelope,
 ) -> Result<overlay::DumpVirt2PhysResp, OpteError> {
     let _req: overlay::DumpVirt2PhysReq = env.copy_in_req()?;
     let state = get_xde_state();
-    Ok(overlay::DumpVirt2PhysResp {
-        ip4: state.v2p.ip4.lock().clone(),
-        ip6: state.v2p.ip6.lock().clone(),
-    })
+    Ok(state.v2p.dump())
 }
 
 #[no_mangle]


### PR DESCRIPTION
After some discussion with @bnaecker I felt that the `dump-v2p` output could better convey the meaning of the data. Namely that the job of the "V2P" table is to map a guest's VPC IP to its "physical" network information: the guest's ethernet address for this interface, the VNI this interface is a part of, and the address of the sled this guest lives on (aka the underlay IP). Depending on how you look at things this "physical" adjective breaks down a bit. Yes, the VNI and Underlay IP fit squarely in the "physical" camp, but we can easily split straws about the guest MAC address. The VPC currently represents an L3 network, and therefore you could argue the guest's MAC address is in the rack's physical network. However, this information is also decided by Nexus and is of course visible to the guest -- so you could argue it's part of the VPC. We've also left open the possibility of allowing Virtual L2 networks in the future, which somewhat muddies this more. But in my opinion you can think of this address in both ways: the virtual MAC address of the guest's virtual NIC, and the inner MAC address of packets traversing our physical network. For that reason the code still refers to this triple of information as `PhysNet`, but opteadm is presenting it as `VPC MAC ADDR` as an attempt to be more clear to the operator that we are not referring to the sled's MAC address.

Here's a sample of the new output:

```
root@sled1:/opt/cargo-bay# ./opteadm dump-v2p
Virtual to Physical Mappings
======================================================================

IPv4 mappings
----------------------------------------------------------------------
VPC IP                   VNI      VPC MAC ADDR      UNDERLAY IP
10.0.0.3                 10       A8:40:25:FF:00:03 fd00:2::1
10.0.0.4                 11       A8:40:25:FF:00:04 fd00:2::1

IPv6 mappings
----------------------------------------------------------------------
VPC IP                   VNI      VPC MAC ADDR      UNDERLAY IP
```