### PR TITLE
ext-ip-hack: fwd all ext traffic to phys gateway

### DIFF
--- a/dtrace/opte-port-process.d
+++ b/dtrace/opte-port-process.d
@@ -5,8 +5,8 @@
  */
 #include "common.h"
 
-#define	HDR_FMT		"%-12s %-3s %-8s %-43s %-18s %s\n"
-#define	LINE_FMT	"%-12s %-3s %-8u %-43s 0x%-16p %s\n"
+#define	HDR_FMT		"%-12s %-3s %-8s %-43s %-5s %s\n"
+#define	LINE_FMT	"%-12s %-3s %-8u %-43s %-5u %s\n"
 
 BEGIN {
 	/*
@@ -18,7 +18,7 @@ BEGIN {
 	protos[17] = "UDP";
 	protos[255] = "XXX";
 
-	printf(HDR_FMT, "NAME", "DIR", "EPOCH", "FLOW", "MBLK", "RESULT");
+	printf(HDR_FMT, "NAME", "DIR", "EPOCH", "FLOW", "LEN", "RESULT");
 	num = 0;
 }
 
@@ -27,11 +27,11 @@ port-process-return {
 	this->name = stringof(arg1);
 	this->flow = (flow_id_sdt_arg_t *)arg2;
 	this->epoch = arg3;
-	this->mp = arg4;
+	this->mp = (mblk_t *)arg4;
 	this->res = stringof(arg5);
 
 	if (num >= 10) {
-		printf(HDR_FMT, "NAME", "DIR", "EPOCH", "FLOW", "MBLK",
+		printf(HDR_FMT, "NAME", "DIR", "EPOCH", "FLOW", "LEN",
 		    "RESULT");
 		num = 0;
 	}
@@ -45,15 +45,15 @@ port-process-return {
 
 port-process-return /this->af == AF_INET/ {
 	FLOW_FMT(this->s, this->flow);
-	printf(LINE_FMT, this->name, this->dir, this->epoch, this->s, this->mp,
-	    this->res);
+	printf(LINE_FMT, this->name, this->dir, this->epoch, this->s,
+	    msgsize(this->mp), this->res);
 	num++;
 }
 
 port-process-return /this->af == AF_INET6/ {
 	FLOW_FMT6(this->s, this->flow);
-	printf(LINE_FMT,  this->name, this->dir, this->epoch, this->s, this->mp,
-	    this->res);
+	printf(LINE_FMT,  this->name, this->dir, this->epoch, this->s,
+	    msgsize(this->mp), this->res);
 	num++;
 }
 

--- a/opte/process-flow.md
+++ b/opte/process-flow.md
@@ -1,0 +1,30 @@
+The size of the TCP flow table is currently 8096.
+
+```mermaid
+flowchart TD
+	process_in([process_in]) --> is_def_id{flow_id == FLOW_ID_DEFAULT?};
+	is_def_id -- Yes --> lp[layers_process];
+	is_def_id -- No --> check_uft{UFT entry?};
+	check_uft -- Yes --> same_epoch{entry.epoch == port.epoch?};
+	check_uft -- No --> lp;
+	same_epoch -- Yes --> run_ht[run HT];
+	same_epoch -- No --> inv[invalidate UFT entry];
+	inv --> lp;
+	run_ht --> is_tcp_uft{TCP?};
+	is_tcp_uft -- Yes --> pite[process_in_tcp_existing];
+	is_tcp_uft -- No --> rm([return Modified]);
+	lp --> lr{Layer Result?};
+	lr -- Allow --> uft_add[add UFT entry];
+	lr -- Deny --> rd([return Drop]);
+	lr -- "Hairpin(hp)" --> rhp(["return Hairpin(hp)"]);
+	lr -- "Err(e)" --> re(["return Err(e)"]);
+	pitn -- "Ok(TcpState::Closed)" --> rd;
+	pitn -- "Ok(tcp_state)" --> rm;
+	pitn -- "Err(e)" --> re;
+	pite -- "Ok(TcpState::Closed)" --> rd;
+	pite -- "Ok(tcp_state)" --> rm;
+	pite -- "Err(e)" --> re;
+	uft_add --> is_tcp_no_uft{TCP?};
+	is_tcp_no_uft -- Yes --> pitn[process_in_tcp_new];
+	is_tcp_no_uft -- No --> rm;
+```

--- a/opte/src/engine/int_test.rs
+++ b/opte/src/engine/int_test.rs
@@ -107,6 +107,7 @@ fn lab_cfg() -> PortCfg {
         snat: Some(SNatCfg {
             public_ip: "76.76.21.21".parse().unwrap(),
             ports: 1025..=4096,
+            phys_gw_mac: MacAddr::from([0x78, 0x23, 0xae, 0x5d, 0x4f, 0x0d]),
         }),
         gw_mac: MacAddr::from([0xAA, 0x00, 0x04, 0x00, 0xFF, 0x01]),
         gw_ip: "172.20.14.1".parse().unwrap(),
@@ -179,8 +180,9 @@ fn g1_cfg() -> PortCfg {
             // which the oxide Rack is simply a part of.
             public_ip: "10.77.77.13".parse().unwrap(),
             ports: 1025..=4096,
+            phys_gw_mac: MacAddr::from([0x78, 0x23, 0xae, 0x5d, 0x4f, 0x0d]),
         }),
-        gw_mac: MacAddr::from([0xA8, 0x40, 0x25, 0xF7, 0x00, 0x1]),
+        gw_mac: MacAddr::from([0xA8, 0x40, 0x25, 0xFF, 0x77, 0x77]),
         gw_ip: "192.168.77.1".parse().unwrap(),
         vni: Vni::new(99u32).unwrap(),
         // Site 0xF7, Rack 1, Sled 1, Interface 1
@@ -202,7 +204,7 @@ fn g1_cfg() -> PortCfg {
 fn g2_cfg() -> PortCfg {
     PortCfg {
         private_ip: "192.168.77.102".parse().unwrap(),
-        private_mac: MacAddr::from([0xA8, 0x40, 0x25, 0xF7, 0x00, 0x66]),
+        private_mac: MacAddr::from([0xA8, 0x40, 0x25, 0xF0, 0x00, 0x66]),
         vpc_subnet: "192.168.77.0/24".parse().unwrap(),
         snat: Some(SNatCfg {
             // NOTE: This is not a routable IP, but remember that a
@@ -211,8 +213,9 @@ fn g2_cfg() -> PortCfg {
             // which the oxide Rack is simply a part of.
             public_ip: "10.77.77.23".parse().unwrap(),
             ports: 4097..=8192,
+            phys_gw_mac: MacAddr::from([0x78, 0x23, 0xae, 0x5d, 0x4f, 0x0d]),
         }),
-        gw_mac: MacAddr::from([0xA8, 0x40, 0x25, 0xF7, 0x00, 0x1]),
+        gw_mac: MacAddr::from([0xA8, 0x40, 0x25, 0xFF, 0x77, 0x77]),
         gw_ip: "192.168.77.1".parse().unwrap(),
         vni: Vni::new(99u32).unwrap(),
         // Site 0xF7, Rack 1, Sled 22, Interface 1

--- a/opte/src/oxide_vpc/api.rs
+++ b/opte/src/oxide_vpc/api.rs
@@ -124,6 +124,7 @@ pub struct CreateXdeReq {
 pub struct SNatCfg {
     pub public_ip: Ipv4Addr,
     pub ports: core::ops::RangeInclusive<u16>,
+    pub phys_gw_mac: MacAddr,
 }
 
 /// Xde delete ioctl parameter data.

--- a/opte/src/oxide_vpc/engine/nat4.rs
+++ b/opte/src/oxide_vpc/engine/nat4.rs
@@ -35,7 +35,11 @@ pub fn setup(
     // XXX-EXT-IP This config should not some from SNAT. This is
     // currently a hack assuming its use is in service of the
     // ext_ip_hack flag.
-    let nat = Nat4::new(cfg.private_ip, cfg.snat.as_ref().unwrap().public_ip);
+    let nat = Nat4::new(
+        cfg.private_ip,
+        cfg.snat.as_ref().unwrap().public_ip,
+        cfg.snat.as_ref().unwrap().phys_gw_mac,
+    );
     let layer = Layer::new(
         NAT4_LAYER_NAME,
         pb.name(),

--- a/opteadm/src/main.rs
+++ b/opteadm/src/main.rs
@@ -144,6 +144,9 @@ enum Command {
         snat_end: Option<u16>,
 
         #[structopt(long)]
+        snat_gw_mac: Option<MacAddr>,
+
+        #[structopt(long)]
         passthrough: bool,
     },
 
@@ -498,6 +501,7 @@ fn main() {
             snat_ip,
             snat_start,
             snat_end,
+            snat_gw_mac,
             passthrough,
         } => {
             let hdl = opteadm::OpteAdm::open(OpteAdm::DLD_CTL).unwrap_or_die();
@@ -508,6 +512,7 @@ fn main() {
                         snat_start.unwrap(),
                         snat_end.unwrap(),
                     ),
+                    phys_gw_mac: snat_gw_mac.unwrap(),
                 }),
 
                 None => None,


### PR DESCRIPTION
This modifies the hacked up NAT layer to always rewrite external
traffic to the local gateway on the "external" subnet. When the
destination is another IP on the subnet the gateway will just forward
it back onto the subnet. In the case of an off-subnet destination, the
gateway will forward it to the next hop. This allows bouth inbound and
outbound external traffic to work with the guest.

I also tried to get intra-guest (aka internal VPC traffic) to work
under the hack but it's fighting me and we want to land what's here
for the next demo.

I also modified the port process DTrace script to print more useful
info. And I added a start to a flowchart for processing flow.