### PR TITLE
XXX test theory around #88

### DIFF
--- a/opte/Cargo.toml
+++ b/opte/Cargo.toml
@@ -68,10 +68,10 @@ pcap-parser = { version = "0.11.1", features = ["serialize"] }
 codegen-units = 1
 
 [profile.dev]
-codegen-units = 16
+codegen-units = 1
 
 [profile.test]
-codegen-units = 16
+codegen-units = 1
 
 [profile.bench]
-codegen-units = 16
+codegen-units = 1

--- a/opte/Cargo.toml
+++ b/opte/Cargo.toml
@@ -63,3 +63,15 @@ features = ["alloc", "medium-ethernet", "proto-ipv4", "proto-ipv6", "proto-dhcpv
 
 [dev-dependencies]
 pcap-parser = { version = "0.11.1", features = ["serialize"] }
+
+[profile.release]
+codegen-units = 1
+
+[profile.dev]
+codegen-units = 16
+
+[profile.test]
+codegen-units = 16
+
+[profile.bench]
+codegen-units = 16

--- a/opteadm/Cargo.toml
+++ b/opteadm/Cargo.toml
@@ -17,3 +17,15 @@ postcard = "0.7.0"
 serde = "1.0"
 structopt = "0.3.23"
 thiserror = "1.0.28"
+
+[profile.release]
+codegen-units = 1
+
+[profile.dev]
+codegen-units = 1
+
+[profile.test]
+codegen-units = 1
+
+[profile.bench]
+codegen-units = 1


### PR DESCRIPTION
So I only have a moment to write this up before heading off to court but I have a theory: perhaps #88 has to do with the amount of codegen units, which explodes the `ld` argument list. IIRC rust/cargo recently reintroduced incremental compilation, which itself had an implicit side effect of bumping `codegen-units` from `16` to `256`. This makes them explicit, taking the units back down to `16`, except in the case of `release` profile where I took it down to `1` (b/c supposedly it _could_ produce more efficient code).