### PR TITLE
PR: Do not panic on failed LFT pair allocation (#150)

### DIFF
--- a/opte/src/engine/ioctl.rs
+++ b/opte/src/engine/ioctl.rs
@@ -65,9 +65,8 @@ pub struct LayerDesc {
     // Number of rules in/out.
     pub rules_in: usize,
     pub rules_out: usize,
-    // Number of flows in/out.
-    pub flows_in: u32,
-    pub flows_out: u32,
+    // Number of flows.
+    pub flows: u32,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/opte/src/oxide_vpc/engine/arp.rs
+++ b/opte/src/oxide_vpc/engine/arp.rs
@@ -25,6 +25,7 @@ use crate::oxide_vpc::PortCfg;
 pub fn setup(
     pb: &mut PortBuilder,
     cfg: &PortCfg,
+    ft_limit: core::num::NonZeroU32,
 ) -> core::result::Result<(), OpteError> {
     let arp = Layer::new(
         "arp",
@@ -33,6 +34,7 @@ pub fn setup(
             // ARP Reply for gateway's IP.
             Action::Hairpin(Arc::new(ArpReply::new(cfg.gw_ip, cfg.gw_mac))),
         ],
+        ft_limit,
     );
 
     // ================================================================

--- a/opte/src/oxide_vpc/engine/dhcp4.rs
+++ b/opte/src/oxide_vpc/engine/dhcp4.rs
@@ -34,7 +34,11 @@ use crate::engine::port::{PortBuilder, Pos};
 use crate::engine::rule::{Action, Rule};
 use crate::oxide_vpc::PortCfg;
 
-pub fn setup(pb: &mut PortBuilder, cfg: &PortCfg) -> Result<(), OpteError> {
+pub fn setup(
+    pb: &mut PortBuilder,
+    cfg: &PortCfg,
+    ft_limit: core::num::NonZeroU32,
+) -> Result<(), OpteError> {
     // All guest interfaces live on a `/32`-network in the Oxide VPC;
     // restricting the L2 domain to two nodes: the guest NIC and the
     // OPTE Port. This allows OPTE to act as the gateway for which all
@@ -109,7 +113,7 @@ pub fn setup(pb: &mut PortBuilder, cfg: &PortCfg) -> Result<(), OpteError> {
     }));
     let ack_idx = 1;
 
-    let dhcp = Layer::new("dhcp4", pb.name(), vec![offer, ack]);
+    let dhcp = Layer::new("dhcp4", pb.name(), vec![offer, ack], ft_limit);
 
     let discover_rule = Rule::new(1, dhcp.action(offer_idx).unwrap().clone());
     dhcp.add_rule(Direction::Out, discover_rule.finalize());

--- a/opte/src/oxide_vpc/engine/dyn_nat4.rs
+++ b/opte/src/oxide_vpc/engine/dyn_nat4.rs
@@ -27,8 +27,9 @@ use crate::oxide_vpc::PortCfg;
 pub fn setup(
     pb: &mut PortBuilder,
     cfg: &PortCfg,
+    ft_limit: core::num::NonZeroU32,
 ) -> core::result::Result<(), OpteError> {
-    let mut pool = NatPool::new();
+    let pool = NatPool::new();
     pool.add(cfg.private_ip, cfg.dyn_nat.public_ip, cfg.dyn_nat.ports.clone());
 
     let nat = DynNat4::new(cfg.private_ip, Arc::new(pool));
@@ -37,6 +38,7 @@ pub fn setup(
         "dyn-nat4",
         pb.name(),
         vec![Action::Stateful(Arc::new(nat))],
+        ft_limit,
     );
 
     let mut rule = Rule::new(1, layer.action(0).unwrap().clone());

--- a/opte/src/oxide_vpc/engine/icmp.rs
+++ b/opte/src/oxide_vpc/engine/icmp.rs
@@ -22,6 +22,7 @@ use crate::oxide_vpc::PortCfg;
 pub fn setup(
     pb: &mut PortBuilder,
     cfg: &PortCfg,
+    ft_limit: core::num::NonZeroU32,
 ) -> core::result::Result<(), OpteError> {
     let reply = Action::Hairpin(Arc::new(Icmp4EchoReply {
         // Map an Echo from guest (src) -> gateway (dst) to an Echo
@@ -31,7 +32,7 @@ pub fn setup(
         echo_dst_mac: cfg.gw_mac.into(),
         echo_dst_ip: cfg.gw_ip,
     }));
-    let icmp = Layer::new("icmp", pb.name(), vec![reply]);
+    let icmp = Layer::new("icmp", pb.name(), vec![reply], ft_limit);
 
     // ================================================================
     // ICMPv4 Echo Reply

--- a/opte/src/oxide_vpc/engine/overlay.rs
+++ b/opte/src/oxide_vpc/engine/overlay.rs
@@ -48,6 +48,7 @@ pub const OVERLAY_LAYER_NAME: &'static str = "overlay";
 pub fn setup(
     pb: &PortBuilder,
     cfg: &PortCfg,
+    ft_limit: core::num::NonZeroU32,
 ) -> core::result::Result<(), OpteError> {
     // Action Index 0
     let encap = Action::Static(Arc::new(EncapAction::new(
@@ -59,7 +60,8 @@ pub fn setup(
     // Action Index 1
     let decap = Action::Static(Arc::new(DecapAction::new()));
 
-    let layer = Layer::new(OVERLAY_LAYER_NAME, pb.name(), vec![encap, decap]);
+    let layer =
+        Layer::new(OVERLAY_LAYER_NAME, pb.name(), vec![encap, decap], ft_limit);
     let encap_rule = Rule::match_any(1, layer.action(0).unwrap().clone());
     layer.add_rule(Direction::Out, encap_rule);
     let decap_rule = Rule::match_any(1, layer.action(1).unwrap().clone());

--- a/opte/src/oxide_vpc/engine/router.rs
+++ b/opte/src/oxide_vpc/engine/router.rs
@@ -68,7 +68,11 @@ fn build_ip4_len_to_pri() -> [u16; 33] {
     v
 }
 
-pub fn setup(pb: &PortBuilder, _cfg: &PortCfg) -> Result<(), OpteError> {
+pub fn setup(
+    pb: &PortBuilder,
+    _cfg: &PortCfg,
+    ft_limit: core::num::NonZeroU32,
+) -> Result<(), OpteError> {
     let ig = Action::Meta(Arc::new(RouterAction::new(
         RouterTargetInternal::InternetGateway,
     )));
@@ -76,7 +80,7 @@ pub fn setup(pb: &PortBuilder, _cfg: &PortCfg) -> Result<(), OpteError> {
     // Indexes:
     //
     // * 0: InternetGateway
-    let layer = Layer::new(ROUTER_LAYER_NAME, pb.name(), vec![ig]);
+    let layer = Layer::new(ROUTER_LAYER_NAME, pb.name(), vec![ig], ft_limit);
 
     // If there is no matching router entry we drop the packet.
     let drop_rule = Rule::match_any(65535, rule::Action::Deny);

--- a/opteadm/src/main.rs
+++ b/opteadm/src/main.rs
@@ -392,18 +392,14 @@ fn print_hr() {
 
 fn print_list_layers(resp: &api::ListLayersResp) {
     println!(
-        "{:<12} {:<10} {:<10} {:<10} {:<10}",
-        "NAME", "RULES IN", "RULES OUT", "FLOWS IN", "FLOWS OUT"
+        "{:<12} {:<10} {:<10} {:<10}",
+        "NAME", "RULES IN", "RULES OUT", "FLOWS",
     );
 
     for desc in &resp.layers {
         println!(
-            "{:<12} {:<10} {:<10} {:<10} {:<10}",
-            desc.name,
-            desc.rules_in,
-            desc.rules_out,
-            desc.flows_in,
-            desc.flows_out,
+            "{:<12} {:<10} {:<10} {:<10}",
+            desc.name, desc.rules_in, desc.rules_out, desc.flows,
         );
     }
 }


### PR DESCRIPTION
Other stuff that came along for the ride:

* UFT, LFT, and TCP table limits are now expressed via NonZeroU32.

* Table limits are now a required argument.

* Changed LFT expiration to be purely based on outbound for the
  moment. I don't really love this.

* Added Resource/ResourceMap traits and implemented the SNAT pool in
  terms of them.

* Implemented resource release for SNAT.

* Ditched the `ActionDesc::fini()` idea and replaced it with `Drop`
  impl.

* More extensive SNAT unit test, part of which verifies resource
  acquisition and release.