### PR TITLE
Fail with permission-denied error if ioctl returns EPERM, rather than…

### DIFF
--- a/opte-ioctl/src/lib.rs
+++ b/opte-ioctl/src/lib.rs
@@ -224,6 +224,8 @@ where
                     "opte driver failed to deser/ser req/resp".to_string()
                 }
 
+                libc::EPERM => "permission denied".to_string(),
+
                 errno => {
                     format!("unexpected errno: {}", errno)
                 }


### PR DESCRIPTION
… numeric errno