### PR TITLE
PR: ICMP echo does not work over SNAT (#231)

### DIFF
--- a/dtrace/opte-layer-process.d
+++ b/dtrace/opte-layer-process.d
@@ -9,10 +9,11 @@
 #include "common.h"
 #include "protos.d"
 
-#define	HDR_FMT		"%-16s %-16s %-3s %-48s %s\n"
+#define	HDR_FMT		"%-16s %-16s %-3s %-48s $-48s %s\n"
 
 BEGIN {
-	printf(HDR_FMT, "PORT", "LAYER", "DIR", "FLOW", "RES");
+	printf(HDR_FMT, "PORT", "LAYER", "DIR", "FLOW BEFORE", "FLOW AFTER",
+	    "RES");
 	num = 0;
 }
 
@@ -20,11 +21,13 @@ layer-process-return {
 	this->dir = stringof(arg0);
 	this->port = stringof(arg1);
 	this->layer = stringof(arg2);
-	this->flow = (flow_id_sdt_arg_t *)arg3;
-	this->res = stringof(arg4);
+	this->flow_before = (flow_id_sdt_arg_t *)arg3;
+	this->flow_after = (flow_id_sdt_arg_t *)arg4;
+	this->res = stringof(arg5);
 
 	if (num >= 10) {
-		printf(HDR_FMT, "PORT", "LAYER", "DIR", "FLOW", "RES");
+		printf(HDR_FMT, "PORT", "LAYER", "DIR", "FLOW BEFORE",
+		    "FLOW AFTER", "RES");
 		num = 0;
 	}
 
@@ -36,13 +39,17 @@ layer-process-return {
 }
 
 layer-process-return /this->af == AF_INET/ {
-	FLOW_FMT(this->s, this->flow);
-	printf(HDR_FMT, this->port, this->layer, this->dir, this->s, this->res);
+	FLOW_FMT(this->s_before, this->flow_before);
+	FLOW_FMT(this->s_after, this->flow_after);
+	printf(HDR_FMT, this->port, this->layer, this->dir, this->s_before,
+	    this->s_after, this->res);
 	num++;
 }
 
 layer-process-return /this->af == AF_INET6/ {
-	FLOW_FMT6(this->s, this->flow);
-	printf(HDR_FMT, this->port, this->layer, this->dir, this->s, this->res);
+	FLOW_FMT6(this->s_before, this->flow_before);
+	FLOW_FMT6(this->s_after, this->flow_after);
+	printf(HDR_FMT, this->port, this->layer, this->dir, this->s_before,
+	    this->s_after, this->res);
 	num++;
 }

--- a/dtrace/opte-port-process.d
+++ b/dtrace/opte-port-process.d
@@ -6,31 +6,29 @@
 #include "common.h"
 #include "protos.d"
 
-#define	HDR_FMT		"%-12s %-3s %-8s %-43s %-5s %s\n"
-#define	LINE_FMT	"%-12s %-3s %-8u %-43s %-5u %s\n"
+#define	HDR_FMT		"%-12s %-3s %-8s %-43s %-43s %-5s %s\n"
+#define	LINE_FMT	"%-12s %-3s %-8u %-43s %-43s %-5u %s\n"
 
 BEGIN {
-	/*
-	 * Use an associative array to stringify the protocol number.
-	 */
-
-	printf(HDR_FMT, "NAME", "DIR", "EPOCH", "FLOW", "LEN", "RESULT");
+	printf(HDR_FMT, "NAME", "DIR", "EPOCH", "FLOW BEFORE", "FLOW AFTER",
+	    "LEN", "RESULT");
 	num = 0;
 }
 
 port-process-return {
 	this->dir = stringof(arg0);
 	this->name = stringof(arg1);
-	this->flow = (flow_id_sdt_arg_t *)arg2;
-	this->epoch = arg3;
-	this->mp = (mblk_t *)arg4;
+	this->flow_before = (flow_id_sdt_arg_t *)arg2;
+	this->flow_after = (flow_id_sdt_arg_t *)arg3;
+	this->epoch = arg4;
+	this->mp = (mblk_t *)arg5;
 	/* If the result is a hairpin packet, then hp_mp is non-NULL. */
-	this->hp_mp = (mblk_t *)arg5;
-	this->res = stringof(arg6);
+	this->hp_mp = (mblk_t *)arg6;
+	this->res = stringof(arg7);
 
 	if (num >= 10) {
-		printf(HDR_FMT, "NAME", "DIR", "EPOCH", "FLOW", "LEN",
-		    "RESULT");
+		printf(HDR_FMT, "NAME", "DIR", "EPOCH", "FLOW BEFORE",
+		    "FLOW AFTER", "LEN", "RESULT");
 		num = 0;
 	}
 
@@ -42,16 +40,18 @@ port-process-return {
 }
 
 port-process-return /this->af == AF_INET/ {
-	FLOW_FMT(this->s, this->flow);
-	printf(LINE_FMT, this->name, this->dir, this->epoch, this->s,
-	    msgsize(this->mp), this->res);
+	FLOW_FMT(this->s_before, this->flow_before);
+	FLOW_FMT(this->s_after, this->flow_after);
+	printf(LINE_FMT, this->name, this->dir, this->epoch, this->s_before,
+	    this->s_after, msgsize(this->mp), this->res);
 	num++;
 }
 
 port-process-return /this->af == AF_INET6/ {
-	FLOW_FMT6(this->s, this->flow);
-	printf(LINE_FMT,  this->name, this->dir, this->epoch, this->s,
-	    msgsize(this->mp), this->res);
+	FLOW_FMT6(this->s_before, this->flow_before);
+	FLOW_FMT6(this->s_after, this->flow_after);
+	printf(LINE_FMT,  this->name, this->dir, this->epoch, this->s_before,
+	    this->s_after, msgsize(this->mp), this->res);
 	num++;
 }
 

--- a/dtrace/usdt-opte-layer-process.d
+++ b/dtrace/usdt-opte-layer-process.d
@@ -3,26 +3,29 @@
  *
  * dtrace -ZCqs ./usdt-opte-layer-process.d
  */
-#define	HDR_FMT "%-16s %-16s %-3s %-48s %s\n"
+#define	HDR_FMT "%-16s %-16s %-3s %-48s %-48s %s\n"
 
 BEGIN {
-	printf(HDR_FMT, "PORT", "LAYER", "DIR", "FLOW", "RES");
+	printf(HDR_FMT, "PORT", "LAYER", "DIR", "FLOW BEFORE", "FLOW AFTER",
+	    "RES");
 	num = 0;
 }
 
 layer-process-return {
-	this->dir = json(copyinstr(arg0), "ok");
-	this->port = copyinstr(arg1);
-	this->layer = copyinstr(arg2);
-	this->flow = copyinstr(arg3);
+	this->dir = json(copyinstr(arg0), "ok.0");
+	this->port = json(copyinstr(arg0), "ok.1");
+	this->layer = copyinstr(arg1);
+	this->flow_before = copyinstr(arg2);
+	this->flow_after = copyinstr(arg3);
 	this->res = copyinstr(arg4);
 	num++;
 
-	printf(HDR_FMT, this->port, this->layer, this->dir, this->flow,
-	    this->res);
+	printf(HDR_FMT, this->port, this->layer, this->dir, this->flow_before,
+	    this->flow_after, this->res);
 
 	if (num >= 10) {
-		printf(HDR_FMT, "PORT", "LAYER", "DIR", "FLOW", "RES");
+		printf(HDR_FMT, "PORT", "LAYER", "DIR", "FLOW BEFORE",
+		    "FLOW AFTER", "RES");
 		num = 0;
 	}
 }

--- a/dtrace/usdt-port-process.d
+++ b/dtrace/usdt-port-process.d
@@ -1,26 +1,28 @@
-#define	HDR_FMT		"%-3s %-12s %-8s %-43s %-18s %s\n"
-#define	LINE_FMT	"%-3s %-12s %-8u %-43s 0x%-16p %s\n"
+#define	HDR_FMT		"%-3s %-12s %-8s %-43s %-43s %-18s %s\n"
+#define	LINE_FMT	"%-3s %-12s %-8u %-43s %-43s 0x%-16p %s\n"
 
 BEGIN {
-	printf(HDR_FMT, "DIR", "NAME", "EPOCH", "FLOW", "MBLK", "RESULT");
+	printf(HDR_FMT, "DIR", "NAME", "EPOCH", "FLOW BEFORE", "FLOW AFTER",
+	    "MBLK", "RESULT");
 	num = 0;
 }
 
 port-process-return {
-	this->dir = json(copyinstr(arg0), "ok");
-	this->name = copyinstr(arg1);
-	this->flow = copyinstr(arg2);
-	this->epoch = arg3;
-	this->mp = arg4;
-	this->res = copyinstr(arg5);
+	this->dir = json(copyinstr(arg0), "ok.0");
+	this->name = json(copyinstr(arg0), "ok.1");
+	this->flow_before = json(copyinstr(arg1), "ok.0");
+	this->flow_after = json(copyinstr(arg1), "ok.1");
+	this->epoch = arg2;
+	this->mp = arg3;
+	this->res = copyinstr(arg4);
 	num++;
 
 	if (num >= 10) {
-		printf(HDR_FMT, "DIR", "NAME", "EPCOH", "FLOW", "MBLK",
-		    "RESULT");
+		printf(HDR_FMT, "DIR", "NAME", "EPCOH", "FLOW BEFORE",
+		    "FLOW AFTER", "MBLK", "RESULT");
 		num = 0;
 	}
 
-	printf(LINE_FMT, this->dir, this->name, this->epoch, this->flow,
-	    this->mp, this->res);
+	printf(LINE_FMT, this->dir, this->name, this->epoch,
+	    this->flow_before, this->flow_after, this->mp, this->res);
 }

--- a/illumos-sys-hdrs/src/lib.rs
+++ b/illumos-sys-hdrs/src/lib.rs
@@ -101,6 +101,10 @@ impl kstat_named_t {
             value: KStatNamedValue { _c: [0; 16] },
         }
     }
+
+    pub fn val_u64(&self) -> u64 {
+        unsafe { self.value._u64 }
+    }
 }
 
 #[repr(C)]

--- a/opte-ioctl/Cargo.lock
+++ b/opte-ioctl/Cargo.lock
@@ -167,6 +167,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +360,7 @@ version = "0.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "cstr_core",
+ "dyn-clone",
  "heapless",
  "illumos-sys-hdrs",
  "kstat-macro",

--- a/opte/Cargo.lock
+++ b/opte/Cargo.lock
@@ -130,6 +130,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +274,7 @@ version = "0.1.0"
 dependencies = [
  "cfg-if",
  "cstr_core",
+ "dyn-clone",
  "heapless",
  "illumos-sys-hdrs",
  "itertools",

--- a/opte/Cargo.toml
+++ b/opte/Cargo.toml
@@ -22,6 +22,7 @@ cfg-if = "0.1"
 # https://github.com/rust-lang/rust/pull/94079
 #
 cstr_core = "0.2.3"
+dyn-clone = "1.0.9"
 heapless = "0.7.9"
 illumos-sys-hdrs = { path = "../illumos-sys-hdrs" }
 kstat-macro = { path = "../kstat-macro" }

--- a/opte/src/ddi/kstat.rs
+++ b/opte/src/ddi/kstat.rs
@@ -58,6 +58,7 @@ cfg_if! {
 /// To register a provider see [`KStatNamed`].
 pub trait KStatProvider {
     const NUM_FIELDS: u32;
+    type Snap;
 
     fn init(&mut self) -> Result<(), Error>;
 
@@ -66,6 +67,10 @@ pub trait KStatProvider {
     fn num_fields(&self) -> u32 {
         Self::NUM_FIELDS
     }
+
+    /// Return a snapshot of the stats. This is how you obtain a copy,
+    /// as opposed to the traditional clone().
+    fn snapshot(&self) -> Self::Snap;
 }
 
 /// Initialize and register a [`KStatProvider`].
@@ -209,6 +214,10 @@ impl KStatU64 {
     pub fn new() -> Self {
         Self { inner: kstat_named_t::new() }
     }
+
+    pub fn val(&self) -> u64 {
+        self.inner.val_u64()
+    }
 }
 
 #[cfg(all(not(feature = "std"), not(test)))]
@@ -231,6 +240,10 @@ impl KStatU64 {
 
     pub fn new() -> Self {
         Self { value: 0 }
+    }
+
+    pub fn val(&self) -> u64 {
+        self.value
     }
 }
 

--- a/opte/src/engine/arp.rs
+++ b/opte/src/engine/arp.rs
@@ -11,9 +11,7 @@
 /// * RFD 9 -- NETWORKING CONSIDERATIONS
 /// ** §1.13 ARP
 /// * RFC 826 -- An Ethernet Address Resolution Protocol
-use super::ether::{
-    EtherHdr, EtherMeta, ETHER_HDR_SZ, ETHER_TYPE_ARP, ETHER_TYPE_IPV4,
-};
+use super::ether::{EtherHdr, EtherMeta, ETHER_TYPE_ARP, ETHER_TYPE_IPV4};
 use super::headers::{Header, RawHeader};
 use super::packet::{
     Packet, PacketMeta, PacketRead, PacketReader, PacketWriter, Parsed,
@@ -384,7 +382,7 @@ impl HairpinAction for ArpReply {
         // TODO Add 2 bytes to alloc and push b_rptr/b_wptr to make
         // sure IP header is properly aligned.
         let pkt =
-            Packet::alloc(ETHER_HDR_SZ + ARP_HDR_SZ + ARP_ETH4_PAYLOAD_SZ);
+            Packet::alloc(EtherHdr::SIZE + ARP_HDR_SZ + ARP_ETH4_PAYLOAD_SZ);
         let mut wtr = PacketWriter::new(pkt, None);
 
         let ethm = &meta.inner.ether.as_ref().unwrap();

--- a/opte/src/engine/ether.rs
+++ b/opte/src/engine/ether.rs
@@ -35,8 +35,6 @@ pub const ETHER_TYPE_IPV6: u16 = 0x86DD;
 
 pub const ETHER_ADDR_LEN: usize = 6;
 
-pub const ETHER_HDR_SZ: usize = mem::size_of::<EtherHdrRaw>();
-
 #[repr(u16)]
 #[derive(
     Clone, Copy, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
@@ -286,8 +284,11 @@ fn test_eth_macro() {
 }
 
 impl EtherHdr {
+    // This type is for non-VLAN ethernet headers only.
+    pub const SIZE: usize = mem::size_of::<EtherHdrRaw>();
+
     pub fn as_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(ETHER_HDR_SZ);
+        let mut bytes = Vec::with_capacity(Self::SIZE);
         let raw = EtherHdrRaw::from(self);
         bytes.extend_from_slice(raw.as_bytes());
         bytes

--- a/opte/src/engine/flow_table.rs
+++ b/opte/src/engine/flow_table.rs
@@ -4,7 +4,7 @@
 
 // Copyright 2022 Oxide Computer Company
 
-use super::layer::InnerFlowId;
+use super::packet::InnerFlowId;
 use crate::ddi::time::{Moment, MILLIS};
 use core::fmt;
 use core::num::NonZeroU32;
@@ -296,7 +296,7 @@ mod test {
     use super::*;
     use crate::engine::headers::IpAddr;
     use crate::engine::ip4::Protocol;
-    use crate::engine::layer::FLOW_ID_DEFAULT;
+    use crate::engine::packet::FLOW_ID_DEFAULT;
     use core::time::Duration;
 
     pub const FT_SIZE: Option<NonZeroU32> = NonZeroU32::new(16);

--- a/opte/src/engine/geneve.rs
+++ b/opte/src/engine/geneve.rs
@@ -29,7 +29,6 @@ pub const GENEVE_VER_MASK: u8 = 0xC0;
 pub const GENEVE_VER_SHIFT: u8 = 6;
 pub const GENEVE_OPT_LEN_MASK: u8 = 0x3F;
 pub const GENEVE_PORT: u16 = 6081;
-pub const GENEVE_HDR_SZ: usize = mem::size_of::<GeneveHdrRaw>();
 
 #[derive(
     Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
@@ -89,6 +88,9 @@ pub struct GeneveHdr {
 }
 
 impl GeneveHdr {
+    // This is for the base header size only.
+    pub const SIZE: usize = mem::size_of::<GeneveHdrRaw>();
+
     pub fn as_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(self.hdr_len());
         let raw = GeneveHdrRaw::from(self);
@@ -97,7 +99,7 @@ impl GeneveHdr {
     }
 
     pub fn hdr_len(&self) -> usize {
-        usize::from(self.opt_len_bytes) + GENEVE_HDR_SZ
+        usize::from(self.opt_len_bytes) + Self::SIZE
     }
 
     pub fn options_len_bytes(&self) -> usize {

--- a/opte/src/engine/headers.rs
+++ b/opte/src/engine/headers.rs
@@ -11,7 +11,7 @@ use super::packet::{PacketRead, ReadErr, WriteError};
 use super::tcp::{TcpHdr, TcpMeta, TcpMetaOpt};
 use super::udp::{UdpHdr, UdpMeta, UdpMetaOpt};
 use core::fmt;
-pub use opte_api::{IpAddr, IpCidr};
+pub use opte_api::{IpAddr, IpCidr, Protocol};
 use serde::{Deserialize, Serialize};
 use zerocopy::LayoutVerified;
 
@@ -210,6 +210,7 @@ pub enum IpMeta {
 }
 
 impl IpMeta {
+    /// Get the [`Ipv4Meta`], if this is IPv4.
     pub fn ip4(&self) -> Option<&Ipv4Meta> {
         match self {
             Self::Ip4(meta) => Some(meta),
@@ -217,10 +218,19 @@ impl IpMeta {
         }
     }
 
+    /// Get the [`Ipv6Meta`], if this is IPv6.
     pub fn ip6(&self) -> Option<&Ipv6Meta> {
         match self {
             Self::Ip6(meta) => Some(meta),
             _ => None,
+        }
+    }
+
+    /// Get the [`Protocol`].
+    pub fn proto(&self) -> Protocol {
+        match self {
+            Self::Ip4(meta) => meta.proto,
+            Self::Ip6(meta) => meta.proto,
         }
     }
 }

--- a/opte/src/engine/icmp.rs
+++ b/opte/src/engine/icmp.rs
@@ -5,8 +5,8 @@
 // Copyright 2022 Oxide Computer Company
 
 //! ICMP headers.
-use super::ether::{self, EtherHdr, EtherMeta, ETHER_HDR_SZ};
-use super::ip4::{Ipv4Hdr, Ipv4Meta, IPV4_HDR_SZ};
+use super::ether::{self, EtherHdr, EtherMeta};
+use super::ip4::{Ipv4Hdr, Ipv4Meta};
 use super::packet::{Packet, PacketMeta, PacketRead, PacketReader, Parsed};
 use super::rule::{
     AllowOrDeny, DataPredicate, EtherAddrMatch, GenErr, GenPacketResult,
@@ -106,7 +106,7 @@ impl HairpinAction for IcmpEchoReply {
         });
 
         let mut pkt_bytes =
-            Vec::with_capacity(ETHER_HDR_SZ + IPV4_HDR_SZ + reply_len);
+            Vec::with_capacity(EtherHdr::SIZE + Ipv4Hdr::SIZE + reply_len);
         pkt_bytes.extend_from_slice(&eth.as_bytes());
         pkt_bytes.extend_from_slice(&ip4.as_bytes());
         pkt_bytes.extend_from_slice(&tmp);

--- a/opte/src/engine/icmpv6.rs
+++ b/opte/src/engine/icmpv6.rs
@@ -6,10 +6,9 @@
 
 //! Internet Control Message Protocol version 6
 
-use super::ether::{self, EtherHdr, EtherMeta, ETHER_HDR_SZ};
+use super::ether::{self, EtherHdr, EtherMeta};
 use super::ip6::Ipv6Hdr;
 use super::ip6::Ipv6Meta;
-use super::ip6::IPV6_HDR_SZ;
 use super::packet::{Packet, PacketMeta, PacketRead, PacketReader, Parsed};
 use super::rule::{
     AllowOrDeny, DataPredicate, EtherAddrMatch, GenErr, GenPacketResult,
@@ -165,7 +164,7 @@ impl HairpinAction for Icmpv6EchoReply {
         });
 
         let mut pkt_bytes =
-            Vec::with_capacity(ETHER_HDR_SZ + IPV6_HDR_SZ + reply_len);
+            Vec::with_capacity(EtherHdr::SIZE + Ipv6Hdr::SIZE + reply_len);
         pkt_bytes.extend_from_slice(&eth.as_bytes());
         pkt_bytes.extend_from_slice(&ip.as_bytes());
         pkt_bytes.extend_from_slice(&ulp_body);

--- a/opte/src/engine/ioctl.rs
+++ b/opte/src/engine/ioctl.rs
@@ -9,6 +9,7 @@
 //! XXX This stuff needs to be moved to oxide-api.
 use super::flow_table::FlowEntryDump;
 use super::layer;
+use super::packet::InnerFlowId;
 use super::port::Port;
 use super::rule;
 use core::fmt::Debug;
@@ -45,8 +46,8 @@ pub struct DumpLayerResp {
     pub name: String,
     pub rules_in: Vec<(layer::RuleId, rule::RuleDump)>,
     pub rules_out: Vec<(layer::RuleId, rule::RuleDump)>,
-    pub ft_in: Vec<(layer::InnerFlowId, FlowEntryDump)>,
-    pub ft_out: Vec<(layer::InnerFlowId, FlowEntryDump)>,
+    pub ft_in: Vec<(InnerFlowId, FlowEntryDump)>,
+    pub ft_out: Vec<(InnerFlowId, FlowEntryDump)>,
 }
 
 impl CmdOk for DumpLayerResp {}
@@ -88,10 +89,10 @@ pub struct DumpUftReq {
 pub struct DumpUftResp {
     pub uft_in_limit: u32,
     pub uft_in_num_flows: u32,
-    pub uft_in: Vec<(layer::InnerFlowId, FlowEntryDump)>,
+    pub uft_in: Vec<(InnerFlowId, FlowEntryDump)>,
     pub uft_out_limit: u32,
     pub uft_out_num_flows: u32,
-    pub uft_out: Vec<(layer::InnerFlowId, FlowEntryDump)>,
+    pub uft_out: Vec<(InnerFlowId, FlowEntryDump)>,
 }
 
 impl CmdOk for DumpUftResp {}
@@ -103,7 +104,7 @@ pub struct DumpTcpFlowsReq {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct DumpTcpFlowsResp {
-    pub flows: Vec<(layer::InnerFlowId, FlowEntryDump)>,
+    pub flows: Vec<(InnerFlowId, FlowEntryDump)>,
 }
 
 impl CmdOk for DumpTcpFlowsResp {}

--- a/opte/src/engine/ip4.rs
+++ b/opte/src/engine/ip4.rs
@@ -38,7 +38,6 @@ cfg_if! {
 pub const IPV4_HDR_LEN_MASK: u8 = 0x0F;
 pub const IPV4_HDR_VER_MASK: u8 = 0xF0;
 pub const IPV4_HDR_VER_SHIFT: u8 = 4;
-pub const IPV4_HDR_SZ: usize = mem::size_of::<Ipv4HdrRaw>();
 pub const IPV4_VERSION: u8 = 4;
 
 pub const DEF_ROUTE: &'static str = "0.0.0.0/0";
@@ -312,6 +311,8 @@ pub enum UlpCsumOpt {
 }
 
 impl Ipv4Hdr {
+    pub const SIZE: usize = mem::size_of::<Ipv4HdrRaw>();
+
     pub fn as_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(self.hdr_len());
         let raw = Ipv4HdrRaw::from(self);
@@ -373,9 +374,9 @@ impl Ipv4Hdr {
         let data_len = tcp.hdr_len() as u16 + body.len() as u16;
 
         Self {
-            hdr_len_bytes: IPV4_HDR_SZ as u8,
+            hdr_len_bytes: Ipv4Hdr::SIZE as u8,
             dscp_ecn: 0,
-            total_len: IPV4_HDR_SZ as u16 + data_len,
+            total_len: Ipv4Hdr::SIZE as u16 + data_len,
             ident: 0,
             frag_and_flags: [0x40, 0x00],
             ttl: 255,

--- a/opte/src/engine/snat.rs
+++ b/opte/src/engine/snat.rs
@@ -6,27 +6,34 @@
 
 //! Types for working with IP Source NAT, both IPv4 and IPv6.
 
+use super::ether::EtherMeta;
 use super::headers::{UlpGenericModify, UlpHeaderAction, UlpMetaModify};
 use super::ip4::Ipv4Meta;
 use super::ip6::Ipv6Meta;
-use super::layer::InnerFlowId;
+use super::packet::{
+    BodyTransform, BodyTransformError, InnerFlowId, Packet, PacketMeta, Parsed,
+};
 use super::port::meta::ActionMeta;
 use super::rule::{
-    self, ActionDesc, AllowOrDeny, DataPredicate, FiniteResource, HdrTransform,
-    Predicate, Resource, ResourceEntry, ResourceError, StatefulAction,
+    ActionDesc, AllowOrDeny, DataPredicate, FiniteResource, GenBtError,
+    GenDescError, GenDescResult, HdrTransform, Predicate, Resource,
+    ResourceEntry, ResourceError, StatefulAction,
 };
 use crate::ddi::sync::{KMutex, KMutexType};
-use core::fmt;
+use core::fmt::{self, Display};
 use core::ops::RangeInclusive;
-use opte_api::{Direction, IpAddr, Ipv4Addr, Ipv6Addr};
+use opte_api::{Direction, IpAddr, Ipv4Addr, Ipv6Addr, MacAddr, Protocol};
+use smoltcp::wire::{Icmpv4Message, Icmpv4Packet};
 
 cfg_if! {
     if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::boxed::Box;
         use alloc::collections::btree_map::BTreeMap;
         use alloc::string::ToString;
         use alloc::sync::Arc;
         use alloc::vec::Vec;
     } else {
+        use std::boxed::Box;
         use std::collections::btree_map::BTreeMap;
         use std::string::ToString;
         use std::sync::Arc;
@@ -37,30 +44,30 @@ cfg_if! {
 /// A single entry in the NAT pool, describing the public IP and port used to
 /// NAT a private address.
 #[derive(Clone, Copy)]
-pub struct NatPoolEntry {
-    ip: IpAddr,
+pub struct NatPoolEntry<T: ConcreteIpAddr> {
+    ip: T,
     port: u16,
 }
 
 // A public IP and port range for NAT. Includes the list of all possible ports
 // and those that are free.
 #[derive(Debug, Clone)]
-struct PortList {
+struct PortList<T: ConcreteIpAddr> {
     // The public IP address to which a private IP is mapped
-    ip: IpAddr,
+    ip: T,
     // The list of all possible ports available in the NAT pool
     ports: RangeInclusive<u16>,
     // The list of unused / free ports in the pool
     free_ports: Vec<u16>,
 }
 
-impl ResourceEntry for NatPoolEntry {}
+impl<T: ConcreteIpAddr> ResourceEntry for NatPoolEntry<T> {}
 
 /// A mapping from private IP addresses to a public IP and a port range used for
 /// NAT-ing connections.
-pub struct NatPool {
+pub struct NatPool<T: ConcreteIpAddr> {
     // Map private IP to public IP + free list of ports
-    free_list: KMutex<BTreeMap<IpAddr, PortList>>,
+    free_list: KMutex<BTreeMap<T, PortList<T>>>,
 }
 
 mod private {
@@ -72,25 +79,19 @@ mod private {
 ///
 /// This can be used to constrain generic types to the same IP address version,
 /// but of either IPv4 or IPv6.
-pub trait ConcreteIpAddr: private::Ip {}
-impl<T> ConcreteIpAddr for T where T: private::Ip {}
+pub trait ConcreteIpAddr: private::Ip + Copy + Clone + Display + Ord {}
+impl<T: Copy + Clone + Display + Ord> ConcreteIpAddr for T where T: private::Ip {}
 
-impl NatPool {
+impl<T: ConcreteIpAddr> NatPool<T> {
     /// Add a new mapping from private IP to public IP and ports.
-    pub fn add<T: ConcreteIpAddr>(
-        &self,
-        priv_ip: T,
-        pub_ip: T,
-        pub_ports: RangeInclusive<u16>,
-    ) {
+    pub fn add(&self, priv_ip: T, pub_ip: T, pub_ports: RangeInclusive<u16>) {
         let free_ports = pub_ports.clone().collect();
-        let entry =
-            PortList { ip: pub_ip.into(), ports: pub_ports, free_ports };
-        self.free_list.lock().insert(priv_ip.into(), entry);
+        let entry = PortList { ip: pub_ip, ports: pub_ports, free_ports };
+        self.free_list.lock().insert(priv_ip, entry);
     }
 
     /// Return the number of available ports for a given private IP address.
-    pub fn num_avail(&self, priv_ip: IpAddr) -> Result<usize, ResourceError> {
+    pub fn num_avail(&self, priv_ip: T) -> Result<usize, ResourceError> {
         match self.free_list.lock().get(&priv_ip) {
             Some(PortList { free_ports, .. }) => Ok(free_ports.len()),
             _ => Err(ResourceError::NoMatch(priv_ip.to_string())),
@@ -98,10 +99,7 @@ impl NatPool {
     }
 
     /// Return the mapping from a private IP to the public IP and port range.
-    pub fn mapping(
-        &self,
-        priv_ip: IpAddr,
-    ) -> Option<(IpAddr, RangeInclusive<u16>)> {
+    pub fn mapping(&self, priv_ip: T) -> Option<(T, RangeInclusive<u16>)> {
         self.free_list
             .lock()
             .get(&priv_ip)
@@ -115,15 +113,10 @@ impl NatPool {
 
     // A helper function to verify correct operation during testing.
     #[cfg(test)]
-    fn verify_available<T: ConcreteIpAddr>(
-        &self,
-        priv_ip: T,
-        pub_ip: T,
-        pub_port: u16,
-    ) -> bool {
-        match self.free_list.lock().get(&priv_ip.into()) {
+    fn verify_available(&self, priv_ip: T, pub_ip: T, pub_port: u16) -> bool {
+        match self.free_list.lock().get(&priv_ip) {
             Some(PortList { ip, free_ports, .. }) => {
-                if pub_ip.into() != *ip {
+                if pub_ip != *ip {
                     return false;
                 }
                 free_ports.contains(&pub_port)
@@ -133,13 +126,13 @@ impl NatPool {
     }
 }
 
-impl Resource for NatPool {}
+impl<T: ConcreteIpAddr> Resource for NatPool<T> {}
 
-impl FiniteResource for NatPool {
-    type Key = IpAddr;
-    type Entry = NatPoolEntry;
+impl<T: ConcreteIpAddr> FiniteResource for NatPool<T> {
+    type Key = T;
+    type Entry = NatPoolEntry<T>;
 
-    fn obtain(&self, priv_ip: &IpAddr) -> Result<Self::Entry, ResourceError> {
+    fn obtain(&self, priv_ip: &T) -> Result<Self::Entry, ResourceError> {
         match self.free_list.lock().get_mut(&priv_ip) {
             Some(PortList { ip, free_ports, .. }) => {
                 if let Some(port) = free_ports.pop() {
@@ -153,7 +146,7 @@ impl FiniteResource for NatPool {
         }
     }
 
-    fn release(&self, priv_ip: &IpAddr, entry: Self::Entry) {
+    fn release(&self, priv_ip: &T, entry: Self::Entry) {
         match self.free_list.lock().get_mut(&priv_ip) {
             Some(PortList { free_ports, .. }) => {
                 free_ports.push(entry.port);
@@ -169,27 +162,67 @@ impl FiniteResource for NatPool {
 /// A NAT pool mapping provided for Source NAT (only outbound connections).
 #[derive(Clone)]
 pub struct SNat {
-    priv_ip: IpAddr,
-    ip_pool: Arc<NatPool>,
+    priv_ip: Ipv4Addr,
+    ip_pool: Arc<NatPool<Ipv4Addr>>,
+    // XXX-EXT-IP
+    phys_gw_mac: Option<MacAddr>,
 }
 
 impl SNat {
-    pub fn new(addr: IpAddr, ip_pool: Arc<NatPool>) -> Self {
-        SNat { priv_ip: addr, ip_pool }
+    pub fn new(
+        addr: Ipv4Addr,
+        ip_pool: Arc<NatPool<Ipv4Addr>>,
+        phys_gw_mac: Option<MacAddr>,
+    ) -> Self {
+        SNat { priv_ip: addr, ip_pool, phys_gw_mac }
+    }
+
+    // A helper method for generating an SNAT + ICMP action descriptor.
+    fn gen_icmp_desc(
+        &self,
+        nat: NatPoolEntry<Ipv4Addr>,
+        pkt: &Packet<Parsed>,
+    ) -> GenDescResult {
+        if let Some(body_segs) = pkt.body_segs() {
+            let icmp = match Icmpv4Packet::new_checked(body_segs[0]) {
+                Ok(icmp) => icmp,
+                Err(e) => {
+                    return Err(GenDescError::Unexpected {
+                        msg: format!("Failed to parse ICMP: {}", e),
+                    });
+                }
+            };
+
+            if icmp.msg_type() != Icmpv4Message::EchoRequest {
+                return Err(GenDescError::Unexpected {
+                    msg: format!(
+                        "Expected ICMP Echo Request, found: {}",
+                        icmp.msg_type()
+                    ),
+                });
+            }
+
+            let desc = SNatIcmpEchoDesc {
+                pool: self.ip_pool.clone(),
+                priv_ip: self.priv_ip,
+                nat,
+                // Panic: We know this is safe because we make it here
+                // only if this ICMP message is an Echo Request.
+                echo_ident: icmp.echo_ident(),
+                phys_gw_mac: self.phys_gw_mac,
+            };
+
+            Ok(AllowOrDeny::Allow(Arc::new(desc)))
+        } else {
+            Err(GenDescError::Unexpected { msg: format!("No ICMP body found") })
+        }
     }
 }
 
-impl fmt::Display for SNat {
+impl Display for SNat {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (pub_ip, ports) = self.ip_pool.mapping(self.priv_ip).unwrap();
-        match pub_ip {
-            IpAddr::Ip4(ip4) => {
-                write!(f, "{}:{}-{}", ip4, ports.start(), ports.end())
-            }
-            IpAddr::Ip6(ip6) => {
-                write!(f, "[{}]:{}-{}", ip6, ports.start(), ports.end())
-            }
-        }
+        write!(f, "{}:{}-{}", pub_ip, ports.start(), ports.end())
     }
 }
 
@@ -197,30 +230,38 @@ impl StatefulAction for SNat {
     fn gen_desc(
         &self,
         flow_id: &InnerFlowId,
+        pkt: &Packet<Parsed>,
         _meta: &mut ActionMeta,
-    ) -> rule::GenDescResult {
+    ) -> GenDescResult {
         let pool = &self.ip_pool;
         let priv_port = flow_id.src_port;
-        match pool.obtain(&self.priv_ip) {
-            Ok(nat) => {
-                let desc = SNatDesc {
-                    pool: pool.clone(),
-                    priv_ip: self.priv_ip,
-                    priv_port: priv_port,
-                    nat,
-                };
+        match pool.obtain(&self.priv_ip.into()) {
+            Ok(nat) => match flow_id.proto {
+                Protocol::ICMP => self.gen_icmp_desc(nat, pkt),
 
-                Ok(AllowOrDeny::Allow(Arc::new(desc)))
-            }
+                _ => {
+                    let desc = SNatDesc {
+                        pool: pool.clone(),
+                        priv_ip: self.priv_ip.into(),
+                        priv_port: priv_port,
+                        phys_gw_mac: self.phys_gw_mac,
+                        nat,
+                    };
+
+                    Ok(AllowOrDeny::Allow(Arc::new(desc)))
+                }
+            },
+
             Err(ResourceError::Exhausted) => {
-                Err(rule::GenDescError::ResourceExhausted {
+                return Err(GenDescError::ResourceExhausted {
                     name: "SNAT Pool (exhausted)".to_string(),
-                })
+                });
             }
+
             Err(ResourceError::NoMatch(ip)) => {
-                Err(rule::GenDescError::Unexpected {
+                return Err(GenDescError::Unexpected {
                     msg: format!("SNAT pool (no match: {})", ip),
-                })
+                });
             }
         }
     }
@@ -234,27 +275,94 @@ impl StatefulAction for SNat {
 }
 
 #[derive(Clone)]
-pub struct SNatDesc {
-    pool: Arc<NatPool>,
-    nat: NatPoolEntry,
-    priv_ip: IpAddr,
+pub struct SNat6 {
+    priv_ip: Ipv6Addr,
+    ip_pool: Arc<NatPool<Ipv6Addr>>,
+    // XXX-EXT-IP
+    phys_gw_mac: Option<MacAddr>,
+}
+
+impl SNat6 {
+    pub fn new(
+        addr: Ipv6Addr,
+        ip_pool: Arc<NatPool<Ipv6Addr>>,
+        phys_gw_mac: Option<MacAddr>,
+    ) -> Self {
+        SNat6 { priv_ip: addr, ip_pool, phys_gw_mac }
+    }
+}
+
+impl StatefulAction for SNat6 {
+    fn gen_desc(
+        &self,
+        flow_id: &InnerFlowId,
+        _pkt: &Packet<Parsed>,
+        _meta: &mut ActionMeta,
+    ) -> GenDescResult {
+        let pool = &self.ip_pool;
+        let priv_port = flow_id.src_port;
+        match pool.obtain(&self.priv_ip) {
+            Ok(nat) => {
+                let desc = SNatDesc {
+                    pool: pool.clone(),
+                    priv_ip: self.priv_ip.into(),
+                    priv_port: priv_port,
+                    phys_gw_mac: self.phys_gw_mac,
+                    nat,
+                };
+
+                Ok(AllowOrDeny::Allow(Arc::new(desc)))
+            }
+
+            Err(ResourceError::Exhausted) => {
+                return Err(GenDescError::ResourceExhausted {
+                    name: "SNAT Pool (exhausted)".to_string(),
+                });
+            }
+
+            Err(ResourceError::NoMatch(ip)) => {
+                return Err(GenDescError::Unexpected {
+                    msg: format!("SNAT pool (no match: {})", ip),
+                });
+            }
+        }
+    }
+
+    // XXX we should be able to set implicit predicates if we add an
+    // IpCidr field to describe which subnet the client is on; but for
+    // now just keep the predicates fully explicit.
+    fn implicit_preds(&self) -> (Vec<Predicate>, Vec<DataPredicate>) {
+        (vec![], vec![])
+    }
+}
+
+impl Display for SNat6 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let (pub_ip, ports) = self.ip_pool.mapping(self.priv_ip).unwrap();
+        write!(f, "[{}]:{}-{}", pub_ip, ports.start(), ports.end())
+    }
+}
+
+#[derive(Clone)]
+pub struct SNatDesc<T: ConcreteIpAddr> {
+    pool: Arc<NatPool<T>>,
+    nat: NatPoolEntry<T>,
+    priv_ip: T,
     priv_port: u16,
+    // XXX-EXT-IP
+    phys_gw_mac: Option<MacAddr>,
 }
 
 pub const SNAT_NAME: &'static str = "SNAT";
 
-impl ActionDesc for SNatDesc {
+impl ActionDesc for SNatDesc<Ipv4Addr> {
     fn gen_ht(&self, dir: Direction) -> HdrTransform {
         match dir {
             // Outbound traffic needs its source IP and source port
             Direction::Out => {
-                let inner_ip = match self.nat.ip {
-                    IpAddr::Ip4(ip) => Ipv4Meta::modify(Some(ip), None, None),
-                    IpAddr::Ip6(ip) => Ipv6Meta::modify(Some(ip), None, None),
-                };
-                HdrTransform {
+                let mut ht = HdrTransform {
                     name: SNAT_NAME.to_string(),
-                    inner_ip: inner_ip,
+                    inner_ip: Ipv4Meta::modify(Some(self.nat.ip), None, None),
                     inner_ulp: UlpHeaderAction::Modify(UlpMetaModify {
                         generic: UlpGenericModify {
                             src_port: Some(self.nat.port),
@@ -263,30 +371,36 @@ impl ActionDesc for SNatDesc {
                         ..Default::default()
                     }),
                     ..Default::default()
+                };
+
+                // XXX-EXT-IP hack to rewrite destination MAC adress
+                // from virtual gateway addr to the real gateway addr
+                // on the same subnet as the external IP.
+                if self.phys_gw_mac.is_some() {
+                    ht.inner_ether = EtherMeta::modify(
+                        None,
+                        Some(self.phys_gw_mac.unwrap()),
+                    );
                 }
+
+                ht
             }
 
             // Inbound traffic needs its destination IP and
             // destination port mapped back to the private values that
             // the guest expects to see.
-            Direction::In => {
-                let inner_ip = match self.priv_ip {
-                    IpAddr::Ip4(ip) => Ipv4Meta::modify(None, Some(ip), None),
-                    IpAddr::Ip6(ip) => Ipv6Meta::modify(None, Some(ip), None),
-                };
-                HdrTransform {
-                    name: SNAT_NAME.to_string(),
-                    inner_ip: inner_ip,
-                    inner_ulp: UlpHeaderAction::Modify(UlpMetaModify {
-                        generic: UlpGenericModify {
-                            dst_port: Some(self.priv_port),
-                            ..Default::default()
-                        },
+            Direction::In => HdrTransform {
+                name: SNAT_NAME.to_string(),
+                inner_ip: Ipv4Meta::modify(None, Some(self.priv_ip), None),
+                inner_ulp: UlpHeaderAction::Modify(UlpMetaModify {
+                    generic: UlpGenericModify {
+                        dst_port: Some(self.priv_port),
                         ..Default::default()
-                    }),
+                    },
                     ..Default::default()
-                }
-            }
+                }),
+                ..Default::default()
+            },
         }
     }
 
@@ -295,9 +409,188 @@ impl ActionDesc for SNatDesc {
     }
 }
 
-impl Drop for SNatDesc {
+impl ActionDesc for SNatDesc<Ipv6Addr> {
+    fn gen_ht(&self, dir: Direction) -> HdrTransform {
+        match dir {
+            // Outbound traffic needs its source IP and source port
+            Direction::Out => {
+                let mut ht = HdrTransform {
+                    name: SNAT_NAME.to_string(),
+                    inner_ip: Ipv6Meta::modify(Some(self.nat.ip), None, None),
+                    inner_ulp: UlpHeaderAction::Modify(UlpMetaModify {
+                        generic: UlpGenericModify {
+                            src_port: Some(self.nat.port),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                };
+
+                // XXX-EXT-IP hack to rewrite destination MAC adress
+                // from virtual gateway addr to the real gateway addr
+                // on the same subnet as the external IP.
+                if self.phys_gw_mac.is_some() {
+                    ht.inner_ether = EtherMeta::modify(
+                        None,
+                        Some(self.phys_gw_mac.unwrap()),
+                    );
+                }
+
+                ht
+            }
+
+            // Inbound traffic needs its destination IP and
+            // destination port mapped back to the private values that
+            // the guest expects to see.
+            Direction::In => HdrTransform {
+                name: SNAT_NAME.to_string(),
+                inner_ip: Ipv6Meta::modify(None, Some(self.priv_ip), None),
+                inner_ulp: UlpHeaderAction::Modify(UlpMetaModify {
+                    generic: UlpGenericModify {
+                        dst_port: Some(self.priv_port),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        }
+    }
+
+    fn name(&self) -> &str {
+        SNAT_NAME
+    }
+}
+
+impl<T: ConcreteIpAddr> Drop for SNatDesc<T> {
     fn drop(&mut self) {
         self.pool.release(&self.priv_ip, self.nat);
+    }
+}
+
+#[derive(Clone)]
+pub struct SNatIcmpEchoDesc {
+    pool: Arc<NatPool<Ipv4Addr>>,
+    nat: NatPoolEntry<Ipv4Addr>,
+    priv_ip: Ipv4Addr,
+    echo_ident: u16,
+    // XXX-EXT-IP
+    phys_gw_mac: Option<MacAddr>,
+}
+
+pub const SNAT_ICMP_ECHO_NAME: &'static str = "SNAT_ICMP_ECHO";
+
+impl ActionDesc for SNatIcmpEchoDesc {
+    fn gen_ht(&self, dir: Direction) -> HdrTransform {
+        match dir {
+            // Outbound traffic needs its source IP and source port
+            Direction::Out => {
+                let mut ht = HdrTransform {
+                    name: SNAT_NAME.to_string(),
+                    inner_ip: Ipv4Meta::modify(Some(self.nat.ip), None, None),
+                    ..Default::default()
+                };
+
+                // XXX-EXT-IP hack to rewrite destination MAC adress
+                // from virtual gateway addr to the real gateway addr
+                // on the same subnet as the external IP.
+                if self.phys_gw_mac.is_some() {
+                    ht.inner_ether = EtherMeta::modify(
+                        None,
+                        Some(self.phys_gw_mac.unwrap()),
+                    );
+                }
+
+                ht
+            }
+
+            // Inbound traffic needs its destination IP and
+            // destination port mapped back to the private values that
+            // the guest expects to see.
+            Direction::In => HdrTransform {
+                name: SNAT_NAME.to_string(),
+                inner_ip: Ipv4Meta::modify(None, Some(self.priv_ip), None),
+                ..Default::default()
+            },
+        }
+    }
+
+    // SNAT needs to generate a payload transform for ICMP traffic in
+    // order to treat the Echo Identifier as a psuedo ULP port.
+    fn gen_bt(
+        &self,
+        _dir: Direction,
+        _meta: &PacketMeta,
+        _payload_segs: &[&[u8]],
+    ) -> Result<Option<Box<dyn BodyTransform>>, GenBtError> {
+        Ok(Some(Box::new(SNatIcmpEchoBt::new(self.echo_ident, self.nat))))
+    }
+
+    fn name(&self) -> &str {
+        SNAT_ICMP_ECHO_NAME
+    }
+}
+
+impl Drop for SNatIcmpEchoDesc {
+    fn drop(&mut self) {
+        self.pool.release(&self.priv_ip.into(), self.nat);
+    }
+}
+
+/// Perform SNAT for ICMP Echo/Reply messages, treating the Identifier
+/// as a source port.
+#[derive(Clone)]
+pub struct SNatIcmpEchoBt {
+    ident: u16,
+    nat: NatPoolEntry<Ipv4Addr>,
+}
+
+impl SNatIcmpEchoBt {
+    pub fn new(ident: u16, nat: NatPoolEntry<Ipv4Addr>) -> Self {
+        Self { ident, nat }
+    }
+}
+
+impl BodyTransform for SNatIcmpEchoBt {
+    fn run(
+        &self,
+        dir: Direction,
+        body: &mut [&mut [u8]],
+    ) -> Result<(), BodyTransformError> {
+        use Icmpv4Message::{EchoReply, EchoRequest};
+
+        let mut icmp = Icmpv4Packet::new_checked(&mut *body[0])?;
+
+        match (icmp.msg_type(), dir) {
+            (EchoReply | EchoRequest, Direction::Out) => {
+                // Panic: We know this is safe because we make it here
+                // only if this ICMP message is an Echo/Reply.
+                icmp.set_echo_ident(self.nat.port);
+            }
+
+            (EchoReply | EchoRequest, Direction::In) => {
+                // Panic: We know this is safe because we make it here
+                // only if this ICMP message is an Echo/Reply.
+                icmp.set_echo_ident(self.ident);
+            }
+
+            (_, _) => {
+                return Err(BodyTransformError::UnexpectedBody(format!(
+                    "Expected ICMP Echo/Reply, found: {}",
+                    icmp.msg_type()
+                )));
+            }
+        }
+
+        icmp.fill_checksum();
+        Ok(())
+    }
+}
+
+impl Display for SNatIcmpEchoBt {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ICMP Echo Ident/SNAT {} <=> {}", self.ident, self.nat.port)
     }
 }
 
@@ -307,38 +600,36 @@ mod test {
 
     #[test]
     fn test_nat_pool_different_ip_types() {
-        let pool = NatPool::new();
+        let pool4 = NatPool::new();
+        let pool6 = NatPool::new();
 
         let ipv4: Ipv4Addr = "172.30.0.1".parse().unwrap();
         let pub_ipv4 = "76.76.21.21".parse().unwrap();
         let ipv6: Ipv6Addr = "fd00::1".parse().unwrap();
         let pub_ipv6 = "2001:db8::1".parse().unwrap();
 
-        assert!(pool.mapping(ipv4.into()).is_none());
-        assert!(pool.mapping(ipv6.into()).is_none());
+        assert!(pool4.mapping(ipv4).is_none());
+        assert!(pool6.mapping(ipv6).is_none());
 
-        pool.add(ipv4, pub_ipv4, 0..=4096);
-        assert!(pool.mapping(ipv4.into()).is_some());
-        assert!(pool.mapping(ipv6.into()).is_none());
+        pool4.add(ipv4, pub_ipv4, 0..=4096);
+        assert!(pool4.mapping(ipv4).is_some());
 
-        pool.add(ipv6, pub_ipv6, 0..=4096);
-        assert!(pool.mapping(ipv4.into()).is_some());
-        assert!(pool.mapping(ipv6.into()).is_some());
+        pool6.add(ipv6, pub_ipv6, 0..=4096);
+        assert!(pool6.mapping(ipv6).is_some());
     }
 
     #[test]
     fn snat4_desc_lifecycle() {
-        use crate::engine::ether::{EtherMeta, ETHER_TYPE_IPV4};
+        use crate::engine::checksum::HeaderChecksum;
+        use crate::engine::ether::{EtherHdr, EtherType};
         use crate::engine::headers::{IpMeta, UlpMeta};
-        use crate::engine::ip4::Protocol;
-        use crate::engine::packet::{MetaGroup, PacketMeta};
-        use crate::engine::tcp::TcpMeta;
+        use crate::engine::ip4::{Ipv4Hdr, Protocol, UlpCsumOpt};
+        use crate::engine::tcp::TcpHdr;
         use opte_api::{Ipv4Addr, MacAddr};
 
         let priv_mac = MacAddr::from([0x02, 0x08, 0x20, 0xd8, 0x35, 0xcf]);
         let dest_mac = MacAddr::from([0x78, 0x23, 0xae, 0x5d, 0x4f, 0x0d]);
-        let priv_ipv4: Ipv4Addr = "10.0.0.220".parse().unwrap();
-        let priv_ip = IpAddr::from(priv_ipv4);
+        let priv_ip: Ipv4Addr = "10.0.0.220".parse().unwrap();
         let priv_port = "4999".parse().unwrap();
         let pub_ip: Ipv4Addr = "52.10.128.69".parse().unwrap();
         let pub_port = "8765".parse().unwrap();
@@ -346,58 +637,46 @@ mod test {
         let outside_port = 80;
 
         let pool = Arc::new(NatPool::new());
-        pool.add(priv_ipv4, pub_ip, 8765..=8765);
-        let snat = SNat::new(priv_ip, pool.clone());
+        pool.add(priv_ip, pub_ip, 8765..=8765);
+        let snat = SNat::new(priv_ip, pool.clone(), None);
         let mut action_meta = ActionMeta::new();
-        assert!(pool.verify_available(priv_ipv4, pub_ip, pub_port));
+        assert!(pool.verify_available(priv_ip, pub_ip, pub_port));
 
         // ================================================================
-        // Build the packet metadata
+        // Build the packet
         // ================================================================
-        let ether = EtherMeta {
-            src: priv_mac,
-            dst: dest_mac,
-            ether_type: ETHER_TYPE_IPV4,
-        };
-        let ip = IpMeta::from(Ipv4Meta {
-            src: priv_ipv4,
-            dst: outside_ip,
-            proto: Protocol::TCP,
-        });
-        let ulp = UlpMeta::from(TcpMeta {
-            src: priv_port,
-            dst: outside_port,
-            flags: 0,
-            seq: 0,
-            ack: 0,
-        });
-
-        let mut pmo = PacketMeta {
-            outer: Default::default(),
-            inner: MetaGroup {
-                ether: Some(ether),
-                ip: Some(ip),
-                ulp: Some(ulp),
-                ..Default::default()
-            },
-        };
+        let body = vec![];
+        let mut tcp = TcpHdr::new(priv_port, outside_port);
+        let mut ip4 = Ipv4Hdr::new_tcp(&mut tcp, &body, priv_ip, outside_ip);
+        ip4.compute_hdr_csum();
+        let tcp_csum =
+            ip4.compute_ulp_csum(UlpCsumOpt::Full, &tcp.as_bytes(), &body);
+        tcp.set_csum(HeaderChecksum::from(tcp_csum).bytes());
+        let eth = EtherHdr::new(EtherType::Ipv4, priv_mac, dest_mac);
+        let mut bytes = vec![];
+        bytes.extend_from_slice(&eth.as_bytes());
+        bytes.extend_from_slice(&ip4.as_bytes());
+        bytes.extend_from_slice(&tcp.as_bytes());
+        bytes.extend_from_slice(&body);
+        let mut pkt = Packet::copy(&bytes).parse().unwrap();
 
         // ================================================================
         // Verify descriptor generation.
         // ================================================================
-        let flow_out = InnerFlowId::from(&pmo);
-        let desc = match snat.gen_desc(&flow_out, &mut action_meta) {
+        let flow_out = InnerFlowId::from(pkt.meta());
+        let desc = match snat.gen_desc(&flow_out, &pkt, &mut action_meta) {
             Ok(AllowOrDeny::Allow(desc)) => desc,
             _ => panic!("expected AllowOrDeny::Allow(desc) result"),
         };
-        assert!(!pool.verify_available(priv_ipv4, pub_ip, pub_port));
+        assert!(!pool.verify_available(priv_ip, pub_ip, pub_port));
 
         // ================================================================
         // Verify outbound header transformation
         // ================================================================
         let out_ht = desc.gen_ht(Direction::Out);
-        out_ht.run(&mut pmo).unwrap();
+        out_ht.run(pkt.meta_mut()).unwrap();
 
+        let pmo = pkt.meta();
         let ether_meta = pmo.inner.ether.as_ref().unwrap();
         assert_eq!(ether_meta.src, priv_mac);
         assert_eq!(ether_meta.dst, dest_mac);
@@ -423,37 +702,25 @@ mod test {
         // ================================================================
         // Verify inbound header transformation.
         // ================================================================
-        let ether = EtherMeta {
-            src: dest_mac,
-            dst: priv_mac,
-            ether_type: ETHER_TYPE_IPV4,
-        };
-        let ip = IpMeta::from(Ipv4Meta {
-            src: outside_ip,
-            dst: pub_ip,
-            proto: Protocol::TCP,
-        });
-        let ulp = UlpMeta::from(TcpMeta {
-            src: outside_port,
-            dst: pub_port,
-            flags: 0,
-            seq: 0,
-            ack: 0,
-        });
-
-        let mut pmi = PacketMeta {
-            outer: Default::default(),
-            inner: MetaGroup {
-                ether: Some(ether),
-                ip: Some(ip),
-                ulp: Some(ulp),
-                ..Default::default()
-            },
-        };
+        let body = vec![];
+        let mut tcp = TcpHdr::new(outside_port, priv_port);
+        let mut ip4 = Ipv4Hdr::new_tcp(&mut tcp, &body, outside_ip, priv_ip);
+        ip4.compute_hdr_csum();
+        let tcp_csum =
+            ip4.compute_ulp_csum(UlpCsumOpt::Full, &tcp.as_bytes(), &body);
+        tcp.set_csum(HeaderChecksum::from(tcp_csum).bytes());
+        let eth = EtherHdr::new(EtherType::Ipv4, dest_mac, priv_mac);
+        let mut bytes = vec![];
+        bytes.extend_from_slice(&eth.as_bytes());
+        bytes.extend_from_slice(&ip4.as_bytes());
+        bytes.extend_from_slice(&tcp.as_bytes());
+        bytes.extend_from_slice(&body);
+        let mut pkt = Packet::copy(&bytes).parse().unwrap();
 
         let in_ht = desc.gen_ht(Direction::In);
-        in_ht.run(&mut pmi).unwrap();
+        in_ht.run(pkt.meta_mut()).unwrap();
 
+        let pmi = pkt.meta();
         let ether_meta = pmi.inner.ether.as_ref().unwrap();
         assert_eq!(ether_meta.src, dest_mac);
         assert_eq!(ether_meta.dst, priv_mac);
@@ -464,7 +731,7 @@ mod test {
         };
 
         assert_eq!(ip4_meta.src, outside_ip);
-        assert_eq!(ip4_meta.dst, priv_ipv4);
+        assert_eq!(ip4_meta.dst, priv_ip);
         assert_eq!(ip4_meta.proto, Protocol::TCP);
 
         let tcp_meta = match pmi.inner.ulp.as_ref().unwrap() {
@@ -481,21 +748,18 @@ mod test {
         // handed back to the pool.
         // ================================================================
         drop(desc);
-        assert!(pool.verify_available(priv_ipv4, pub_ip, pub_port));
+        assert!(pool.verify_available(priv_ip, pub_ip, pub_port));
     }
 
     #[test]
     fn nat_mappings() {
         let pool = NatPool::new();
-        let priv1_ip = "192.168.2.8".parse::<Ipv4Addr>().unwrap();
-        let priv1 = IpAddr::Ip4(priv1_ip);
-        let priv2_ip = "192.168.2.33".parse::<Ipv4Addr>().unwrap();
-        let priv2 = IpAddr::Ip4(priv2_ip);
+        let priv1 = "192.168.2.8".parse::<Ipv4Addr>().unwrap();
+        let priv2 = "192.168.2.33".parse::<Ipv4Addr>().unwrap();
         let external_ip = "52.10.128.69".parse().unwrap();
-        let public = IpAddr::Ip4(external_ip);
 
-        pool.add(priv1_ip, external_ip, 1025..=4096);
-        pool.add(priv2_ip, external_ip, 4097..=8192);
+        pool.add(priv1, external_ip, 1025..=4096);
+        pool.add(priv2, external_ip, 4097..=8192);
 
         assert_eq!(pool.num_avail(priv1).unwrap(), 3072);
         let npe1 = match pool.obtain(&priv1) {
@@ -503,7 +767,7 @@ mod test {
             _ => panic!("failed to obtain mapping"),
         };
         assert_eq!(pool.num_avail(priv1).unwrap(), 3071);
-        assert_eq!(npe1.ip, public);
+        assert_eq!(npe1.ip, external_ip);
         assert!(npe1.port >= 1025);
         assert!(npe1.port <= 4096);
 
@@ -513,7 +777,7 @@ mod test {
             _ => panic!("failed to obtain mapping"),
         };
         assert_eq!(pool.num_avail(priv2).unwrap(), 4095);
-        assert_eq!(npe2.ip, public);
+        assert_eq!(npe2.ip, external_ip);
         assert!(npe2.port >= 4097);
         assert!(npe2.port <= 8192);
 

--- a/opte/src/engine/tcp.rs
+++ b/opte/src/engine/tcp.rs
@@ -278,7 +278,7 @@ impl TcpHdr {
             seq: 0,
             ack: 0,
             hdr_len_bytes: 20,
-            flags: 0x02,
+            flags: 0x00,
             win: 0,
             csum: [0; 2],
             csum_minus_hdr: Checksum::from(0),

--- a/opte/src/engine/tcp_state.rs
+++ b/opte/src/engine/tcp_state.rs
@@ -4,7 +4,7 @@
 
 // Copyright 2022 Oxide Computer Company
 
-use super::layer::InnerFlowId;
+use super::packet::InnerFlowId;
 use super::tcp::{TcpFlags, TcpMeta, TcpState};
 use core::fmt::{self, Display};
 use cstr_core::CString;

--- a/opte/src/engine/udp.rs
+++ b/opte/src/engine/udp.rs
@@ -246,8 +246,6 @@ impl TryFrom<&LayoutVerified<&[u8], UdpHdrRaw>> for UdpHdr {
     fn try_from(
         raw: &LayoutVerified<&[u8], UdpHdrRaw>,
     ) -> Result<Self, Self::Error> {
-        const UDP_HDR_MIN_SZ: u16 = 8;
-
         let src_port = u16::from_be_bytes(raw.src_port);
 
         if src_port == DYNAMIC_PORT {
@@ -262,7 +260,7 @@ impl TryFrom<&LayoutVerified<&[u8], UdpHdrRaw>> for UdpHdr {
 
         let length = u16::from_be_bytes(raw.length);
 
-        if length < UDP_HDR_MIN_SZ {
+        if length < UdpHdr::SIZE as u16 {
             return Err(UdpHdrError::BadLength { length });
         }
 

--- a/opte/src/lib.rs
+++ b/opte/src/lib.rs
@@ -112,10 +112,10 @@ mod opte_provider {
     ) {
     }
     fn layer__process__return(
-        dir: Direction,
-        port: &str,
+        dir_port: (Direction, &str),
         name: &str,
-        flow: &str,
+        flow_before: &str,
+        flow_after: &str,
         res: &str,
     ) {
     }
@@ -127,14 +127,17 @@ mod opte_provider {
         pkt: &illumos_sys_hdrs::uintptr_t,
     ) {
     }
+    // XXX USDT (at least on mac/ARM) only allows up to 6 args.
+    // Furthemore, there is a bug on mac/ARM that causes arg5 to
+    // always come back NULL -- effectively limiting us to 5 args. For
+    // this reason we merge some of the arguments.
+    //
+    // https://github.com/oxidecomputer/usdt/issues/62
     pub fn port__process__return(
-        dir: Direction,
-        name: &str,
-        ifid: &str,
+        dir_port: (Direction, &str),
+        ifid_before_after: (&str, &str),
         epoch: u64,
         pkt: &illumos_sys_hdrs::uintptr_t,
-        // XXX there appears to be a bug for usdt on ARM macOS where
-        // arg5 always comes back NULL.
         res: &str,
     ) {
     }

--- a/opteadm/Cargo.lock
+++ b/opteadm/Cargo.lock
@@ -152,6 +152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +353,7 @@ version = "0.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "cstr_core",
+ "dyn-clone",
  "heapless",
  "illumos-sys-hdrs",
  "kstat-macro",

--- a/opteadm/src/main.rs
+++ b/opteadm/src/main.rs
@@ -18,7 +18,7 @@ use opte::api::{
 };
 use opte::engine::flow_table::FlowEntryDump;
 use opte::engine::ioctl as api;
-use opte::engine::layer::InnerFlowId;
+use opte::engine::packet::InnerFlowId;
 use opte::engine::rule::RuleDump;
 use opteadm::OpteAdm;
 use oxide_vpc::api::{
@@ -541,7 +541,7 @@ fn main() {
                     vpc_subnet,
                     private_ip: private_ip.into(),
                     gateway_ip: gateway_ip.into(),
-                    snat_cfg: snat,
+                    snat,
                     external_ips: external_ipv4,
                 }),
                 private_mac,

--- a/oxide-vpc/Cargo.lock
+++ b/oxide-vpc/Cargo.lock
@@ -217,6 +217,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +375,7 @@ version = "0.1.0"
 dependencies = [
  "cfg-if 0.1.10",
  "cstr_core",
+ "dyn-clone",
  "heapless",
  "illumos-sys-hdrs",
  "kstat-macro",

--- a/oxide-vpc/Cargo.toml
+++ b/oxide-vpc/Cargo.toml
@@ -14,6 +14,16 @@ api = ["opte/api"]
 engine = ["api", "opte/engine"]
 kernel = ["opte/kernel"]
 std = ["opte/std"]
+#
+# XXX: This is a hack in order for integration tests to make use of
+# test-only methods.
+#
+# For a method/function to be used by both unit and integration tests
+# mark them with the following:
+#
+# #[cfg(any(feature = "test-help", test))]
+#
+test-help = []
 usdt = ["opte/usdt", "dep:usdt"]
 
 [dependencies]
@@ -61,5 +71,5 @@ ctor = "0.1.22"
 #
 # https://github.com/rust-lang/cargo/issues/2911
 #
-oxide-vpc = { path = ".", features = ["engine"] }
+oxide-vpc = { path = ".", features = ["engine", "test-help"] }
 pcap-parser = { version = "0.11.1", features = ["serialize"] }

--- a/oxide-vpc/src/engine/firewall.rs
+++ b/oxide-vpc/src/engine/firewall.rs
@@ -25,7 +25,8 @@ use crate::api::{
     SetFwRulesReq,
 };
 use opte::api::{Direction, OpteError};
-use opte::engine::layer::{InnerFlowId, Layer};
+use opte::engine::layer::Layer;
+use opte::engine::packet::{InnerFlowId, Packet, Parsed};
 use opte::engine::port::meta::ActionMeta;
 use opte::engine::port::{Port, PortBuilder, Pos};
 use opte::engine::rule::{
@@ -133,6 +134,7 @@ impl StatefulAction for FwStatefulAction {
     fn gen_desc(
         &self,
         _flow_id: &InnerFlowId,
+        _pkt: &Packet<Parsed>,
         _meta: &mut ActionMeta,
     ) -> rule::GenDescResult {
         Ok(AllowOrDeny::Allow(Arc::new(IdentityDesc::new(self.name.clone()))))

--- a/oxide-vpc/src/engine/nat.rs
+++ b/oxide-vpc/src/engine/nat.rs
@@ -27,7 +27,7 @@ use opte::engine::port::{PortBuilder, Pos};
 use opte::engine::rule::{
     Action, EtherTypeMatch, Ipv4AddrMatch, Ipv6AddrMatch, Predicate, Rule,
 };
-use opte::engine::snat::{NatPool, SNat};
+use opte::engine::snat::{NatPool, SNat, SNat6};
 
 pub const NAT_LAYER_NAME: &'static str = "nat";
 const ONE_TO_ONE_NAT_PRIORITY: u16 = 10;
@@ -81,14 +81,14 @@ fn setup_ipv4_nat(
         layer.add_rule(Direction::In, in_nat.finalize());
     }
 
-    if let Some(snat_cfg) = &ip_cfg.snat_cfg {
+    if let Some(snat_cfg) = &ip_cfg.snat {
         let pool = NatPool::new();
         pool.add(
             ip_cfg.private_ip,
             snat_cfg.external_ip,
             snat_cfg.ports.clone(),
         );
-        let snat = SNat::new(ip_cfg.private_ip.into(), Arc::new(pool));
+        let snat = SNat::new(ip_cfg.private_ip, Arc::new(pool), phys_gw_mac);
         let mut rule =
             Rule::new(SNAT_PRIORITY, Action::Stateful(Arc::new(snat)));
 
@@ -137,14 +137,14 @@ fn setup_ipv6_nat(
         layer.add_rule(Direction::In, in_nat.finalize());
     }
 
-    if let Some(ref snat_cfg) = ip_cfg.snat_cfg {
+    if let Some(ref snat_cfg) = ip_cfg.snat {
         let pool = NatPool::new();
         pool.add(
             ip_cfg.private_ip,
             snat_cfg.external_ip,
             snat_cfg.ports.clone(),
         );
-        let snat = SNat::new(ip_cfg.private_ip.into(), Arc::new(pool));
+        let snat = SNat6::new(ip_cfg.private_ip, Arc::new(pool), phys_gw_mac);
         let mut rule =
             Rule::new(SNAT_PRIORITY, Action::Stateful(Arc::new(snat)));
 

--- a/oxide-vpc/src/engine/overlay.rs
+++ b/oxide-vpc/src/engine/overlay.rs
@@ -34,7 +34,8 @@ use opte::engine::geneve::{GeneveMeta, Vni, GENEVE_PORT};
 use opte::engine::headers::{HeaderAction, IpAddr};
 use opte::engine::ip4::Protocol;
 use opte::engine::ip6::{Ipv6Addr, Ipv6Meta};
-use opte::engine::layer::{InnerFlowId, Layer};
+use opte::engine::layer::Layer;
+use opte::engine::packet::InnerFlowId;
 use opte::engine::port::meta::{ActionMeta, ActionMetaValue};
 use opte::engine::port::{PortBuilder, Pos};
 use opte::engine::rule::{

--- a/oxide-vpc/src/engine/router.rs
+++ b/oxide-vpc/src/engine/router.rs
@@ -28,7 +28,8 @@ use opte::api::{
     Direction, Ipv4Addr, Ipv4Cidr, Ipv6Addr, Ipv6Cidr, NoResp, OpteError,
 };
 use opte::engine::headers::{IpAddr, IpCidr};
-use opte::engine::layer::{InnerFlowId, Layer};
+use opte::engine::layer::Layer;
+use opte::engine::packet::InnerFlowId;
 use opte::engine::port::meta::{ActionMeta, ActionMetaValue};
 use opte::engine::port::{Port, PortBuilder, Pos};
 use opte::engine::rule::{

--- a/xde/Cargo.lock
+++ b/xde/Cargo.lock
@@ -73,6 +73,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7313c0d620d0cb4dbd9d019e461a4beb501071ff46ec0ab933efb4daa76d73e3"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +163,7 @@ version = "0.1.0"
 dependencies = [
  "cfg-if",
  "cstr_core",
+ "dyn-clone",
  "heapless",
  "illumos-sys-hdrs",
  "kstat-macro",

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -1171,8 +1171,7 @@ unsafe extern "C" fn xde_mc_unicst(
 fn guest_loopback_probe(pkt: &Packet<Parsed>, src: &XdeDev, dst: &XdeDev) {
     use opte::engine::rule::flow_id_sdt_arg;
 
-    let fid = opte::engine::layer::InnerFlowId::from(pkt.meta());
-    let fid_arg = flow_id_sdt_arg::from(&fid);
+    let fid_arg = flow_id_sdt_arg::from(pkt.flow());
 
     unsafe {
         __dtrace_probe_guest__loopback(


### PR DESCRIPTION
In order for ICMP Echo to work over SNAT, we must map the Echo Identifier into the SNAT port space. There are two ways to do this:

1. Map ICMP message bodies into a pseudo-ULP header and allow them to be acted upon just like other header data.

2. Add support for body transforms (like VFP's "action context").

OPTE used to implement option (1), but there were some issues in the past that caused me to remove that behavior. It might be good to reintroduce that behavior at some point, but instead I opted to take option (2). We might eventually need body transforms for other reasons, so I thought it would be good to at least see what it might look like. This implementation of body transforms is simple: it only allows transforming of bytes, it doesn't allow a change in body length (removing or adding bytes). So while this works for the purposes of implementing ICMP/SNAT rewrite, it may need some further development for future, more advanced body transformations.

This work only supports outbound ICMP Echo (and associated inbound reply). There is more ICMP support we need to figure out:

- A DU reply to an ICMP Echo over SNAT. This should be easy enough to deal with in the body transform.

- A DU reply to a TCP/UDP flow over SNAT or NAT. A harder problem to solves is dealing with DU replies (from some external network) to TCP/UDP traffic. The inbound flow id will be for ICMP and therefore will match nothing. We could allow all inbound ICMP DU traffic, but the user may explicitly block that traffic in the firewall, and we need to honor that. Rather, we need to be smart enough to know there is a stateful firewall flow and that we need to allow inbound ICMP DU for active flows. It could be that we reach into the ICMP DU body and use that data to build its flow id, as in some sense **that is** its real flow id -- it's a response to **that** flow.

Other Work
----------

- Regression in flow id handling causes it to be immutable (#252)

- Added ability to snapshot (clone) kstats. This is useful for verifying stat values in integration tests.