### PR TITLE
Adds basic support for IPv6

### DIFF
--- a/dtrace/common.h
+++ b/dtrace/common.h
@@ -27,13 +27,13 @@
 	*this->src_ip6 = fvar->src_ip6;				\
 	*this->dst_ip6 = fvar->dst_ip6;				\
 	svar = protos[fvar->proto];				\
-	svar = strjoin(svar, ",");				\
+	svar = strjoin(svar, ",[");				\
 	svar = strjoin(svar, inet_ntoa6(this->src_ip6));	\
-	svar = strjoin(svar, ":");				\
+	svar = strjoin(svar, "]:");				\
 	svar = strjoin(svar, lltostr(ntohs(fvar->src_port)));	\
-	svar = strjoin(svar, ",");				\
+	svar = strjoin(svar, ",[");				\
 	svar = strjoin(svar, inet_ntoa6(this->dst_ip6));	\
-	svar = strjoin(svar, ":");				\
+	svar = strjoin(svar, "]:");				\
 	svar = strjoin(svar, lltostr(ntohs(fvar->dst_port)));
 
 #define ETH_FMT(svar, evar)					\

--- a/dtrace/opte-flow-expire.d
+++ b/dtrace/opte-flow-expire.d
@@ -6,18 +6,11 @@
  * dtrace -L ./lib -I . -Cqs ./opte-flow-expire.d
  */
 #include "common.h"
+#include "protos.d"
 
 #define	HDR_FMT "%-24s %-18s %s\n"
 
 BEGIN {
-	/*
-	 * Use an associative array to stringify the protocol number.
-	 */
-	protos[1]= "ICMP";
-	protos[2] = "IGMP";
-	protos[6] = "TCP";
-	protos[17] = "UDP";
-
 	printf(HDR_FMT, "PORT", "FT NAME", "FLOW");
 	num = 0;
 }

--- a/dtrace/opte-gen-desc-fail.d
+++ b/dtrace/opte-gen-desc-fail.d
@@ -4,18 +4,11 @@
  * dtrace -L ./lib -I . -Cqs ./opte-gen-desc-fail.d
  */
 #include "common.h"
+#include "protos.d"
 
 #define HDR_FMT	"%-12s %-12s %-4s %-48s %s\n"
 
 BEGIN {
-	/*
-	 * Use an associative array to stringify the protocol number.
-	 */
-	protos[1] = "ICMP";
-	protos[2] = "IGMP";
-	protos[6] = "TCP";
-	protos[17] = "UDP";
-
 	printf(HDR_FMT, "PORT", "LAYER", "DIR", "FLOW", "MSG");
 	num = 0;
 }

--- a/dtrace/opte-gen-ht-fail.d
+++ b/dtrace/opte-gen-ht-fail.d
@@ -4,17 +4,11 @@
  * dtrace -L ./lib -I . -Cqs ./opte-gen-desc-fail.d
  */
 #include "common.h"
