### PR TITLE
packaging: add xde.conf to p5p package

### DIFF
--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -14,6 +14,7 @@ mkdir -p proto/kernel/drv/amd64
 mkdir -p proto/opt/oxide/opte/bin
 cp ../opteadm/target/release/opteadm proto/opt/oxide/opte/bin/
 cp ../xde/target/x86_64-unknown-unknown/release/xde proto/kernel/drv/amd64/xde
+cp ../xde/xde.conf proto/kernel/drv/
 
 # create the package
 sed -e "s/%PUBLISHER%/$PUBLISHER/g" \

--- a/pkg/opte.template.p5m
+++ b/pkg/opte.template.p5m
@@ -13,6 +13,7 @@ dir path=opt/oxide/opte/bin owner=root group=bin mode=0755
 file path=opt/oxide/opte/bin/opteadm owner=root group=bin mode=0755
 dir path=kernel owner=root group=sys mode=0755
 dir path=kernel/drv owner=root group=sys mode=0755
+file path=kernel/drv/xde.conf owner=root group=sys mode=0644
 
 # XXX the bypasses below are a hack, but idk what the right thing to do is.
 # Without the bypass this happens

--- a/xde/xde.conf
+++ b/xde/xde.conf
@@ -1,6 +1,3 @@
 # xde kernel module configuration file
 
 name="xde" parent="pseudo" instance=0;
-
-underlay1 = "vioif0";
-underlay2 = "vioif1";


### PR DESCRIPTION
Without `/kernel/drv/xde.conf` the `xde` driver will fail to attach. This commit adds `xde.conf` to the p5p package for `xde`.