+#include "protos.d"
 
 #define HDR_FMT	"%-12s %-12s %-4s %-48s %s\n"
 
 BEGIN {
-	/*
-	 * Use an associative array to stringify the protocol number.
-	 */
-	protos[1] = "ICMP";
-	protos[2] = "IGMP";
-	protos[6] = "TCP";
-	protos[17] = "UDP";
 
 	printf(HDR_FMT, "PORT", "LAYER", "DIR", "FLOW", "MSG");
 	num = 0;

--- a/dtrace/opte-guest-loopback.d
+++ b/dtrace/opte-guest-loopback.d
@@ -4,19 +4,11 @@
  * dtrace -L ./lib -I . -Cqs ./opte-guest-loopback.d
  */
 #include "common.h"
+#include "protos.d"
 
 #define	HDR_FMT		"%-43s %-12s %-12s\n"
 
 BEGIN {
-	/*
-	 * Use an associative array to stringify the protocol number.
-	 */
-	protos[1] = "ICMP";
-	protos[2] = "IGMP";
-	protos[6] = "TCP";
-	protos[17] = "UDP";
-	protos[255] = "XXX";
-
 	printf(HDR_FMT, "FLOW", "SRC PORT", "DST PORT");
 	num = 0;
 }

--- a/dtrace/opte-ht.d
+++ b/dtrace/opte-ht.d
@@ -1,21 +1,14 @@
 /*
- * Track Header Transpositions as they happen.
+ * Track Header Transformations as they happen.
  *
  * dtrace -L ./lib -I . -Cqs ./opte-ht.d
  */
 #include "common.h"
+#include "protos.d"
 
 #define	HDR_FMT "%-3s %-12s %-12s %-40s %-40s\n"
 
 BEGIN {
-	/*
-	 * Use an associative array to stringify the protocol number.
-	 */
-	protos[1]= "ICMP";
-	protos[2] = "IGMP";
-	protos[6] = "TCP";
-	protos[17] = "UDP";
-
 	printf(HDR_FMT, "DIR", "PORT", "LOCATION", "BEFORE", "AFTER");
 	num = 0;
 }

--- a/dtrace/opte-layer-process.d
+++ b/dtrace/opte-layer-process.d
@@ -7,19 +7,11 @@
  * dtrace -L ./lib -I . -Cqs ./opte-layer-process.d
  */
 #include "common.h"
+#include "protos.d"
 
 #define	HDR_FMT		"%-16s %-16s %-3s %-48s %s\n"
 
 BEGIN {
-	/*
-	 * Use an associative array to stringify the protocol number.
-	 */
-	protos[1] = "ICMP";
-	protos[2] = "IGMP";
-	protos[6] = "TCP";
-	protos[17] = "UDP";
-	protos[255] = "XXX";
-
 	printf(HDR_FMT, "PORT", "LAYER", "DIR", "FLOW", "RES");
 	num = 0;
 }

--- a/dtrace/opte-port-process.d
+++ b/dtrace/opte-port-process.d
@@ -4,6 +4,7 @@
  * dtrace -L ./lib -I . -Cqs ./opte-port-process.d
  */
 #include "common.h"
+#include "protos.d"
 
 #define	HDR_FMT		"%-12s %-3s %-8s %-43s %-5s %s\n"
 #define	LINE_FMT	"%-12s %-3s %-8u %-43s %-5u %s\n"
@@ -12,11 +13,6 @@ BEGIN {
 	/*
 	 * Use an associative array to stringify the protocol number.
 	 */
-	protos[1] = "ICMP";
-	protos[2] = "IGMP";
-	protos[6] = "TCP";
-	protos[17] = "UDP";
-	protos[255] = "XXX";
 
 	printf(HDR_FMT, "NAME", "DIR", "EPOCH", "FLOW", "LEN", "RESULT");
 	num = 0;

--- a/dtrace/opte-rule-match.d
+++ b/dtrace/opte-rule-match.d
@@ -4,19 +4,11 @@
  * dtrace -L ./lib -I . -Cqs ./opte-rule-match.d
  */
 #include "common.h"
+#include "protos.d"
 
 #define	HDR_FMT		"%-8s %-12s %-6s %-3s %-43s %s\n"
 
 BEGIN {
-	/*
-	 * Use an associative array to stringify the protocol number.
-	 */
-	protos[1] = "ICMP";
-	protos[2] = "IGMP";
-	protos[6] = "TCP";
-	protos[17] = "UDP";
-	protos[255] = "XXX";
-
 	printf(HDR_FMT, "PORT", "LAYER", "MATCH", "DIR", "FLOW", "ACTION");
 	num = 0;
 }

--- a/dtrace/opte-tcp-flow-state.d
+++ b/dtrace/opte-tcp-flow-state.d
@@ -4,17 +4,11 @@
  * dtrace -L ./lib -I . -Cqs ./opte-tcp-flow-state.d
  */
 #include "common.h"
+#include "protos.d"
 
 #define	FMT	"%-16s %-12s %-12s %s\n"
 
 BEGIN {
-	/*
-	 * Use an associative array to stringify the protocol number.
-	 * It's always going to be TCP but we need this declared so
-	 * the FLOW_FMT macros work.
-	 */
-	protos[6] = "TCP";
-
 	/*
 	 * Use an associative array to stringify the TCP state
 	 * values.

--- a/dtrace/opte-uft-invaildate.d
+++ b/dtrace/opte-uft-invaildate.d
@@ -8,20 +8,12 @@
  * dtrace -L ./lib -I . -Cqs ./opte-uft-invalidate.d
  */
 #include "common.h"
+#include "protos.d"
 
 #define	HDR_FMT		"%-8s %-3s %-43s %s\n"
 #define	LINE_FMT	"%-8s %-3s %-43s %u\n"
 
 BEGIN {
-	/*
-	 * Use an associative array to stringify the protocol number.
-	 */
-	protos[1] = "ICMP";
-	protos[2] = "IGMP";
-	protos[6] = "TCP";
-	protos[17] = "UDP";
-	protos[255] = "XXX";
-
 	printf(HDR_FMT, "PORT", "DIR", "FLOW", "EPOCH");
 	num = 0;
 }

--- a/dtrace/protos.d
+++ b/dtrace/protos.d
@@ -1,0 +1,11 @@
+/*
+ * Definitions of the IP protocol numbers as an associative array.
+ */
+BEGIN {
+	protos[1] = "ICMP";
+	protos[2] = "IGMP";
+	protos[6] = "TCP";
+	protos[17] = "UDP";
+	protos[58] = "ICMPv6";
+	protos[255] = "XXX";
+}

--- a/opte-api/check-api-version.sh
+++ b/opte-api/check-api-version.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# If there is a change to an opte-api source file in the last commit,
-# then verify that the API_VERSION value has increased.
-if git log -1 -p master..HEAD | grep '^diff.*opte-api/src'
+# If there is a change to an opte-api source file relative to the `master`
+# branch, # then verify that the API_VERSION value has increased.
+if git diff master..HEAD | grep '^diff.*opte-api/src'
 then
-	git log -p -1 master..HEAD | awk -f check-api-version.awk
+	git diff master..HEAD | awk -f check-api-version.awk
 fi

--- a/opte-api/src/cmd.rs
+++ b/opte-api/src/cmd.rs
@@ -24,21 +24,21 @@ pub const XDE_DLD_OPTE_CMD: i32 = XDE_DLD_PREFIX | 7777;
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub enum OpteCmd {
-    ListPorts = 1,           // list all ports
-    AddFwRule = 20,          // add firewall rule
-    RemFwRule = 21,          // remove firewall rule
-    SetFwRules = 22,         // set/replace all firewall rules at once
-    DumpTcpFlows = 30,       // dump TCP flows
-    DumpLayer = 31,          // dump the specified Layer
-    DumpUft = 32,            // dump the Unified Flow Table
-    ListLayers = 33,         // list the layers on a given port
-    ClearUft = 40,           // clear the UFT
-    SetVirt2Phys = 50,       // set a v2p mapping
-    DumpVirt2Phys = 51,      // dump the v2p mappings
-    AddRouterEntryIpv4 = 60, // add a router entry for IPv4 dest
-    CreateXde = 70,          // create a new xde device
-    DeleteXde = 71,          // delete an xde device
-    SetXdeUnderlay = 72,     // set xde underlay devices
+    ListPorts = 1,       // list all ports
+    AddFwRule = 20,      // add firewall rule
+    RemFwRule = 21,      // remove firewall rule
+    SetFwRules = 22,     // set/replace all firewall rules at once
+    DumpTcpFlows = 30,   // dump TCP flows
+    DumpLayer = 31,      // dump the specified Layer
+    DumpUft = 32,        // dump the Unified Flow Table
+    ListLayers = 33,     // list the layers on a given port
+    ClearUft = 40,       // clear the UFT
+    SetVirt2Phys = 50,   // set a v2p mapping
+    DumpVirt2Phys = 51,  // dump the v2p mappings
+    AddRouterEntry = 60, // add a router entry for IP dest
+    CreateXde = 70,      // create a new xde device
+    DeleteXde = 71,      // delete an xde device
+    SetXdeUnderlay = 72, // set xde underlay devices
 }
 
 impl TryFrom<c_int> for OpteCmd {
@@ -57,7 +57,7 @@ impl TryFrom<c_int> for OpteCmd {
             40 => Ok(Self::ClearUft),
             50 => Ok(Self::SetVirt2Phys),
             51 => Ok(Self::DumpVirt2Phys),
-            60 => Ok(Self::AddRouterEntryIpv4),
+            60 => Ok(Self::AddRouterEntry),
             70 => Ok(Self::CreateXde),
             71 => Ok(Self::DeleteXde),
             72 => Ok(Self::SetXdeUnderlay),

--- a/opte-api/src/cmd.rs
+++ b/opte-api/src/cmd.rs
@@ -5,6 +5,7 @@
 // Copyright 2022 Oxide Computer Company
 
 use super::encap::Vni;
+use super::ip::IpCidr;
 use super::mac::MacAddr;
 use super::API_VERSION;
 use illumos_sys_hdrs::{c_int, size_t};
@@ -146,7 +147,7 @@ pub enum OpteError {
     DeserCmdErr(String),
     DeserCmdReq(String),
     FlowExists(String),
-    InvalidRouteDest(String),
+    InvalidRouterEntry { dest: IpCidr, target: String },
     LayerNotFound(String),
     MacExists { port: String, vni: Vni, mac: MacAddr },
     MaxCapacity(u64),
@@ -181,7 +182,7 @@ impl OpteError {
             Self::DeserCmdErr(_) => ENOMSG,
             Self::DeserCmdReq(_) => ENOMSG,
             Self::FlowExists(_) => EEXIST,
-            Self::InvalidRouteDest(_) => EINVAL,
+            Self::InvalidRouterEntry { .. } => EINVAL,
             Self::LayerNotFound(_) => ENOENT,
             Self::MacExists { .. } => EEXIST,
             Self::MaxCapacity(_) => ENFILE,

--- a/opte-api/src/ip.rs
+++ b/opte-api/src/ip.rs
@@ -20,13 +20,39 @@ cfg_if! {
     }
 }
 
+/// Generate an ICMPv6 Echo Reply message.
+#[derive(Debug, Clone, Copy)]
+pub struct Icmpv6EchoReply {
+    /// The MAC address of the Echo Request source.
+    pub src_mac: MacAddr,
+
+    /// The IP address of the Echo Request source.
+    pub src_ip: Ipv6Addr,
+
+    /// The MAC address of the Echo Request destination.
+    pub dst_mac: MacAddr,
+
+    /// The IP address of the Echo source destination.
+    pub dst_ip: Ipv6Addr,
+}
+
+impl Display for Icmpv6EchoReply {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "ICMPv6 Echo Reply ({},{}) => ({},{})",
+            self.dst_mac, self.dst_ip, self.src_mac, self.src_ip,
+        )
+    }
+}
+
 /// Generate an ICMPv4 Echo Reply message.
 ///
 /// Map an ICMPv4 Echo Message (Type=8, Code=0) from `src` to `dst`
 /// into an ICMPv4 Echo Reply Message (Type=0, Code=0) from `dst` to
 /// `src`.
 #[derive(Clone, Debug)]
-pub struct Icmp4EchoReply {
+pub struct IcmpEchoReply {
     /// The MAC address of the sender of the Echo message. The
     /// destination MAC address of the Echo Reply.
     pub echo_src_mac: MacAddr,
@@ -44,7 +70,7 @@ pub struct Icmp4EchoReply {
     pub echo_dst_ip: Ipv4Addr,
 }
 
-impl Display for Icmp4EchoReply {
+impl Display for IcmpEchoReply {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -66,7 +92,7 @@ impl Display for Icmp4EchoReply {
 /// specifies in the parameter request list. This has worked thus far,
 /// but we should come back to this and comb over RFC 2131 more
 /// carefully -- particularly §4.3.1 and §4.3.2.
-pub struct Dhcp4Action {
+pub struct DhcpAction {
     /// The client's MAC address.
     pub client_mac: MacAddr,
 
@@ -96,7 +122,7 @@ pub struct Dhcp4Action {
 
     /// The value of the `DHCP Message Type Option (code 53)`. This
     /// action supports only the Offer and Ack messages.
-    pub reply_type: Dhcp4ReplyType,
+    pub reply_type: DhcpReplyType,
 
     /// A static route entry, sent to the client via the `Classless
     /// Static Route Option (code 131)`.
@@ -112,19 +138,19 @@ pub struct Dhcp4Action {
     pub dns_servers: Option<[Option<Ipv4Addr>; 3]>,
 }
 
-impl Display for Dhcp4Action {
+impl Display for DhcpAction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "DHCPv4 {}: {}", self.reply_type, self.client_ip)
     }
 }
 
 #[derive(Clone, Copy, Debug)]
-pub enum Dhcp4ReplyType {
+pub enum DhcpReplyType {
     Offer,
     Ack,
 }
 
-impl Display for Dhcp4ReplyType {
+impl Display for DhcpReplyType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Offer => write!(f, "OFFER"),
@@ -279,6 +305,18 @@ pub enum IpAddr {
     Ip6(Ipv6Addr),
 }
 
+impl From<Ipv4Addr> for IpAddr {
+    fn from(ipv4: Ipv4Addr) -> Self {
+        IpAddr::Ip4(ipv4)
+    }
+}
+
+impl From<Ipv6Addr> for IpAddr {
+    fn from(ipv6: Ipv6Addr) -> Self {
+        IpAddr::Ip6(ipv6)
+    }
+}
+
 impl Default for IpAddr {
     fn default() -> Self {
         IpAddr::Ip4(Default::default())
@@ -290,6 +328,17 @@ impl fmt::Display for IpAddr {
         match self {
             IpAddr::Ip4(ip4) => write!(f, "{}", ip4),
             IpAddr::Ip6(ip6) => write!(f, "{}", ip6),
+        }
+    }
+}
+
+impl FromStr for IpAddr {
+    type Err = String;
+    fn from_str(val: &str) -> result::Result<Self, Self::Err> {
+        if let Ok(ipv4) = val.parse::<Ipv4Addr>() {
+            Ok(ipv4.into())
+        } else {
+            val.parse::<Ipv6Addr>().map(IpAddr::Ip6)
         }
     }
 }
@@ -430,7 +479,7 @@ pub struct Ipv6Addr {
 }
 
 impl Ipv6Addr {
-    pub const ANY_ADDR: [u8; 16] = [0; 16];
+    pub const ANY_ADDR: Self = Self { inner: [0; 16] };
 
     /// Return the bytes of the address.
     pub fn bytes(&self) -> [u8; 16] {
@@ -489,6 +538,15 @@ impl From<std::net::Ipv6Addr> for Ipv6Addr {
     }
 }
 
+impl From<smoltcp::wire::Ipv6Address> for Ipv6Addr {
+    fn from(ip: smoltcp::wire::Ipv6Address) -> Self {
+        // Safety: We assume the `smoltcp` type is well-formed, with at least 16
+        // octets in the correct order.
+        let bytes: [u8; 16] = ip.as_bytes().try_into().unwrap();
+        Self::from(bytes)
+    }
+}
+
 impl From<&[u8; 16]> for Ipv6Addr {
     fn from(bytes: &[u8; 16]) -> Ipv6Addr {
         Ipv6Addr { inner: *bytes }
@@ -514,13 +572,13 @@ impl From<[u16; 8]> for Ipv6Addr {
     }
 }
 
-#[cfg(any(feature = "std", test))]
 impl FromStr for Ipv6Addr {
     type Err = String;
 
     fn from_str(val: &str) -> result::Result<Self, Self::Err> {
-        let ip =
-            val.parse::<std::net::Ipv6Addr>().map_err(|e| format!("{}", e))?;
+        let ip = val
+            .parse::<smoltcp::wire::Ipv6Address>()
+            .map_err(|_| String::from("Invalid IPv6 address"))?;
         Ok(ip.into())
     }
 }
@@ -532,18 +590,30 @@ pub enum IpCidr {
     Ip6(Ipv6Cidr),
 }
 
+impl From<Ipv4Cidr> for IpCidr {
+    fn from(cidr: Ipv4Cidr) -> Self {
+        IpCidr::Ip4(cidr)
+    }
+}
+
+impl From<Ipv6Cidr> for IpCidr {
+    fn from(cidr: Ipv6Cidr) -> Self {
+        IpCidr::Ip6(cidr)
+    }
+}
+
 impl IpCidr {
     pub fn is_default(&self) -> bool {
         match self {
             Self::Ip4(ip4) => ip4.is_default(),
-            Self::Ip6(_) => todo!("IPv6 is_default"),
+            Self::Ip6(ip6) => ip6.is_default(),
         }
     }
 
     pub fn prefix_len(&self) -> usize {
         match self {
             Self::Ip4(ip4) => ip4.prefix_len() as usize,
-            Self::Ip6(_) => todo!("IPv6 prefix_len"),
+            Self::Ip6(ip6) => ip6.prefix_len() as usize,
         }
     }
 }
@@ -557,9 +627,29 @@ impl fmt::Display for IpCidr {
     }
 }
 
+impl FromStr for IpCidr {
+    type Err = String;
+
+    /// Convert a string like "192.168.2.0/24" into an `IpCidr`.
+    fn from_str(val: &str) -> result::Result<Self, Self::Err> {
+        match val.parse::<Ipv4Cidr>() {
+            Ok(ip4) => Ok(IpCidr::Ip4(ip4)),
+            Err(_) => val.parse::<Ipv6Cidr>().map(IpCidr::Ip6),
+        }
+    }
+}
+
 /// A valid IPv4 prefix legnth.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Ipv4PrefixLen(u8);
+
+impl TryFrom<u8> for Ipv4PrefixLen {
+    type Error = String;
+
+    fn try_from(p: u8) -> Result<Self, Self::Error> {
+        Self::new(p)
+    }
+}
 
 impl Ipv4PrefixLen {
     pub const NETMASK_NONE: Self = Self(0);
@@ -682,7 +772,6 @@ impl fmt::Display for Ipv6Cidr {
     }
 }
 
-#[cfg(any(feature = "std", test))]
 impl FromStr for Ipv6Cidr {
     type Err = String;
 
@@ -693,9 +782,9 @@ impl FromStr for Ipv6Cidr {
             None => return Err(format!("no '/' found")),
         };
 
-        let ip = match ip_s.parse::<std::net::Ipv6Addr>() {
+        let ip = match ip_s.parse::<smoltcp::wire::Ipv6Address>() {
             Ok(v) => v.into(),
-            Err(e) => return Err(format!("bad IP: {}", e)),
+            Err(_) => return Err(String::from("Bad IP address component")),
         };
 
         let prefix_len = match prefix_s.parse::<u8>() {
@@ -713,7 +802,18 @@ impl FromStr for Ipv6Cidr {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Ipv6PrefixLen(u8);
 
+impl TryFrom<u8> for Ipv6PrefixLen {
+    type Error = String;
+
+    fn try_from(p: u8) -> Result<Self, Self::Error> {
+        Self::new(p)
+    }
+}
+
 impl Ipv6PrefixLen {
+    pub const NETMASK_NONE: Self = Self(0);
+    pub const NETMASK_ALL: Self = Self(128);
+
     pub fn new(prefix_len: u8) -> result::Result<Self, String> {
         if prefix_len > 128 {
             return Err(format!("bad IPv6 prefix length: {}", prefix_len));
@@ -728,6 +828,11 @@ impl Ipv6PrefixLen {
 }
 
 impl Ipv6Cidr {
+    pub fn new(ip: Ipv6Addr, prefix_len: Ipv6PrefixLen) -> Self {
+        let ip = ip.safe_mask(prefix_len);
+        Ipv6Cidr { ip, prefix_len }
+    }
+
     pub fn new_checked(
         ip: Ipv6Addr,
         prefix_len: u8,
@@ -739,6 +844,27 @@ impl Ipv6Cidr {
 
     pub fn parts(&self) -> (Ipv6Addr, Ipv6PrefixLen) {
         (self.ip, self.prefix_len)
+    }
+
+    /// Return `true` if this is the default route subnet
+    pub fn is_default(&self) -> bool {
+        let (ip, prefix_len) = self.parts();
+        ip == Ipv6Addr::ANY_ADDR && prefix_len.val() == 0
+    }
+
+    /// Return the prefix length (netmask).
+    pub fn prefix_len(self) -> u8 {
+        self.prefix_len.0
+    }
+
+    /// Return the network address of this CIDR.
+    pub fn ip(&self) -> Ipv6Addr {
+        self.ip
+    }
+
+    /// Is this `ip` a member of the CIDR?
+    pub fn is_member(&self, ip: Ipv6Addr) -> bool {
+        ip.safe_mask(self.prefix_len) == self.ip
     }
 }
 
@@ -870,6 +996,76 @@ mod test {
         assert_eq!(ip6.mask(56).unwrap(), ip6_prefix);
 
         let ip6 = Ipv6Addr::from([1; 16]);
-        assert_eq!(ip6.mask(0).unwrap().bytes(), Ipv6Addr::ANY_ADDR);
+        assert_eq!(ip6.mask(0).unwrap(), Ipv6Addr::ANY_ADDR);
+    }
+
+    #[test]
+    fn ipv6_is_default() {
+        let cidr = Ipv6Cidr::new_checked(Ipv6Addr::from([1; 16]), 1).unwrap();
+        assert!(!cidr.is_default());
+        let cidr = Ipv6Cidr::new_checked(Ipv6Addr::from([0; 16]), 1).unwrap();
+        assert!(!cidr.is_default());
+
+        let cidr = Ipv6Cidr::new_checked(Ipv6Addr::from([1; 16]), 0).unwrap();
+        assert!(cidr.is_default());
+        let cidr = Ipv6Cidr::new_checked(Ipv6Addr::from([0; 16]), 0).unwrap();
+        assert!(cidr.is_default());
+    }
+
+    #[test]
+    fn ipv6_prefix_len() {
+        for i in 0u8..=128 {
+            let len = Ipv6Cidr::new_checked(Ipv6Addr::from([1; 16]), i)
+                .unwrap()
+                .prefix_len();
+            assert_eq!(i, len);
+        }
+        assert!(Ipv6Cidr::new_checked(Ipv6Addr::from([1; 16]), 129).is_err());
+    }
+
+    #[test]
+    fn ipv6_cidr_is_member() {
+        let cidr: Ipv6Cidr = "fd00:1::1/16".parse().unwrap();
+        assert!(cidr.is_member("fd00:1::1".parse().unwrap()));
+        assert!(cidr.is_member("fd00:1::10".parse().unwrap()));
+        assert!(cidr.is_member("fd00:2::1".parse().unwrap()));
+
+        assert!(!cidr.is_member("fd01:1::1".parse().unwrap()));
+        assert!(!cidr.is_member("fd01:1::10".parse().unwrap()));
+        assert!(!cidr.is_member("fd01:2::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_ip_addr_from_str() {
+        assert_eq!(
+            IpAddr::Ip4(Ipv4Addr::from([172, 30, 0, 1])),
+            "172.30.0.1".parse().unwrap()
+        );
+        let bytes = [0xfd00, 0, 0, 0, 0, 0, 0, 1];
+        assert_eq!(
+            IpAddr::Ip6(Ipv6Addr::from(bytes)),
+            "fd00::1".parse().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_ip_cidr_from_str() {
+        assert_eq!(
+            IpCidr::Ip4(
+                Ipv4Cidr::new_checked(Ipv4Addr::from([10, 0, 0, 0]), 24)
+                    .unwrap()
+            ),
+            "10.0.0.0/24".parse().unwrap(),
+        );
+        assert_eq!(
+            IpCidr::Ip6(
+                Ipv6Cidr::new_checked(
+                    Ipv6Addr::from([0xfd00, 0, 0, 0, 0, 0, 0, 1]),
+                    64
+                )
+                .unwrap()
+            ),
+            "fd00::1/64".parse().unwrap(),
+        );
     }
 }

--- a/opte-api/src/ip.rs
+++ b/opte-api/src/ip.rs
@@ -338,7 +338,9 @@ impl FromStr for IpAddr {
         if let Ok(ipv4) = val.parse::<Ipv4Addr>() {
             Ok(ipv4.into())
         } else {
-            val.parse::<Ipv6Addr>().map(IpAddr::Ip6)
+            val.parse::<Ipv6Addr>()
+                .map(IpAddr::Ip6)
+                .map_err(|_| String::from("Invalid IP address"))
         }
     }
 }
@@ -634,7 +636,10 @@ impl FromStr for IpCidr {
     fn from_str(val: &str) -> result::Result<Self, Self::Err> {
         match val.parse::<Ipv4Cidr>() {
             Ok(ip4) => Ok(IpCidr::Ip4(ip4)),
-            Err(_) => val.parse::<Ipv6Cidr>().map(IpCidr::Ip6),
+            Err(_) => val
+                .parse::<Ipv6Cidr>()
+                .map(IpCidr::Ip6)
+                .map_err(|_| String::from("Invalid IP CIDR")),
         }
     }
 }
@@ -784,7 +789,9 @@ impl FromStr for Ipv6Cidr {
 
         let ip = match ip_s.parse::<smoltcp::wire::Ipv6Address>() {
             Ok(v) => v.into(),
-            Err(_) => return Err(String::from("Bad IP address component")),
+            Err(_) => {
+                return Err(format!("Bad IP address component: '{}'", ip_s))
+            }
         };
 
         let prefix_len = match prefix_s.parse::<u8>() {

--- a/opte-api/src/lib.rs
+++ b/opte-api/src/lib.rs
@@ -50,7 +50,7 @@ pub use ulp::*;
 ///
 /// We rely on CI and the check-api-version.sh script to verify that
 /// this number is incremented anytime the oxide-api code changes.
-pub const API_VERSION: u64 = 11;
+pub const API_VERSION: u64 = 12;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Direction {

--- a/opte-ioctl/src/lib.rs
+++ b/opte-ioctl/src/lib.rs
@@ -4,7 +4,6 @@
 
 // Copyright 2022 Oxide Computer Company
 
-// Copyright 2022 Oxide Computer Company
 pub use opte::api::OpteError;
 use opte::api::{
     CmdOk, NoResp, OpteCmd, OpteCmdIoctl, SetXdeUnderlayReq, API_VERSION,

--- a/opte/src/engine/dhcp.rs
+++ b/opte/src/engine/dhcp.rs
@@ -29,7 +29,7 @@ use super::rule::{
     IpProtoMatch, Ipv4AddrMatch, PortMatch, Predicate,
 };
 use super::udp::{UdpHdr, UdpMeta};
-use opte_api::{Dhcp4Action, Dhcp4ReplyType, MacAddr, SubnetRouterPair};
+use opte_api::{DhcpAction, DhcpReplyType, MacAddr, SubnetRouterPair};
 
 /// The DHCP message type.
 ///
@@ -55,13 +55,13 @@ impl From<MessageType> for smoltcp::wire::DhcpMessageType {
     }
 }
 
-impl From<Dhcp4ReplyType> for MessageType {
-    fn from(rt: Dhcp4ReplyType) -> Self {
+impl From<DhcpReplyType> for MessageType {
+    fn from(rt: DhcpReplyType) -> Self {
         use smoltcp::wire::DhcpMessageType as SmolDMT;
 
         match rt {
-            Dhcp4ReplyType::Offer => Self::from(SmolDMT::Offer),
-            Dhcp4ReplyType::Ack => Self::from(SmolDMT::Ack),
+            DhcpReplyType::Offer => Self::from(SmolDMT::Offer),
+            DhcpReplyType::Ack => Self::from(SmolDMT::Ack),
         }
     }
 }
@@ -224,8 +224,8 @@ impl ClasslessStaticRouteOpt {
 // client/server and those might be unicast, at which point these
 // preds need to include that possibility. Though it may also require
 // a whole separate action (and this should perhaps be named the
-// Dhcp4LeaseAction).
-impl HairpinAction for Dhcp4Action {
+// DhcpLeaseAction).
+impl HairpinAction for DhcpAction {
     fn implicit_preds(&self) -> (Vec<Predicate>, Vec<DataPredicate>) {
         use smoltcp::wire::DhcpMessageType as SmolDMT;
 
@@ -248,14 +248,14 @@ impl HairpinAction for Dhcp4Action {
         ];
 
         let data_preds = match self.reply_type {
-            Dhcp4ReplyType::Offer => {
-                vec![DataPredicate::Dhcp4MsgType(MessageType::from(
+            DhcpReplyType::Offer => {
+                vec![DataPredicate::DhcpMsgType(MessageType::from(
                     SmolDMT::Discover,
                 ))]
             }
 
-            Dhcp4ReplyType::Ack => {
-                vec![DataPredicate::Dhcp4MsgType(MessageType::from(
+            DhcpReplyType::Ack => {
+                vec![DataPredicate::DhcpMsgType(MessageType::from(
                     SmolDMT::Request,
                 ))]
             }

--- a/opte/src/engine/icmpv6.rs
+++ b/opte/src/engine/icmpv6.rs
@@ -1,0 +1,174 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Internet Control Message Protocol version 6
+
+use super::ether::{self, EtherHdr, EtherMeta, ETHER_HDR_SZ};
+use super::ip6::Ipv6Hdr;
+use super::ip6::Ipv6Meta;
+use super::ip6::IPV6_HDR_SZ;
+use super::packet::{Packet, PacketMeta, PacketRead, PacketReader, Parsed};
+use super::rule::{
+    AllowOrDeny, DataPredicate, EtherAddrMatch, GenErr, GenPacketResult,
+    HairpinAction, IpProtoMatch, Ipv6AddrMatch, Predicate,
+};
+use core::fmt::{self, Display};
+pub use opte_api::ip::{Icmpv6EchoReply, Protocol};
+use serde::{Deserialize, Serialize};
+use smoltcp::phy::{Checksum, ChecksumCapabilities as Csum};
+use smoltcp::wire::{
+    Icmpv6Message, Icmpv6Packet, Icmpv6Repr, IpAddress, Ipv6Address,
+};
+
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::vec::Vec;
+    } else {
+        use std::vec::Vec;
+    }
+}
+
+/// An ICMPv6 message type
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(from = "u8", into = "u8")]
+pub struct MessageType {
+    inner: Icmpv6Message,
+}
+
+impl From<Icmpv6Message> for MessageType {
+    fn from(inner: Icmpv6Message) -> MessageType {
+        MessageType { inner }
+    }
+}
+
+impl From<MessageType> for Icmpv6Message {
+    fn from(mt: MessageType) -> Self {
+        mt.inner
+    }
+}
+
+impl From<MessageType> for u8 {
+    fn from(mt: MessageType) -> u8 {
+        u8::from(mt.inner)
+    }
+}
+
+impl From<u8> for MessageType {
+    fn from(val: u8) -> Self {
+        Self { inner: Icmpv6Message::from(val) }
+    }
+}
+
+impl Display for MessageType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl HairpinAction for Icmpv6EchoReply {
+    fn implicit_preds(&self) -> (Vec<Predicate>, Vec<DataPredicate>) {
+        let hdr_preds = vec![
+            Predicate::InnerEtherSrc(vec![EtherAddrMatch::Exact(
+                self.src_mac.into(),
+            )]),
+            Predicate::InnerEtherDst(vec![EtherAddrMatch::Exact(
+                self.dst_mac.into(),
+            )]),
+            Predicate::InnerSrcIp6(vec![Ipv6AddrMatch::Exact(self.src_ip)]),
+            Predicate::InnerDstIp6(vec![Ipv6AddrMatch::Exact(self.dst_ip)]),
+            Predicate::InnerIpProto(vec![IpProtoMatch::Exact(
+                Protocol::ICMPv6,
+            )]),
+        ];
+
+        let data_preds = vec![DataPredicate::Icmpv6MsgType(MessageType::from(
+            Icmpv6Message::EchoRequest,
+        ))];
+
+        (hdr_preds, data_preds)
+    }
+
+    fn gen_packet(
+        &self,
+        meta: &PacketMeta,
+        rdr: &mut PacketReader<Parsed, ()>,
+    ) -> GenPacketResult {
+        // Collect the src / dst IP addresses, which are needed to emit the
+        // resulting ICMPv6 echo reply.
+        let (src_ip, dst_ip) = if let Some(metadata) = meta.inner_ip6() {
+            (
+                IpAddress::Ipv6(Ipv6Address(metadata.src.bytes())),
+                IpAddress::Ipv6(Ipv6Address(metadata.dst.bytes())),
+            )
+        } else {
+            // Getting here implies the predicate matched, but that the
+            // extracted metadata indicates this isn't an IPv6 packet. That
+            // should be impossible, but we avoid panicking given the kernel
+            // context.
+            return Err(GenErr::Unexpected(format!(
+                "Expected IPv6 packet metadata, but found: {:?}",
+                meta
+            )));
+        };
+        let body = rdr.copy_remaining();
+        let src_pkt = Icmpv6Packet::new_checked(&body)?;
+        let src_icmp =
+            Icmpv6Repr::parse(&src_ip, &dst_ip, &src_pkt, &Csum::ignored())?;
+
+        let (src_ident, src_seq_no, src_data) = match src_icmp {
+            Icmpv6Repr::EchoRequest { ident, seq_no, data } => {
+                (ident, seq_no, data)
+            }
+
+            _ => {
+                // We should never hit this case because the predicate
+                // should have verified that we are dealing with an
+                // Echo Request. However, programming error could
+                // cause this to happen -- let's not take any chances.
+                return Err(GenErr::Unexpected(format!(
+                    "expected an ICMPv6 Echo Request, got {} {}",
+                    src_pkt.msg_type(),
+                    src_pkt.msg_code()
+                )));
+            }
+        };
+
+        let reply = Icmpv6Repr::EchoReply {
+            ident: src_ident,
+            seq_no: src_seq_no,
+            data: src_data,
+        };
+
+        let reply_len = reply.buffer_len();
+        let mut ulp_body = vec![0u8; reply_len];
+        let mut icmp_reply = Icmpv6Packet::new_unchecked(&mut ulp_body);
+        let mut csum = Csum::ignored();
+        csum.icmpv6 = Checksum::Tx;
+        reply.emit(&dst_ip, &src_ip, &mut icmp_reply, &csum);
+
+        let mut ip = Ipv6Hdr::from(&Ipv6Meta {
+            src: self.dst_ip,
+            dst: self.src_ip,
+            proto: Protocol::ICMPv6,
+        });
+
+        // There are no extension headers, so the ULP is the only content.
+        ip.set_pay_len(reply_len as u16);
+
+        let eth = EtherHdr::from(&EtherMeta {
+            dst: self.src_mac.into(),
+            src: self.dst_mac.into(),
+            ether_type: ether::ETHER_TYPE_IPV6,
+        });
+
+        let mut pkt_bytes =
+            Vec::with_capacity(ETHER_HDR_SZ + IPV6_HDR_SZ + reply_len);
+        pkt_bytes.extend_from_slice(&eth.as_bytes());
+        pkt_bytes.extend_from_slice(&ip.as_bytes());
+        pkt_bytes.extend_from_slice(&ulp_body);
+        Ok(AllowOrDeny::Allow(Packet::copy(&pkt_bytes)))
+    }
+}

--- a/opte/src/engine/ip4.rs
+++ b/opte/src/engine/ip4.rs
@@ -171,7 +171,7 @@ impl MatchExact<Protocol> for Protocol {
 }
 
 #[derive(
-    Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
+    Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize, Copy,
 )]
 pub struct Ipv4Meta {
     pub src: Ipv4Addr,

--- a/opte/src/engine/ip4.rs
+++ b/opte/src/engine/ip4.rs
@@ -171,7 +171,7 @@ impl MatchExact<Protocol> for Protocol {
 }
 
 #[derive(
-    Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize, Copy,
+    Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
 )]
 pub struct Ipv4Meta {
     pub src: Ipv4Addr,

--- a/opte/src/engine/ip6.rs
+++ b/opte/src/engine/ip6.rs
@@ -262,8 +262,8 @@ impl Ipv6Hdr {
         self.payload_len = len - self.hdr_len() as u16;
     }
 
-    /// Return the total length of the packet, including extension headers and
-    /// payload.
+    /// Return the total length of the packet, including the base header, any
+    /// extension headers, and the payload itself.
     pub fn total_len(&self) -> u16 {
         self.payload_len + IPV6_HDR_SZ as u16
     }

--- a/opte/src/engine/ip6.rs
+++ b/opte/src/engine/ip6.rs
@@ -54,7 +54,7 @@ impl MatchPrefix<Ipv6Cidr> for Ipv6Addr {
 }
 
 #[derive(
-    Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize, Copy,
+    Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
 )]
 pub struct Ipv6Meta {
     pub src: Ipv6Addr,

--- a/opte/src/engine/ip6.rs
+++ b/opte/src/engine/ip6.rs
@@ -6,10 +6,15 @@
 
 use super::checksum::Checksum;
 use super::headers::{
-    Header, HeaderAction, IpMeta, IpMetaOpt, ModifyActionArg, PushActionArg,
+    Header, HeaderAction, HeaderActionModify, IpMeta, IpMetaOpt,
+    ModifyActionArg, PushActionArg,
 };
 use super::ip4::Protocol;
 use super::packet::{PacketRead, ReadErr};
+use crate::engine::rule::MatchExact;
+use crate::engine::rule::MatchExactVal;
+use crate::engine::rule::MatchPrefix;
+use crate::engine::rule::MatchPrefixVal;
 use core::convert::TryFrom;
 pub use opte_api::{Ipv6Addr, Ipv6Cidr};
 use serde::{Deserialize, Serialize};
@@ -33,13 +38,39 @@ pub const IPV6_HDR_SZ: usize = smoltcp::wire::IPV6_HEADER_LEN;
 pub const IPV6_VERSION: u8 = 6;
 pub const DDM_HEADER_ID: u8 = 0xFE;
 
+impl MatchExactVal for Ipv6Addr {}
+impl MatchPrefixVal for Ipv6Cidr {}
+
+impl MatchExact<Ipv6Addr> for Ipv6Addr {
+    fn match_exact(&self, val: &Ipv6Addr) -> bool {
+        *self == *val
+    }
+}
+
+impl MatchPrefix<Ipv6Cidr> for Ipv6Addr {
+    fn match_prefix(&self, prefix: &Ipv6Cidr) -> bool {
+        prefix.is_member(*self)
+    }
+}
+
 #[derive(
-    Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
+    Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize, Copy,
 )]
 pub struct Ipv6Meta {
     pub src: Ipv6Addr,
     pub dst: Ipv6Addr,
     pub proto: Protocol,
+}
+
+impl Ipv6Meta {
+    // XXX check that at least one field was specified.
+    pub fn modify(
+        src: Option<Ipv6Addr>,
+        dst: Option<Ipv6Addr>,
+        proto: Option<Protocol>,
+    ) -> HeaderAction<IpMeta, IpMetaOpt> {
+        HeaderAction::Modify(Ipv6MetaOpt { src, dst, proto }.into())
+    }
 }
 
 impl PushActionArg for Ipv6Meta {}
@@ -52,8 +83,9 @@ impl From<&Ipv6Hdr> for Ipv6Meta {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Ipv6MetaOpt {
-    src: Option<[u8; 16]>,
-    dst: Option<[u8; 16]>,
+    src: Option<Ipv6Addr>,
+    dst: Option<Ipv6Addr>,
+    proto: Option<Protocol>,
 }
 
 impl ModifyActionArg for Ipv6MetaOpt {}
@@ -65,6 +97,20 @@ impl Ipv6Meta {
         proto: Protocol,
     ) -> HeaderAction<IpMeta, IpMetaOpt> {
         HeaderAction::Push(IpMeta::Ip6(Ipv6Meta { src, dst, proto }))
+    }
+}
+
+impl HeaderActionModify<Ipv6MetaOpt> for Ipv6Meta {
+    fn run_modify(&mut self, spec: &Ipv6MetaOpt) {
+        if let Some(src) = spec.src {
+            self.src = src;
+        }
+        if let Some(dst) = spec.dst {
+            self.dst = dst;
+        }
+        if let Some(proto) = spec.proto {
+            self.proto = proto;
+        }
     }
 }
 
@@ -179,6 +225,12 @@ impl Ipv6Hdr {
         usize::from(self.payload_len)
     }
 
+    /// Set the payload length of the contained packet, including any extension
+    /// headers.
+    pub fn set_pay_len(&mut self, len: u16) {
+        self.payload_len = len;
+    }
+
     /// Return the length of the upper-layer protocol payload.
     pub fn ulp_len(&self) -> usize {
         self.pay_len() - self.ext_len()
@@ -208,6 +260,12 @@ impl Ipv6Hdr {
     /// Set the total length of the packet
     pub fn set_total_len(&mut self, len: u16) {
         self.payload_len = len - self.hdr_len() as u16;
+    }
+
+    /// Return the total length of the packet, including extension headers and
+    /// payload.
+    pub fn total_len(&self) -> u16 {
+        self.payload_len + IPV6_HDR_SZ as u16
     }
 
     /// Return the source IPv6 address
@@ -366,6 +424,8 @@ impl From<&Ipv6Meta> for Ipv6Hdr {
 
 #[cfg(test)]
 pub(crate) mod test {
+    use super::Ipv6Addr;
+    use super::Ipv6Cidr;
     use super::Ipv6Hdr;
     use super::DDM_HEADER_ID;
     use super::IPV6_HDR_SZ;
@@ -373,6 +433,8 @@ pub(crate) mod test {
     use crate::engine::packet::Initialized;
     use crate::engine::packet::Packet;
     use crate::engine::packet::PacketReader;
+    use crate::engine::rule::MatchExact;
+    use crate::engine::rule::MatchPrefix;
     use itertools::Itertools;
     use smoltcp::wire::IpProtocol;
     use smoltcp::wire::Ipv6Address;
@@ -602,5 +664,33 @@ pub(crate) mod test {
             PAYLOAD_LEN - header.ext_len(),
             "ULP length is not correct"
         );
+        assert_eq!(
+            header.total_len(),
+            (PAYLOAD_LEN + IPV6_HDR_SZ) as u16,
+            "Total packet length is not correct",
+        );
+    }
+
+    #[test]
+    fn test_ipv6_addr_match_exact() {
+        let addr: Ipv6Addr = "fd00::1".parse().unwrap();
+        assert!(addr.match_exact(&addr));
+        assert!(!addr.match_exact(&("fd00::2".parse().unwrap())));
+    }
+
+    #[test]
+    fn test_ipv6_cidr_match_prefix() {
+        let cidr: Ipv6Cidr = "fd00::1/16".parse().unwrap();
+        let addr: Ipv6Addr = "fd00::1".parse().unwrap();
+        assert!(addr.match_prefix(&cidr));
+
+        let addr: Ipv6Addr = "fd00::2".parse().unwrap();
+        assert!(addr.match_prefix(&cidr));
+
+        let addr: Ipv6Addr = "fd01::1".parse().unwrap();
+        assert!(!addr.match_prefix(&cidr));
+
+        let addr: Ipv6Addr = "fd01::2".parse().unwrap();
+        assert!(!addr.match_prefix(&cidr));
     }
 }

--- a/opte/src/engine/mod.rs
+++ b/opte/src/engine/mod.rs
@@ -17,6 +17,7 @@ pub mod geneve;
 #[macro_use]
 pub mod headers;
 pub mod icmp;
+pub mod icmpv6;
 pub mod ioctl;
 #[macro_use]
 pub mod ip4;

--- a/opte/src/engine/nat.rs
+++ b/opte/src/engine/nat.rs
@@ -6,14 +6,16 @@
 
 use super::ether::EtherMeta;
 use super::ip4::Ipv4Meta;
+use super::ip6::Ipv6Meta;
 use super::layer::InnerFlowId;
 use super::port::meta::ActionMeta;
 use super::rule::{
     self, ActionDesc, AllowOrDeny, DataPredicate, HdrTransform, Predicate,
     StatefulAction,
 };
+use crate::engine::snat::ConcreteIpAddr;
 use core::fmt;
-use opte_api::{Direction, Ipv4Addr, MacAddr};
+use opte_api::{Direction, IpAddr, MacAddr};
 
 cfg_if! {
     if #[cfg(all(not(feature = "std"), not(test)))] {
@@ -27,17 +29,20 @@ cfg_if! {
     }
 }
 
-#[derive(Clone)]
-pub struct Nat4 {
-    priv_ip: Ipv4Addr,
-    public_ip: Ipv4Addr,
+/// A mapping from a private to public IP address for NAT.
+#[derive(Debug, Clone, Copy)]
+pub struct Nat {
+    priv_ip: IpAddr,
+    public_ip: IpAddr,
+    // XXX-EXT-IP Remove
     phys_gw_mac: Option<MacAddr>,
 }
 
-impl Nat4 {
-    pub fn new(
-        priv_ip: Ipv4Addr,
-        public_ip: Ipv4Addr,
+impl Nat {
+    /// Create a new NAT mapping from a private to public IP address.
+    pub fn new<T: ConcreteIpAddr>(
+        priv_ip: T,
+        public_ip: T,
         phys_gw_mac: Option<MacAddr>,
     ) -> Self {
         Self {
@@ -48,19 +53,19 @@ impl Nat4 {
     }
 }
 
-impl fmt::Display for Nat4 {
+impl fmt::Display for Nat {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} <=> {}", self.priv_ip, self.public_ip)
     }
 }
 
-impl StatefulAction for Nat4 {
+impl StatefulAction for Nat {
     fn gen_desc(
         &self,
         _flow_id: &InnerFlowId,
         _meta: &mut ActionMeta,
     ) -> rule::GenDescResult {
-        let desc = Nat4Desc {
+        let desc = NatDesc {
             priv_ip: self.priv_ip,
             public_ip: self.public_ip,
             // XXX-EXT-IP This is assuming ext_ip_hack. All packets
@@ -80,27 +85,32 @@ impl StatefulAction for Nat4 {
     }
 }
 
-#[derive(Clone)]
-pub struct Nat4Desc {
-    priv_ip: Ipv4Addr,
-    public_ip: Ipv4Addr,
+/// An action descriptor for a NAT action.
+#[derive(Debug, Clone, Copy)]
+pub struct NatDesc {
+    priv_ip: IpAddr,
+    public_ip: IpAddr,
     // XXX-EXT-IP
     phys_gw_mac: Option<MacAddr>,
 }
 
-pub const NAT4_NAME: &'static str = "NAT4";
+pub const NAT_NAME: &'static str = "NAT";
 
-impl ActionDesc for Nat4Desc {
+impl ActionDesc for NatDesc {
     fn gen_ht(&self, dir: Direction) -> HdrTransform {
         match dir {
             Direction::Out => {
+                let inner_ip = match self.public_ip {
+                    IpAddr::Ip4(ipv4) => {
+                        Ipv4Meta::modify(Some(ipv4), None, None)
+                    }
+                    IpAddr::Ip6(ipv6) => {
+                        Ipv6Meta::modify(Some(ipv6), None, None)
+                    }
+                };
                 let mut ht = HdrTransform {
-                    name: NAT4_NAME.to_string(),
-                    inner_ip: Ipv4Meta::modify(
-                        Some(self.public_ip),
-                        None,
-                        None,
-                    ),
+                    name: NAT_NAME.to_string(),
+                    inner_ip,
                     ..Default::default()
                 };
 
@@ -117,16 +127,26 @@ impl ActionDesc for Nat4Desc {
                 ht
             }
 
-            Direction::In => HdrTransform {
-                name: NAT4_NAME.to_string(),
-                inner_ip: Ipv4Meta::modify(None, Some(self.priv_ip), None),
-                ..Default::default()
-            },
+            Direction::In => {
+                let inner_ip = match self.priv_ip {
+                    IpAddr::Ip4(ipv4) => {
+                        Ipv4Meta::modify(None, Some(ipv4), None)
+                    }
+                    IpAddr::Ip6(ipv6) => {
+                        Ipv6Meta::modify(None, Some(ipv6), None)
+                    }
+                };
+                HdrTransform {
+                    name: NAT_NAME.to_string(),
+                    inner_ip,
+                    ..Default::default()
+                }
+            }
         }
     }
 
     fn name(&self) -> &str {
-        NAT4_NAME
+        NAT_NAME
     }
 }
 
@@ -145,13 +165,13 @@ mod test {
 
         let priv_mac = MacAddr::from([0xA8, 0x40, 0x25, 0xF0, 0x00, 0x01]);
         let dest_mac = MacAddr::from([0xA8, 0x40, 0x25, 0xFF, 0x77, 0x77]);
-        let priv_ip = "10.0.0.220".parse().unwrap();
+        let priv_ipv4 = "10.0.0.220".parse().unwrap();
         let priv_port = "4999".parse().unwrap();
-        let pub_ip = "52.10.128.69".parse().unwrap();
-        let outside_ip = "76.76.21.21".parse().unwrap();
+        let pub_ipv4 = "52.10.128.69".parse().unwrap();
+        let outside_ipv4 = "76.76.21.21".parse().unwrap();
         let outside_port = 80;
         let gw_mac = MacAddr::from([0x78, 0x23, 0xae, 0x5d, 0x4f, 0x0d]);
-        let nat = Nat4::new(priv_ip, pub_ip, Some(gw_mac));
+        let nat = Nat::new(priv_ipv4, pub_ipv4, Some(gw_mac));
         let mut ameta = ActionMeta::new();
 
         // ================================================================
@@ -163,8 +183,8 @@ mod test {
             ether_type: ETHER_TYPE_IPV4,
         };
         let ip = IpMeta::from(Ipv4Meta {
-            src: priv_ip,
-            dst: outside_ip,
+            src: priv_ipv4,
+            dst: outside_ipv4,
             proto: Protocol::TCP,
         });
         let ulp = UlpMeta::from(TcpMeta {
@@ -209,8 +229,8 @@ mod test {
             _ => panic!("expect Ipv4Meta"),
         };
 
-        assert_eq!(ip4_meta.src, pub_ip);
-        assert_eq!(ip4_meta.dst, outside_ip);
+        assert_eq!(ip4_meta.src, pub_ipv4);
+        assert_eq!(ip4_meta.dst, outside_ipv4);
         assert_eq!(ip4_meta.proto, Protocol::TCP);
 
         let tcp_meta = match pmo.inner.ulp.as_ref().unwrap() {
@@ -231,8 +251,8 @@ mod test {
             ether_type: ETHER_TYPE_IPV4,
         };
         let ip = IpMeta::from(Ipv4Meta {
-            src: outside_ip,
-            dst: pub_ip,
+            src: outside_ipv4,
+            dst: pub_ipv4,
             proto: Protocol::TCP,
         });
         let ulp = UlpMeta::from(TcpMeta {
@@ -265,8 +285,8 @@ mod test {
             _ => panic!("expect Ipv4Meta"),
         };
 
-        assert_eq!(ip4_meta.src, outside_ip);
-        assert_eq!(ip4_meta.dst, priv_ip);
+        assert_eq!(ip4_meta.src, outside_ipv4);
+        assert_eq!(ip4_meta.dst, priv_ipv4);
         assert_eq!(ip4_meta.proto, Protocol::TCP);
 
         let tcp_meta = match pmi.inner.ulp.as_ref().unwrap() {

--- a/opte/src/engine/packet.rs
+++ b/opte/src/engine/packet.rs
@@ -881,7 +881,7 @@ impl Packet<Initialized> {
         match proto {
             Protocol::TCP => Self::parse_hg_tcp(rdr, hg, offsets)?,
             Protocol::UDP => Self::parse_hg_udp(rdr, hg, offsets)?,
-            // See comment above about treating ICMPv6 as a header.
+            // See comment above about treating ICMP as a header.
             Protocol::ICMPv6 => (),
             _ => return Err(ParseError::UnsupportedProtocol(proto)),
         }

--- a/opte/src/engine/packet.rs
+++ b/opte/src/engine/packet.rs
@@ -396,6 +396,14 @@ impl PacketMeta {
         }
     }
 
+    /// Return the inner IPv6 metadata.
+    pub fn inner_ip6(&self) -> Option<&Ipv6Meta> {
+        match &self.inner.ip {
+            Some(IpMeta::Ip6(x)) => Some(x),
+            _ => None,
+        }
+    }
+
     /// Return the inner TCP metadata, if the inner ULP is TCP.
     /// Otherwise, return `None`.
     pub fn inner_tcp(&self) -> Option<&TcpMeta> {
@@ -873,6 +881,8 @@ impl Packet<Initialized> {
         match proto {
             Protocol::TCP => Self::parse_hg_tcp(rdr, hg, offsets)?,
             Protocol::UDP => Self::parse_hg_udp(rdr, hg, offsets)?,
+            // See comment above about treating ICMPv6 as a header.
+            Protocol::ICMPv6 => (),
             _ => return Err(ParseError::UnsupportedProtocol(proto)),
         }
 

--- a/opte/src/engine/rule.rs
+++ b/opte/src/engine/rule.rs
@@ -66,7 +66,7 @@ pub trait MatchExact<M: MatchExactVal + Eq + PartialEq> {
     fn match_exact(&self, val: &M) -> bool;
 }
 
-/// A marker trait for types that can be match up to a prefix.
+/// A marker trait for types that can be match by prefix.
 pub trait MatchPrefixVal {}
 
 /// A trait describing how to match data by prefix.

--- a/opte/src/engine/rule.rs
+++ b/opte/src/engine/rule.rs
@@ -15,9 +15,10 @@ use super::headers::{
     self, HeaderAction, HeaderActionError, IpAddr, IpMeta, IpMetaOpt,
     UlpHeaderAction, UlpMeta, UlpMetaOpt,
 };
-use super::icmp::MessageType as Icmp4MessageType;
+use super::icmp::MessageType as IcmpMessageType;
+use super::icmpv6::MessageType as Icmpv6MessageType;
 use super::ip4::{Ipv4Addr, Ipv4Cidr, Ipv4Meta, Protocol};
-use super::ip6::Ipv6Meta;
+use super::ip6::{Ipv6Addr, Ipv6Cidr, Ipv6Meta};
 use super::layer::InnerFlowId;
 use super::packet::{
     Initialized, Packet, PacketMeta, PacketRead, PacketReader, Parsed,
@@ -31,7 +32,10 @@ use illumos_sys_hdrs::c_char;
 use opte_api::{Direction, MacAddr};
 use serde::{Deserialize, Serialize};
 use smoltcp::phy::ChecksumCapabilities as Csum;
-use smoltcp::wire::{DhcpPacket, DhcpRepr, Icmpv4Packet, Icmpv4Repr};
+use smoltcp::wire::{
+    self, DhcpPacket, DhcpRepr, Icmpv4Packet, Icmpv4Repr, Icmpv6Packet,
+    Icmpv6Repr,
+};
 
 cfg_if! {
     if #[cfg(all(not(feature = "std"), not(test)))] {
@@ -52,20 +56,28 @@ cfg_if! {
 // of payloads include an ARP request, ICMP body, or TCP body.
 pub trait Payload {}
 
+/// A marker trait for types that can be matched exactly, usually by direct
+/// equality comparison.
 pub trait MatchExactVal {}
 
+/// Trait support matching a value exactly, usually by direct equality
+/// comparison.
 pub trait MatchExact<M: MatchExactVal + Eq + PartialEq> {
     fn match_exact(&self, val: &M) -> bool;
 }
 
+/// A marker trait for types that can be match up to a prefix.
 pub trait MatchPrefixVal {}
 
+/// A trait describing how to match data by prefix.
 pub trait MatchPrefix<M: MatchPrefixVal> {
     fn match_prefix(&self, prefix: &M) -> bool;
 }
 
+/// A marker trait for types that can match a range of values.
 pub trait MatchRangeVal {}
 
+/// A trait describing how to match data over a range of values.
 pub trait MatchRange<M: MatchRangeVal> {
     fn match_range(&self, start: &M, end: &M) -> bool;
 }
@@ -185,9 +197,12 @@ impl Display for ArpOpMatch {
     }
 }
 
+/// Describe how to match an IPv4 address
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Ipv4AddrMatch {
+    /// Match an exact address
     Exact(Ipv4Addr),
+    /// Match an address in the same CIDR block
     Prefix(Ipv4Cidr),
 }
 
@@ -203,6 +218,35 @@ impl Ipv4AddrMatch {
 impl Display for Ipv4AddrMatch {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Ipv4AddrMatch::*;
+
+        match self {
+            Exact(ip) => write!(f, "{}", ip),
+            Prefix(cidr) => write!(f, "{}", cidr),
+        }
+    }
+}
+
+/// Describe how to match an IPv6 address
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum Ipv6AddrMatch {
+    /// Match an exact address
+    Exact(Ipv6Addr),
+    /// Match an address in the same CIDR block
+    Prefix(Ipv6Cidr),
+}
+
+impl Ipv6AddrMatch {
+    fn matches(&self, flow_ip: Ipv6Addr) -> bool {
+        match self {
+            Self::Exact(ip) => flow_ip.match_exact(ip),
+            Self::Prefix(cidr) => flow_ip.match_prefix(cidr),
+        }
+    }
+}
+
+impl Display for Ipv6AddrMatch {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Ipv6AddrMatch::*;
 
         match self {
             Exact(ip) => write!(f, "{}", ip),
@@ -275,6 +319,8 @@ pub enum Predicate {
     InnerArpOp(ArpOpMatch),
     InnerSrcIp4(Vec<Ipv4AddrMatch>),
     InnerDstIp4(Vec<Ipv4AddrMatch>),
+    InnerSrcIp6(Vec<Ipv6AddrMatch>),
+    InnerDstIp6(Vec<Ipv6AddrMatch>),
     InnerIpProto(Vec<IpProtoMatch>),
     InnerSrcPort(Vec<PortMatch>),
     InnerDstPort(Vec<PortMatch>),
@@ -351,6 +397,24 @@ impl Display for Predicate {
                     .collect::<Vec<String>>()
                     .join(",");
                 write!(f, "inner.ip.dst={}", s)
+            }
+
+            InnerSrcIp6(list) => {
+                let s = list
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<String>>()
+                    .join(",");
+                write!(f, "inner.ip6.src={}", s)
+            }
+
+            InnerDstIp6(list) => {
+                let s = list
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<String>>()
+                    .join(",");
+                write!(f, "inner.ip6.dst={}", s)
             }
 
             InnerSrcPort(list) => {
@@ -510,6 +574,28 @@ impl Predicate {
                 _ => return false,
             },
 
+            Self::InnerSrcIp6(list) => match meta.inner.ip {
+                Some(IpMeta::Ip6(Ipv6Meta { src: ip, .. })) => {
+                    for m in list {
+                        if m.matches(ip) {
+                            return true;
+                        }
+                    }
+                }
+                _ => return false,
+            },
+
+            Self::InnerDstIp6(list) => match meta.inner.ip {
+                Some(IpMeta::Ip6(Ipv6Meta { dst: ip, .. })) => {
+                    for m in list {
+                        if m.matches(ip) {
+                            return true;
+                        }
+                    }
+                }
+                _ => return false,
+            },
+
             Self::InnerSrcPort(list) => match meta.inner.ulp {
                 None => return false,
 
@@ -557,8 +643,9 @@ impl Predicate {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum DataPredicate {
-    Dhcp4MsgType(DhcpMessageType),
-    Icmp4MsgType(Icmp4MessageType),
+    DhcpMsgType(DhcpMessageType),
+    IcmpMsgType(IcmpMessageType),
+    Icmpv6MsgType(Icmpv6MessageType),
     InnerArpTpa(Vec<Ipv4AddrMatch>),
     Not(Box<DataPredicate>),
 }
@@ -568,12 +655,16 @@ impl Display for DataPredicate {
         use DataPredicate::*;
 
         match self {
-            Dhcp4MsgType(mt) => {
-                write!(f, "dhcp4.msg_type={}", mt)
+            DhcpMsgType(mt) => {
+                write!(f, "dhcp.msg_type={}", mt)
             }
 
-            Icmp4MsgType(mt) => {
+            IcmpMsgType(mt) => {
                 write!(f, "icmp.msg_type={}", mt)
+            }
+
+            Icmpv6MsgType(mt) => {
+                write!(f, "icmpv6.msg_type={}", mt)
             }
 
             InnerArpTpa(list) => {
@@ -605,7 +696,7 @@ impl DataPredicate {
         match self {
             Self::Not(pred) => return !pred.is_match(meta, rdr),
 
-            Self::Dhcp4MsgType(mt) => {
+            Self::DhcpMsgType(mt) => {
                 let bytes = rdr.copy_remaining();
                 let pkt = match DhcpPacket::new_checked(&bytes) {
                     Ok(v) => v,
@@ -633,7 +724,7 @@ impl DataPredicate {
                 return res;
             }
 
-            Self::Icmp4MsgType(mt) => {
+            Self::IcmpMsgType(mt) => {
                 let bytes = rdr.copy_remaining();
                 let pkt = match Icmpv4Packet::new_checked(&bytes) {
                     Ok(v) => v,
@@ -656,7 +747,45 @@ impl DataPredicate {
                     }
                 };
 
-                return Icmp4MessageType::from(pkt.msg_type()) == *mt;
+                return IcmpMessageType::from(pkt.msg_type()) == *mt;
+            }
+
+            Self::Icmpv6MsgType(mt) => {
+                // Pull out the IPv6 source / destination addresses. This checks
+                // that this is actually an IPv6 packet, and these are needed
+                // for the `smoltcp` packet parsing / validation.
+                let (src, dst) = if let Some(metadata) = meta.inner_ip6() {
+                    (
+                        wire::IpAddress::Ipv6(wire::Ipv6Address(
+                            metadata.src.bytes(),
+                        )),
+                        wire::IpAddress::Ipv6(wire::Ipv6Address(
+                            metadata.dst.bytes(),
+                        )),
+                    )
+                } else {
+                    // This isn't an IPv6 packet at all
+                    return false;
+                };
+
+                let bytes = rdr.copy_remaining();
+                let pkt = match Icmpv6Packet::new_checked(&bytes) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        super::err(format!(
+                            "Icmpv6Packet::new_checked() failed: {:?}",
+                            e
+                        ));
+                        return false;
+                    }
+                };
+                if let Err(e) =
+                    Icmpv6Repr::parse(&src, &dst, &pkt, &Csum::ignored())
+                {
+                    super::err(format!("Icmpv6Repr::parse() failed: {:?}", e,));
+                    return false;
+                }
+                return Icmpv6MessageType::from(pkt.msg_type()) == *mt;
             }
 
             Self::InnerArpTpa(list) => match meta.inner.arp {

--- a/opte/src/engine/snat.rs
+++ b/opte/src/engine/snat.rs
@@ -491,11 +491,11 @@ mod test {
         let priv1 = IpAddr::Ip4(priv1_ip);
         let priv2_ip = "192.168.2.33".parse::<Ipv4Addr>().unwrap();
         let priv2 = IpAddr::Ip4(priv2_ip);
-        let public_ip = "52.10.128.69".parse().unwrap();
-        let public = IpAddr::Ip4(public_ip);
+        let external_ip = "52.10.128.69".parse().unwrap();
+        let public = IpAddr::Ip4(external_ip);
 
-        pool.add(priv1_ip, public_ip, 1025..=4096);
-        pool.add(priv2_ip, public_ip, 4097..=8192);
+        pool.add(priv1_ip, external_ip, 1025..=4096);
+        pool.add(priv2_ip, external_ip, 4097..=8192);
 
         assert_eq!(pool.num_avail(priv1).unwrap(), 3072);
         let npe1 = match pool.obtain(&priv1) {

--- a/opteadm/src/lib.rs
+++ b/opteadm/src/lib.rs
@@ -10,15 +10,13 @@
 use std::fs::{File, OpenOptions};
 use std::os::unix::io::AsRawFd;
 
-use opte::api::{
-    Ipv4Addr, Ipv4Cidr, MacAddr, NoResp, OpteCmd, SetXdeUnderlayReq, Vni,
-};
+use opte::api::{NoResp, OpteCmd, SetXdeUnderlayReq};
 use opte::engine::ioctl::{self as api};
 use opte_ioctl::{run_cmd_ioctl, Error};
 use oxide_vpc::api::{
-    AddFwRuleReq, AddRouterEntryIpv4Req, CreateXdeReq, DeleteXdeReq,
-    FirewallRule, ListPortsReq, ListPortsResp, RemFwRuleReq, SNatCfg,
-    SetFwRulesReq, SetVirt2PhysReq,
+    AddFwRuleReq, AddRouterEntryReq, CreateXdeReq, DeleteXdeReq, FirewallRule,
+    ListPortsReq, ListPortsResp, RemFwRuleReq, SetFwRulesReq, SetVirt2PhysReq,
+    VpcCfg,
 };
 use oxide_vpc::engine::overlay;
 
@@ -36,17 +34,7 @@ impl OpteAdm {
     pub fn create_xde(
         &self,
         name: &str,
-        private_mac: MacAddr,
-        private_ip: std::net::Ipv4Addr,
-        vpc_subnet: Ipv4Cidr,
-        gw_mac: MacAddr,
-        gw_ip: std::net::Ipv4Addr,
-        bsvc_addr: std::net::Ipv6Addr,
-        bsvc_vni: Vni,
-        vpc_vni: Vni,
-        src_underlay_addr: std::net::Ipv6Addr,
-        snat: Option<SNatCfg>,
-        external_ips_v4: Option<Ipv4Addr>,
+        cfg: VpcCfg,
         passthrough: bool,
     ) -> Result<NoResp, Error> {
         use libnet::link;
@@ -59,22 +47,7 @@ impl OpteAdm {
 
         let xde_devname = name.into();
         let cmd = OpteCmd::CreateXde;
-        let req = CreateXdeReq {
-            xde_devname,
-            linkid,
-            private_mac,
-            private_ip: private_ip.into(),
-            vpc_subnet,
-            gw_mac,
-            gw_ip: gw_ip.into(),
-            bsvc_addr: bsvc_addr.into(),
-            bsvc_vni,
-            vpc_vni,
-            src_underlay_addr: src_underlay_addr.into(),
-            snat,
-            external_ips_v4,
-            passthrough,
-        };
+        let req = CreateXdeReq { xde_devname, linkid, cfg, passthrough };
 
         let res = run_cmd_ioctl(self.device.as_raw_fd(), cmd, &req);
 
@@ -235,11 +208,11 @@ impl OpteAdm {
         )
     }
 
-    pub fn add_router_entry_ip4(
+    pub fn add_router_entry(
         &self,
-        req: &AddRouterEntryIpv4Req,
+        req: &AddRouterEntryReq,
     ) -> Result<NoResp, Error> {
-        let cmd = OpteCmd::AddRouterEntryIpv4;
+        let cmd = OpteCmd::AddRouterEntry;
         run_cmd_ioctl(self.device.as_raw_fd(), cmd, &req)
     }
 }

--- a/opteadm/src/main.rs
+++ b/opteadm/src/main.rs
@@ -526,7 +526,7 @@ fn main() {
             let hdl = opteadm::OpteAdm::open(OpteAdm::DLD_CTL).unwrap_or_die();
             let snat = match snat_ip {
                 Some(ip) => Some(SNat4Cfg {
-                    public_ip: ip.into(),
+                    external_ip: ip.into(),
                     ports: core::ops::RangeInclusive::new(
                         snat_start.unwrap(),
                         snat_end.unwrap(),

--- a/oxide-vpc/.gitignore
+++ b/oxide-vpc/.gitignore
@@ -1,4 +1,4 @@
-gateway_icmpv4_ping.pcap
+gateway_icmpv[46]_ping.pcap
 overlay_guest_to_guest-guest-1.pcap
 overlay_guest_to_guest-guest-2.pcap
 overlay_guest_to_guest-phys-1.pcap

--- a/oxide-vpc/src/api.rs
+++ b/oxide-vpc/src/api.rs
@@ -300,18 +300,18 @@ pub struct CreateXdeReq {
 }
 
 /// Configuration of source NAT for a port, describing how a private IP
-/// address is mapped to a public IP and port range for outbound connections.
+/// address is mapped to an external IP and port range for outbound connections.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SNat4Cfg {
-    pub public_ip: Ipv4Addr,
+    pub external_ip: Ipv4Addr,
     pub ports: core::ops::RangeInclusive<u16>,
 }
 
 /// Configuration of source NAT for a port, describing how a private IP
-/// address is mapped to a public IP and port range for outbound connections.
+/// address is mapped to an external IP and port range for outbound connections.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SNat6Cfg {
-    pub public_ip: Ipv6Addr,
+    pub external_ip: Ipv6Addr,
     pub ports: core::ops::RangeInclusive<u16>,
 }
 

--- a/oxide-vpc/src/api.rs
+++ b/oxide-vpc/src/api.rs
@@ -21,6 +21,128 @@ cfg_if! {
     }
 }
 
+/// Description of Boundary Services, the endpoint used to route traffic
+/// to networks outside of an Oxide rack.
+// NOTE: This is identical to the `PhysNet` type below, but serves a different
+// purpose, to identify Boundary Services itself, not a generic physical network
+// endpoint in an Oxide rack.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct BoundaryServices {
+    /// IPv6 address of the switch running Boundary Services
+    pub ip: Ipv6Addr,
+    /// Dedicated Geneve VNI for Boundary Services traffic
+    pub vni: Vni,
+    /// A MAC address identifying Boundary Services as a logical next
+    /// hop
+    // This value is effectively arbitrary. It's never used to filter or
+    // direct traffic by the Oxide VPC. It is used to rewrite the
+    // destination MAC address of the _inner_ guest Ethernet frame, from
+    // the OPTE virtual gateway MAC, to this one. This serves two
+    // purposes: OPTE acts "correctly" as a gateway, rewriting the
+    // destination MAC to the logical next hop; and as an observability
+    // tool, allowing us to snoop traffic with this MAC. We already have
+    // the VNI of Boundary Services for that, but it might be useful
+    // nonetheless.
+    pub mac: MacAddr,
+}
+
+/// The IPv4 configuration for an OPTE port
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ipv4Cfg {
+    /// The private IP subnet of the VPC Subnet
+    pub vpc_subnet: Ipv4Cidr,
+
+    /// The port's private IP address in the VPC Subnet
+    pub private_ip: Ipv4Addr,
+
+    /// The IP address of the port's gateway
+    pub gateway_ip: Ipv4Addr,
+
+    /// The source NAT configuration for making outbound connections
+    /// from the private network.
+    pub snat_cfg: Option<SNat4Cfg>,
+
+    /// Optional external IP addresses for this port
+    pub external_ips: Option<Ipv4Addr>,
+}
+
+/// The IPv6 configuration for an OPTE port
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ipv6Cfg {
+    /// The private IP subnet of the VPC Subnet
+    pub vpc_subnet: Ipv6Cidr,
+
+    /// The port's private IP address in the VPC Subnet
+    pub private_ip: Ipv6Addr,
+
+    /// The IP address of the port's gateway
+    pub gateway_ip: Ipv6Addr,
+
+    /// The source NAT configuration for making outbound connections
+    /// from the private network.
+    pub snat_cfg: Option<SNat6Cfg>,
+
+    /// Optional external IP addresses for this port
+    pub external_ips: Option<Ipv6Addr>,
+}
+
+/// The IP configuration for a port
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum IpCfg {
+    Ipv4(Ipv4Cfg),
+    Ipv6(Ipv6Cfg),
+    DualStack { ipv4: Ipv4Cfg, ipv6: Ipv6Cfg },
+}
+
+/// The overall configuration for an OPTE port
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VpcCfg {
+    /// IP address configuration
+    pub ip_cfg: IpCfg,
+
+    /// The private MAC address of the port
+    pub private_mac: MacAddr,
+
+    /// The MAC address of the virtual gateway, OPTE.
+    pub gateway_mac: MacAddr,
+
+    /// The Geneve Virtual Network Identifier for this VPC
+    pub vni: Vni,
+
+    /// The IP address of the hosting sled
+    pub phys_ip: Ipv6Addr,
+
+    /// Information for reaching Boundary Services, for traffic destined
+    /// for off-rack networks.
+    pub boundary_services: BoundaryServices,
+
+    // XXX-EXT-IP the following two fields are for the external IP hack.
+    pub proxy_arp_enable: bool,
+    pub phys_gw_mac: Option<MacAddr>,
+}
+
+impl VpcCfg {
+    /// Return the IPv4 configuration, if it exists, or None.
+    pub fn ipv4_cfg(&self) -> Option<&Ipv4Cfg> {
+        match self.ip_cfg {
+            IpCfg::Ipv4(ref ipv4) | IpCfg::DualStack { ref ipv4, .. } => {
+                Some(ipv4)
+            }
+            _ => None,
+        }
+    }
+
+    /// Return the IPv6 configuration, if it exists, or None.
+    pub fn ipv6_cfg(&self) -> Option<&Ipv6Cfg> {
+        match self.ip_cfg {
+            IpCfg::Ipv6(ref ipv6) | IpCfg::DualStack { ref ipv6, .. } => {
+                Some(ipv6)
+            }
+            _ => None,
+        }
+    }
+}
+
 /// A network destination on the Oxide Rack's physical network.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct PhysNet {
@@ -55,7 +177,7 @@ pub struct GuestPhysAddr {
 /// abstraction, it's simply allowing one subnet to talk to another.
 /// There is no separate VPC router process, the real routing is done
 /// by the underlay.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Copy, Deserialize, Serialize)]
 pub enum RouterTarget {
     Drop,
     InternetGateway,
@@ -84,6 +206,14 @@ impl FromStr for RouterTarget {
                     Ok(Self::VpcSubnet(IpCidr::Ip4(cidr4)))
                 }
 
+                Some(("ip6", ip6s)) => {
+                    ip6s.parse().map(|x| Self::Ip(IpAddr::Ip6(x)))
+                }
+
+                Some(("sub6", cidr6s)) => {
+                    cidr6s.parse().map(|x| Self::VpcSubnet(IpCidr::Ip6(x)))
+                }
+
                 _ => Err(format!("malformed router target: {}", lower)),
             },
         }
@@ -91,12 +221,28 @@ impl FromStr for RouterTarget {
 }
 
 /// Xde create ioctl parameter data.
+///
+/// The bulk of the information is provided via [`VpcCfg`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CreateXdeReq {
     /// The link identifier of the guest, as provided by dlmgmtd.
     pub linkid: datalink_id_t,
+
+    /// The name of the data link, as it appears to `dlmgmtd`.
     pub xde_devname: String,
 
+    /// Configuration information describing the device. See [`VpcCfg`] for more
+    /// details.
+    pub cfg: VpcCfg,
+
+    /// This is a development tool for completely bypassing OPTE processing.
+    ///
+    /// XXX Pretty sure we aren't making much use of this anymore, and
+    /// should go away before v1.
+    pub passthrough: bool,
+}
+
+/*
     /// The VPC IPv4 address of the guest.
     pub private_ip: Ipv4Addr,
 
@@ -107,7 +253,7 @@ pub struct CreateXdeReq {
     pub private_mac: MacAddr,
 
     /// The MAC address for the virtual gateway. The virtual gateway
-    /// is what the guest sees as it's gateway to all other networks,
+    /// is what the guest sees as its gateway to all other networks,
     /// including other VPC guests as well as external networks and
     /// the internet. Essentially, this is the MAC address of OPTE
     /// itself, which is acting as the gateway to the guest.
@@ -144,28 +290,32 @@ pub struct CreateXdeReq {
     ///
     /// XXX Keep this optional for now until NAT'ing is more thoroughly
     /// implemented in Omicron.
-    pub snat: Option<SNatCfg>,
+    pub snat: Option<SNat4Cfg>,
 
     /// The external IPv4 address of the guest. This allows hosts on
     /// the external network to make inbound connections to the guest.
-    /// Whe present, it is also used as 1:1 NAT for outbound
+    /// When present, it is also used as 1:1 NAT for outbound
     /// connections from the guest to an external network.
     ///
     /// XXX For now we only allow one external IP.
     pub external_ips_v4: Option<Ipv4Addr>,
-
-    /// This is a development tool for completely bypassing OPTE processing.
-    ///
-    /// XXX Pretty sure we aren't making much use of this anymore, and
-    /// should go away before v1.
-    pub passthrough: bool,
 }
+*/
 
+/// Configuration of source NAT for a port, describing how a private IP
+/// address is mapped to a public IP and port range for outbound connections.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SNatCfg {
+pub struct SNat4Cfg {
     pub public_ip: Ipv4Addr,
     pub ports: core::ops::RangeInclusive<u16>,
-    pub phys_gw_mac: MacAddr,
+}
+
+/// Configuration of source NAT for a port, describing how a private IP
+/// address is mapped to a public IP and port range for outbound connections.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SNat6Cfg {
+    pub public_ip: Ipv6Addr,
+    pub ports: core::ops::RangeInclusive<u16>,
 }
 
 /// Xde delete ioctl parameter data.
@@ -185,7 +335,10 @@ pub struct ListPortsReq {
 pub struct PortInfo {
     pub name: String,
     pub mac_addr: MacAddr,
-    pub ip4_addr: Ipv4Addr,
+    pub ip4_addr: Option<Ipv4Addr>,
+    pub external_ip4_addr: Option<Ipv4Addr>,
+    pub ip6_addr: Option<Ipv6Addr>,
+    pub external_ip6_addr: Option<Ipv6Addr>,
     pub state: String,
 }
 
@@ -203,23 +356,24 @@ pub struct SetVirt2PhysReq {
     pub phys: PhysNet,
 }
 
-/// Add an entry to the IPv4 router.
+/// Add an entry to the router. Addresses may be either IPv4 or IPv6, though the
+/// destination and target must match in protocol version.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct AddRouterEntryIpv4Req {
+pub struct AddRouterEntryReq {
     pub port_name: String,
-    pub dest: Ipv4Cidr,
+    pub dest: IpCidr,
     pub target: RouterTarget,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct DelRouterEntryIpv4Req {
+pub struct DelRouterEntryReq {
     pub port_name: String,
-    pub dest: Ipv4Cidr,
+    pub dest: IpCidr,
     pub target: RouterTarget,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum DelRouterEntryIpv4Resp {
+pub enum DelRouterEntryResp {
     Ok,
     NotFound,
 }

--- a/oxide-vpc/src/engine/arp.rs
+++ b/oxide-vpc/src/engine/arp.rs
@@ -27,54 +27,71 @@ pub fn setup(
     cfg: &VpcCfg,
     ft_limit: core::num::NonZeroU32,
 ) -> core::result::Result<(), OpteError> {
-    // The ARP layer only contains meaningful actions if this port is configured
-    // to use IPv4.
-    let ip_cfg = match cfg.ipv4_cfg() {
-        None => return Ok(()),
-        Some(cfg) => cfg,
-    };
-    let mut actions = vec![
-        // ARP Reply for gateway's IPv4 address.
-        Action::Hairpin(Arc::new(ArpReply::new(
-            ip_cfg.gateway_ip,
-            cfg.gateway_mac,
-        ))),
-    ];
+    // If the guest is configured to use IPv4, we need to respond to its ARP
+    // requests to resolve the gateway (OPTE) IP address. While the external IP
+    // hack is still in place, we also need to Proxy ARP external requests for
+    // the guest's IP address.
+    //
+    // Regardless of which IP version the guest is configured to use, we need to
+    // drop any other ARP request, inbound or outbound.
+    let mut arp = if let Some(ip_cfg) = cfg.ipv4_cfg() {
+        let mut actions = vec![
+            // ARP Reply for gateway's IPv4 address.
+            Action::Hairpin(Arc::new(ArpReply::new(
+                ip_cfg.gateway_ip,
+                cfg.gateway_mac,
+            ))),
+        ];
 
-    if let Some(ip) = ip_cfg.external_ips.as_ref() {
-        if cfg.proxy_arp_enable {
-            // XXX-EXT-IP Hack to get remote access to guest instance
-            // via Proxy ARP.
-            //
-            // Reuse the same MAC address for both IPs. This should be
-            // fine as the VIP is contained solely to the guest
-            // instance.
-            actions.push(Action::Hairpin(Arc::new(ArpReply::new(
-                *ip,
-                cfg.private_mac,
-            ))));
+        if let Some(ip) = ip_cfg.external_ips.as_ref() {
+            if cfg.proxy_arp_enable {
+                // XXX-EXT-IP Hack to get remote access to guest instance
+                // via Proxy ARP.
+                //
+                // Reuse the same MAC address for both IPs. This should be
+                // fine as the VIP is contained solely to the guest
+                // instance.
+                actions.push(Action::Hairpin(Arc::new(ArpReply::new(
+                    *ip,
+                    cfg.private_mac,
+                ))));
+            }
         }
-    }
+        let mut arp = Layer::new(
+            "arp",
+            pb.name(),
+            // vec![
+            //     // ARP Reply for gateway's IP.
+            //     Action::Hairpin(Arc::new(ArpReply::new(cfg.gw_ip, cfg.gw_mac))),
+            // ],
+            actions,
+            ft_limit,
+        );
 
-    let mut arp = Layer::new(
-        "arp",
-        pb.name(),
-        // vec![
-        //     // ARP Reply for gateway's IP.
-        //     Action::Hairpin(Arc::new(ArpReply::new(cfg.gw_ip, cfg.gw_mac))),
-        // ],
-        actions,
-        ft_limit,
-    );
+        // ================================================================
+        // Outbound ARP Request for Gateway, from Guest
+        // ================================================================
+        let mut rule = Rule::new(1, arp.action(0).unwrap().clone());
+        rule.add_predicate(Predicate::InnerEtherSrc(vec![
+            EtherAddrMatch::Exact(MacAddr::from(cfg.private_mac)),
+        ]));
+        arp.add_rule(Direction::Out, rule.finalize());
 
-    // ================================================================
-    // Outbound ARP Request for Gateway, from Guest
-    // ================================================================
-    let mut rule = Rule::new(1, arp.action(0).unwrap().clone());
-    rule.add_predicate(Predicate::InnerEtherSrc(vec![EtherAddrMatch::Exact(
-        MacAddr::from(cfg.private_mac),
-    )]));
-    arp.add_rule(Direction::Out, rule.finalize());
+        // ================================================================
+        // Proxy ARP for any incoming requests for guest's external IP.
+        //
+        // XXX-EXT-IP This is a hack to get guest access working until we
+        // have boundary services integrated.
+        // ================================================================
+        if ip_cfg.external_ips.is_some() && cfg.proxy_arp_enable {
+            let rule = Rule::new(1, arp.action(1).unwrap().clone());
+            arp.add_rule(Direction::In, rule.finalize());
+        }
+
+        arp
+    } else {
+        Layer::new("arp", pb.name(), vec![], ft_limit)
+    };
 
     // ================================================================
     // Drop all other outbound ARP Requests from Guest
@@ -84,17 +101,6 @@ pub fn setup(
         ETHER_TYPE_ARP,
     )]));
     arp.add_rule(Direction::Out, rule.finalize());
-
-    // ================================================================
-    // Proxy ARP for any incoming requests for guest's external IP.
-    //
-    // XXX-EXT-IP This is a hack to get guest access working until we
-    // have boundary services integrated.
-    // ================================================================
-    if ip_cfg.external_ips.is_some() && cfg.proxy_arp_enable {
-        let rule = Rule::new(1, arp.action(1).unwrap().clone());
-        arp.add_rule(Direction::In, rule.finalize());
-    }
 
     // ================================================================
     // Drop all inbound ARP Requests

--- a/oxide-vpc/src/engine/icmpv6.rs
+++ b/oxide-vpc/src/engine/icmpv6.rs
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Layer handling ICMPv6 messages
+
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::sync::Arc;
+    } else {
+        use std::sync::Arc;
+    }
+}
+
+use crate::api::VpcCfg;
+use opte::api::{Direction, OpteError};
+use opte::engine::icmpv6::Icmpv6EchoReply;
+use opte::engine::layer::Layer;
+use opte::engine::port::{PortBuilder, Pos};
+use opte::engine::rule::{Action, Rule};
+
+pub fn setup(
+    pb: &mut PortBuilder,
+    cfg: &VpcCfg,
+    ft_limit: core::num::NonZeroU32,
+) -> core::result::Result<(), OpteError> {
+    // The ICMPv6 layer only contains meaningful actions if the port is
+    // configured to support IPv6.
+    let ip_cfg = match cfg.ipv6_cfg() {
+        None => return Ok(()),
+        Some(cfg) => cfg,
+    };
+
+    let reply = Action::Hairpin(Arc::new(Icmpv6EchoReply {
+        // Map an Echo Request from guest (src) -> gateway (dst) to an Echo
+        // Reply from gateway (dst) -> guest (src).
+        src_mac: cfg.private_mac.into(),
+        src_ip: ip_cfg.private_ip,
+        dst_mac: cfg.gateway_mac.into(),
+        dst_ip: ip_cfg.gateway_ip,
+    }));
+    let mut icmp = Layer::new("icmpv6", pb.name(), vec![reply], ft_limit);
+
+    let rule = Rule::new(1, icmp.action(0).unwrap().clone());
+    icmp.add_rule(Direction::Out, rule.finalize());
+    pb.add_layer(icmp, Pos::Before("firewall"))
+}

--- a/oxide-vpc/src/engine/mod.rs
+++ b/oxide-vpc/src/engine/mod.rs
@@ -5,9 +5,10 @@
 // Copyright 2022 Oxide Computer Company
 
 pub mod arp;
-pub mod dhcp4;
+pub mod dhcp;
 pub mod firewall;
 pub mod icmp;
+pub mod icmpv6;
 pub mod nat;
 pub mod overlay;
 pub mod router;

--- a/oxide-vpc/src/engine/nat.rs
+++ b/oxide-vpc/src/engine/nat.rs
@@ -15,35 +15,54 @@ cfg_if! {
 }
 
 use super::router::{RouterTargetInternal, ROUTER_LAYER_NAME};
-use crate::VpcCfg;
+use crate::api::{Ipv4Cfg, Ipv6Cfg, MacAddr, VpcCfg};
+use core::num::NonZeroU32;
+use core::result::Result;
 use opte::api::{Direction, OpteError};
-use opte::engine::ether::ETHER_TYPE_IPV4;
+use opte::engine::ether::{ETHER_TYPE_IPV4, ETHER_TYPE_IPV6};
 use opte::engine::layer::Layer;
-use opte::engine::nat::Nat4;
+use opte::engine::nat::Nat;
 use opte::engine::port::meta::ActionMetaValue;
 use opte::engine::port::{PortBuilder, Pos};
 use opte::engine::rule::{
-    Action, EtherTypeMatch, Ipv4AddrMatch, Predicate, Rule,
+    Action, EtherTypeMatch, Ipv4AddrMatch, Ipv6AddrMatch, Predicate, Rule,
 };
-use opte::engine::snat::{NatPool, SNat4};
+use opte::engine::snat::{NatPool, SNat};
 
 pub const NAT_LAYER_NAME: &'static str = "nat";
+const ONE_TO_ONE_NAT_PRIORITY: u16 = 10;
+const SNAT_PRIORITY: u16 = 100;
 
 pub fn setup(
     pb: &mut PortBuilder,
     cfg: &VpcCfg,
-    ft_limit: core::num::NonZeroU32,
-) -> core::result::Result<(), OpteError> {
+    ft_limit: NonZeroU32,
+) -> Result<(), OpteError> {
     let mut layer = Layer::new(NAT_LAYER_NAME, pb.name(), vec![], ft_limit);
+    if let Some(ipv4_cfg) = cfg.ipv4_cfg() {
+        setup_ipv4_nat(&mut layer, ipv4_cfg, cfg.phys_gw_mac)?;
+    }
+    if let Some(ipv6_cfg) = cfg.ipv6_cfg() {
+        setup_ipv6_nat(&mut layer, ipv6_cfg, cfg.phys_gw_mac)?;
+    }
+    pb.add_layer(layer, Pos::After(ROUTER_LAYER_NAME))
+}
 
+fn setup_ipv4_nat(
+    layer: &mut Layer,
+    ip_cfg: &Ipv4Cfg,
+    // XXX-EXT-IP Remove
+    phys_gw_mac: Option<MacAddr>,
+) -> Result<(), OpteError> {
     // When it comes to NAT we always prefer using 1:1 NAT of external
     // IP to SNAT. To achieve this we place the NAT rules at a lower
     // priority than SNAT.
-    if let Some(ip4) = cfg.external_ips_v4 {
-        let nat = Arc::new(Nat4::new(cfg.private_ip, ip4, cfg.phys_gw_mac));
+    if let Some(ip4) = ip_cfg.external_ips {
+        let nat = Arc::new(Nat::new(ip_cfg.private_ip, ip4, phys_gw_mac));
 
         // 1:1 NAT outbound packets destined for internet gateway.
-        let mut out_nat = Rule::new(10, Action::Stateful(nat.clone()));
+        let mut out_nat =
+            Rule::new(ONE_TO_ONE_NAT_PRIORITY, Action::Stateful(nat.clone()));
         out_nat.add_predicate(Predicate::InnerEtherType(vec![
             EtherTypeMatch::Exact(ETHER_TYPE_IPV4),
         ]));
@@ -54,22 +73,20 @@ pub fn setup(
         layer.add_rule(Direction::Out, out_nat.finalize());
 
         // 1:1 NAT inbound packets destined for external IP.
-        let mut in_nat = Rule::new(10, Action::Stateful(nat));
+        let mut in_nat =
+            Rule::new(ONE_TO_ONE_NAT_PRIORITY, Action::Stateful(nat));
         in_nat.add_predicate(Predicate::InnerDstIp4(vec![
             Ipv4AddrMatch::Exact(ip4),
         ]));
         layer.add_rule(Direction::In, in_nat.finalize());
     }
 
-    if cfg.snat.is_some() {
+    if let Some(snat_cfg) = &ip_cfg.snat_cfg {
         let pool = NatPool::new();
-        pool.add(
-            cfg.private_ip,
-            cfg.snat.as_ref().unwrap().public_ip,
-            cfg.snat.as_ref().unwrap().ports.clone(),
-        );
-        let snat = SNat4::new(cfg.private_ip, Arc::new(pool));
-        let mut rule = Rule::new(100, Action::Stateful(Arc::new(snat)));
+        pool.add(ip_cfg.private_ip, snat_cfg.public_ip, snat_cfg.ports.clone());
+        let snat = SNat::new(ip_cfg.private_ip.into(), Arc::new(pool));
+        let mut rule =
+            Rule::new(SNAT_PRIORITY, Action::Stateful(Arc::new(snat)));
 
         rule.add_predicate(Predicate::InnerEtherType(vec![
             EtherTypeMatch::Exact(ETHER_TYPE_IPV4),
@@ -80,6 +97,57 @@ pub fn setup(
         ));
         layer.add_rule(Direction::Out, rule.finalize());
     }
+    Ok(())
+}
 
-    pb.add_layer(layer, Pos::After(ROUTER_LAYER_NAME))
+fn setup_ipv6_nat(
+    layer: &mut Layer,
+    ip_cfg: &Ipv6Cfg,
+    // XXX-EXT-IP Remove
+    phys_gw_mac: Option<MacAddr>,
+) -> Result<(), OpteError> {
+    // When it comes to NAT we always prefer using 1:1 NAT of external
+    // IP to SNAT. To achieve this we place the NAT rules at a lower
+    // priority than SNAT.
+    if let Some(ip6) = ip_cfg.external_ips {
+        let nat = Arc::new(Nat::new(ip_cfg.private_ip, ip6, phys_gw_mac));
+
+        // 1:1 NAT outbound packets destined for internet gateway.
+        let mut out_nat =
+            Rule::new(ONE_TO_ONE_NAT_PRIORITY, Action::Stateful(nat.clone()));
+        out_nat.add_predicate(Predicate::InnerEtherType(vec![
+            EtherTypeMatch::Exact(ETHER_TYPE_IPV6),
+        ]));
+        out_nat.add_predicate(Predicate::Meta(
+            RouterTargetInternal::KEY.to_string(),
+            RouterTargetInternal::InternetGateway.as_meta(),
+        ));
+        layer.add_rule(Direction::Out, out_nat.finalize());
+
+        // 1:1 NAT inbound packets destined for external IP.
+        let mut in_nat =
+            Rule::new(ONE_TO_ONE_NAT_PRIORITY, Action::Stateful(nat));
+        in_nat.add_predicate(Predicate::InnerDstIp6(vec![
+            Ipv6AddrMatch::Exact(ip6),
+        ]));
+        layer.add_rule(Direction::In, in_nat.finalize());
+    }
+
+    if let Some(ref snat_cfg) = ip_cfg.snat_cfg {
+        let pool = NatPool::new();
+        pool.add(ip_cfg.private_ip, snat_cfg.public_ip, snat_cfg.ports.clone());
+        let snat = SNat::new(ip_cfg.private_ip.into(), Arc::new(pool));
+        let mut rule =
+            Rule::new(SNAT_PRIORITY, Action::Stateful(Arc::new(snat)));
+
+        rule.add_predicate(Predicate::InnerEtherType(vec![
+            EtherTypeMatch::Exact(ETHER_TYPE_IPV6),
+        ]));
+        rule.add_predicate(Predicate::Meta(
+            RouterTargetInternal::KEY.to_string(),
+            RouterTargetInternal::InternetGateway.as_meta(),
+        ));
+        layer.add_rule(Direction::Out, rule.finalize());
+    }
+    Ok(())
 }

--- a/oxide-vpc/src/engine/nat.rs
+++ b/oxide-vpc/src/engine/nat.rs
@@ -83,7 +83,11 @@ fn setup_ipv4_nat(
 
     if let Some(snat_cfg) = &ip_cfg.snat_cfg {
         let pool = NatPool::new();
-        pool.add(ip_cfg.private_ip, snat_cfg.public_ip, snat_cfg.ports.clone());
+        pool.add(
+            ip_cfg.private_ip,
+            snat_cfg.external_ip,
+            snat_cfg.ports.clone(),
+        );
         let snat = SNat::new(ip_cfg.private_ip.into(), Arc::new(pool));
         let mut rule =
             Rule::new(SNAT_PRIORITY, Action::Stateful(Arc::new(snat)));
@@ -135,7 +139,11 @@ fn setup_ipv6_nat(
 
     if let Some(ref snat_cfg) = ip_cfg.snat_cfg {
         let pool = NatPool::new();
-        pool.add(ip_cfg.private_ip, snat_cfg.public_ip, snat_cfg.ports.clone());
+        pool.add(
+            ip_cfg.private_ip,
+            snat_cfg.external_ip,
+            snat_cfg.ports.clone(),
+        );
         let snat = SNat::new(ip_cfg.private_ip.into(), Arc::new(pool));
         let mut rule =
             Rule::new(SNAT_PRIORITY, Action::Stateful(Arc::new(snat)));

--- a/oxide-vpc/src/lib.rs
+++ b/oxide-vpc/src/lib.rs
@@ -41,30 +41,5 @@ extern crate cfg_if;
 #[cfg(any(feature = "api", test))]
 pub mod api;
 
-cfg_if! {
-    if #[cfg(any(feature = "engine", test))] {
-        use opte::api::{Ipv4Addr, Ipv4Cidr, Ipv6Addr, MacAddr, Vni};
-        use crate::api::{PhysNet, SNatCfg};
-
-        pub mod engine;
-
-        // TODO Tease out generic PortCfg.
-        #[derive(Clone, Debug)]
-        pub struct VpcCfg {
-            pub vpc_subnet: Ipv4Cidr,
-            pub private_mac: MacAddr,
-            pub private_ip: Ipv4Addr,
-            pub gw_mac: MacAddr,
-            pub gw_ip: Ipv4Addr,
-            // XXX For now we limit to one external IP.
-            pub external_ips_v4: Option<Ipv4Addr>,
-            pub snat: Option<SNatCfg>,
-            pub vni: Vni,
-            pub phys_ip: Ipv6Addr,
-            pub bsvc_addr: PhysNet,
-            // XXX-EXT-IP the follow two fields are for the external IP hack.
-            pub proxy_arp_enable: bool,
-            pub phys_gw_mac: Option<MacAddr>,
-        }
-    }
-}
+#[cfg(any(feature = "engine", test))]
+pub mod engine;

--- a/oxide-vpc/tests/integration_tests.rs
+++ b/oxide-vpc/tests/integration_tests.rs
@@ -386,7 +386,7 @@ fn lab_cfg() -> VpcCfg {
         private_ip: "172.20.14.16".parse().unwrap(),
         gateway_ip: "172.20.14.1".parse().unwrap(),
         snat_cfg: Some(SNat4Cfg {
-            public_ip: "76.76.21.21".parse().unwrap(),
+            external_ip: "76.76.21.21".parse().unwrap(),
             ports: 1025..=4096,
         }),
         external_ips: None,
@@ -494,7 +494,7 @@ fn g1_cfg() -> VpcCfg {
             private_ip: "172.30.0.5".parse().unwrap(),
             gateway_ip: "172.30.0.1".parse().unwrap(),
             snat_cfg: Some(SNat4Cfg {
-                public_ip: "10.77.77.13".parse().unwrap(),
+                external_ip: "10.77.77.13".parse().unwrap(),
                 ports: 1025..=4096,
             }),
             external_ips: None,
@@ -504,7 +504,7 @@ fn g1_cfg() -> VpcCfg {
             private_ip: "fd00::5".parse().unwrap(),
             gateway_ip: "fd00::1".parse().unwrap(),
             snat_cfg: Some(SNat6Cfg {
-                public_ip: "2001:db8::1".parse().unwrap(),
+                external_ip: "2001:db8::1".parse().unwrap(),
                 ports: 1025..=4096,
             }),
             external_ips: None,
@@ -539,7 +539,7 @@ fn g2_cfg() -> VpcCfg {
             private_ip: "172.30.0.6".parse().unwrap(),
             gateway_ip: "172.30.0.1".parse().unwrap(),
             snat_cfg: Some(SNat4Cfg {
-                public_ip: "10.77.77.23".parse().unwrap(),
+                external_ip: "10.77.77.23".parse().unwrap(),
                 ports: 4096..=8192,
             }),
             external_ips: None,
@@ -549,7 +549,7 @@ fn g2_cfg() -> VpcCfg {
             private_ip: "fd00::5".parse().unwrap(),
             gateway_ip: "fd00::1".parse().unwrap(),
             snat_cfg: Some(SNat6Cfg {
-                public_ip: "2001:db8::1".parse().unwrap(),
+                external_ip: "2001:db8::1".parse().unwrap(),
                 ports: 1025..=4096,
             }),
             external_ips: None,
@@ -1564,7 +1564,13 @@ fn guest_to_internet() {
         IpMeta::Ip4(ip4) => {
             assert_eq!(
                 ip4.src,
-                g1_cfg.ipv4_cfg().unwrap().snat_cfg.as_ref().unwrap().public_ip
+                g1_cfg
+                    .ipv4_cfg()
+                    .unwrap()
+                    .snat_cfg
+                    .as_ref()
+                    .unwrap()
+                    .external_ip
             );
             assert_eq!(ip4.dst, dst_ip);
             assert_eq!(ip4.proto, Protocol::TCP);

--- a/oxide-vpc/tests/integration_tests.rs
+++ b/oxide-vpc/tests/integration_tests.rs
@@ -434,7 +434,7 @@ fn oxide_net_builder(
     let one_limit = NonZeroU32::new(1).unwrap();
 
     firewall::setup(&mut pb, fw_limit).expect("failed to add firewall layer");
-    dhcp::setup(&mut pb, cfg, one_limit).expect("failed to add dhcp4 layer");
+    dhcp::setup(&mut pb, cfg, one_limit).expect("failed to add dhcp layer");
     icmp::setup(&mut pb, cfg, one_limit).expect("failed to add icmp layer");
     icmpv6::setup(&mut pb, cfg, one_limit).expect("failed to add icmpv6 layer");
     arp::setup(&mut pb, cfg, one_limit).expect("failed to add arp layer");
@@ -494,10 +494,6 @@ fn g1_cfg() -> VpcCfg {
             private_ip: "172.30.0.5".parse().unwrap(),
             gateway_ip: "172.30.0.1".parse().unwrap(),
             snat_cfg: Some(SNat4Cfg {
-                // NOTE: This is not a routable IP, but remember that a
-                // "public IP" for an Oxide guest could either be a
-                // public, routable IP or simply an IP on their wider LAN
-                // which the oxide Rack is simply a part of.
                 public_ip: "10.77.77.13".parse().unwrap(),
                 ports: 1025..=4096,
             }),
@@ -543,10 +539,6 @@ fn g2_cfg() -> VpcCfg {
             private_ip: "172.30.0.6".parse().unwrap(),
             gateway_ip: "172.30.0.1".parse().unwrap(),
             snat_cfg: Some(SNat4Cfg {
-                // NOTE: This is not a routable IP, but remember that a
-                // "public IP" for an Oxide guest could either be a
-                // public, routable IP or simply an IP on their wider LAN
-                // which the oxide Rack is simply a part of.
                 public_ip: "10.77.77.23".parse().unwrap(),
                 ports: 4096..=8192,
             }),
@@ -565,7 +557,7 @@ fn g2_cfg() -> VpcCfg {
     };
     VpcCfg {
         ip_cfg,
-        private_mac: MacAddr::from([0xA8, 0x40, 0x25, 0xFA, 0xFA, 0x37]),
+        private_mac: MacAddr::from([0xA8, 0x40, 0x25, 0xF0, 0x00, 0x66]),
         gateway_mac: MacAddr::from([0xA8, 0x40, 0x25, 0xFF, 0x77, 0x77]),
         vni: Vni::new(1287581u32).unwrap(),
         // Site 0xF7, Rack 1, Sled 22, Interface 1

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -1438,10 +1438,11 @@ unsafe extern "C" fn xde_mc_tx(
                             // This should be unreachable!(). We have an IP header,
                             // but neither `ip4()` nor `ip6()` returned something.
                             opte::engine::dbg(format!(
-                            "Packet contains IP header, but neither `ip4()` \
-                            nor `ip6()` returned `Some`. IP header: {:?}",
-                            ip_hdr,
-                        ));
+                                "Packet contains IP header, but neither \
+                                `ip4()` nor `ip6()` returned `Some`. \
+                                IP header: {:?}",
+                                ip_hdr,
+                            ));
                             false
                         }
                     } else {


### PR DESCRIPTION
- Adds IPv6 support to the OPTE API and main engine types. This includes fleshing out some missing edges for IPv6 addresses and CIDRs, and adding support for specifying IPv6 addresses in router entries, etc. The main type expanded here is the `VpcCfg`, which now supports an `IpCfg` that specifies all L3 information. That supports exactly one IPv4 or IPv6, or one of each, for private addresses. An optional SNAT and external address for each are also supported.
- Updates the `opte-ioctl` and `opteadm` crates to support IPv6, and to use a `VpcCfg` as the argument, rather than a bunch of disparate arguments. Fleshes out handling for IPv6 in router entries, port info and printing, and layer / rule printing.
- Adds a few niceties to the D scripts for pretty-printing IPv6
- Renames a lot of IPv4 specific types, such as `Dhcp4Reply` to `DhcpReply`. Types without a prefix will be assumed to refer to IPv4, and IPv6 will always have a version number.
- Adds an `icmpv6` layer to `opte` and the `oxide-vpc`, and inserts it in the configuration created by the `xde` driver. This supports ICMPv6 echo requests from the guest to the gateway only. An integration test verifying the hairpinned echo reply is also here.
- Updates the API version check script to compare all commits relative to the `master` branch, rather than the last.