### PR TITLE
Implements core NDP support

### DIFF
--- a/opte-api/src/lib.rs
+++ b/opte-api/src/lib.rs
@@ -34,12 +34,14 @@ pub mod cmd;
 pub mod encap;
 pub mod ip;
 pub mod mac;
+pub mod ndp;
 pub mod ulp;
 
 pub use cmd::*;
 pub use encap::*;
 pub use ip::*;
 pub use mac::*;
+pub use ndp::*;
 pub use ulp::*;
 
 /// The overall version of the API. Anytime an API is added, removed,
@@ -50,7 +52,7 @@ pub use ulp::*;
 ///
 /// We rely on CI and the check-api-version.sh script to verify that
 /// this number is incremented anytime the oxide-api code changes.
-pub const API_VERSION: u64 = 12;
+pub const API_VERSION: u64 = 13;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Direction {

--- a/opte-api/src/ndp.rs
+++ b/opte-api/src/ndp.rs
@@ -1,0 +1,125 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Types for working with the IPv6 Neighbor Discovery Protocol
+
+use super::Ipv6Addr;
+use super::MacAddr;
+use core::fmt::{self, Debug, Display};
+
+/// A Neighbor Discovery Protocol Router Advertisement, generated in response to
+/// a Router Solicitation.
+#[derive(Clone, Copy, Debug)]
+pub struct RouterAdvertisement {
+    /// The expected MAC address of the client whose Router Solicitations we
+    /// respond to.
+    pub src_mac: MacAddr,
+
+    /// The MAC address advertised by the router.
+    pub mac: MacAddr,
+
+    // The IPv6 address advertised by the router, which is the EUI-64 transform
+    // of the router MAC address.
+    ip: Ipv6Addr,
+
+    /// Managed address configuration, indicating that the peer can use DHCPv6
+    /// to acquire an IPv6 address.
+    pub managed_cfg: bool,
+}
+
+impl RouterAdvertisement {
+    /// Create new `RouterAdvertisement`.
+    ///
+    /// The `src_mac` is the expected source MAC address a Router Solicitation
+    /// should come from. There are no restrictions on the source IP address,
+    /// other than that it be link-local, in `fe80::/10`.
+    ///
+    /// `mac` is the MAC address of the router, to which Solicitations are
+    /// expected to be addressed, and from which Advertisements are sent. The
+    /// source IPv6 address of the Advertisement is derived from this, using the
+    /// EUI-64 transform.
+    ///
+    /// `managed_cfg` is set to `true` to indicate that the host can get further
+    /// configuration from a DHCPv6 server running on the network.
+    pub fn new(src_mac: MacAddr, mac: MacAddr, managed_cfg: bool) -> Self {
+        let ip = Ipv6Addr::from_eui64(&mac);
+        Self { src_mac, mac, ip, managed_cfg }
+    }
+
+    /// Return the IPv6 address the router sends advertisements from.
+    pub fn ip(&self) -> &Ipv6Addr {
+        &self.ip
+    }
+}
+
+impl Display for RouterAdvertisement {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "NDP RA IPv6={} MAC={}", self.ip, self.mac)
+    }
+}
+
+/// A Neighbor Discovery Protocol Neighbor Advertisement, generated in response to
+/// a Neighbor Solicitation.
+#[derive(Clone, Copy, Debug)]
+pub struct NeighborAdvertisement {
+    /// The expected MAC address of the client whose Neighbor Solicitations we
+    /// respond to.
+    pub src_mac: MacAddr,
+
+    /// The MAC address advertised by the neighbor.
+    pub mac: MacAddr,
+
+    // The advertised IPv6 address of the neighbor, which is the EUI-64
+    // transform of the source MAC address, in `mac`.
+    ip: Ipv6Addr,
+
+    /// If true, advertise that this neighbor is a router.
+    pub is_router: bool,
+
+    /// If true, respond to Neighbor Solicitations sent from the unspecified
+    /// address `::`, in addition to those from a link-local address
+    /// `fe80::/10`.
+    pub allow_unspec: bool,
+}
+
+impl NeighborAdvertisement {
+    /// Create new `NeighborAdvertisement`.
+    ///
+    /// The `src_mac` is the expected source MAC address a Neighbor Solicitation
+    /// should come from. There are no restrictions on the source IP address,
+    /// other than that it be link-local, in `fe80::/10`.
+    ///
+    /// `mac` is the MAC address of the neighbor, to which Solicitations are
+    /// expected to be addressed, and from which Advertisements are sent. The
+    /// source IPv6 address of the Advertisement is derived from this, using the
+    /// EUI-64 transform.
+    ///
+    /// `is_router` is `true` if the advert should be marked as coming from a
+    /// router.
+    ///
+    /// `allow_unspec` is `true` if the advertisement is generated in response
+    /// to Neigbor Solicitations from the unspecified address.
+    pub fn new(
+        src_mac: MacAddr,
+        mac: MacAddr,
+        is_router: bool,
+        allow_unspec: bool,
+    ) -> Self {
+        let ip = Ipv6Addr::from_eui64(&mac);
+        Self { src_mac, mac, ip, is_router, allow_unspec }
+    }
+
+    /// Return the IPv6 address the neighbor sends advertisements from.
+    pub fn ip(&self) -> &Ipv6Addr {
+        &self.ip
+    }
+}
+
+impl Display for NeighborAdvertisement {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "NDP NA IPv6={} MAC={}", self.ip, self.mac)
+    }
+}

--- a/opte/src/engine/icmpv6.rs
+++ b/opte/src/engine/icmpv6.rs
@@ -15,18 +15,26 @@ use super::rule::{
     HairpinAction, IpProtoMatch, Ipv6AddrMatch, Predicate,
 };
 use core::fmt::{self, Display};
-pub use opte_api::ip::{Icmpv6EchoReply, Protocol};
+pub use opte_api::ip::Ipv6Cidr;
+pub use opte_api::ip::{Icmpv6EchoReply, Ipv6Addr, Protocol};
+use opte_api::mac::MacAddr;
+pub use opte_api::ndp::NeighborAdvertisement;
+pub use opte_api::ndp::RouterAdvertisement;
 use serde::{Deserialize, Serialize};
 use smoltcp::phy::{Checksum, ChecksumCapabilities as Csum};
+use smoltcp::wire::NdiscNeighborFlags;
+use smoltcp::wire::RawHardwareAddress;
 use smoltcp::wire::{
-    Icmpv6Message, Icmpv6Packet, Icmpv6Repr, IpAddress, Ipv6Address,
+    Icmpv6Message, Icmpv6Packet, Icmpv6Repr, IpAddress, Ipv6Address, NdiscRepr,
 };
 
 cfg_if! {
     if #[cfg(all(not(feature = "std"), not(test)))] {
         use alloc::vec::Vec;
+        use alloc::string::String;
     } else {
         use std::vec::Vec;
+        use std::string::String;
     }
 }
 
@@ -160,6 +168,422 @@ impl HairpinAction for Icmpv6EchoReply {
         let eth = EtherHdr::from(&EtherMeta {
             dst: self.src_mac.into(),
             src: self.dst_mac.into(),
+            ether_type: ether::ETHER_TYPE_IPV6,
+        });
+
+        let mut pkt_bytes =
+            Vec::with_capacity(EtherHdr::SIZE + Ipv6Hdr::SIZE + reply_len);
+        pkt_bytes.extend_from_slice(&eth.as_bytes());
+        pkt_bytes.extend_from_slice(&ip.as_bytes());
+        pkt_bytes.extend_from_slice(&ulp_body);
+        Ok(AllowOrDeny::Allow(Packet::copy(&pkt_bytes)))
+    }
+}
+
+impl HairpinAction for RouterAdvertisement {
+    fn implicit_preds(&self) -> (Vec<Predicate>, Vec<DataPredicate>) {
+        const ALL_ROUTERS_MAC: MacAddr =
+            Ipv6Addr::ALL_ROUTERS.unchecked_multicast_mac();
+        let hdr_preds = vec![
+            // We expect that the source MAC is the MAC provided to the client.
+            Predicate::InnerEtherSrc(vec![EtherAddrMatch::Exact(
+                self.src_mac.into(),
+            )]),
+            // It's directed to the multicast MAC address derived from the
+            // All-Routers multicast IPv6 address.
+            Predicate::InnerEtherDst(vec![EtherAddrMatch::Exact(
+                ALL_ROUTERS_MAC,
+            )]),
+            // The source IP must be a link-local IPv6 address. We make no
+            // assumptions about its format otherwise.
+            Predicate::InnerSrcIp6(vec![Ipv6AddrMatch::Prefix(
+                Ipv6Cidr::LINK_LOCAL,
+            )]),
+            // And the packet must be directed to the All-Routers IPv6 multicast
+            // address.
+            Predicate::InnerDstIp6(vec![Ipv6AddrMatch::Exact(
+                Ipv6Addr::ALL_ROUTERS,
+            )]),
+            // NDP runs over ICMPv6.
+            Predicate::InnerIpProto(vec![IpProtoMatch::Exact(
+                Protocol::ICMPv6,
+            )]),
+        ];
+
+        let data_preds = vec![
+            // This must be a Router Solicitation message.
+            DataPredicate::Icmpv6MsgType(MessageType::from(
+                Icmpv6Message::RouterSolicit,
+            )),
+        ];
+
+        (hdr_preds, data_preds)
+    }
+
+    fn gen_packet(
+        &self,
+        meta: &PacketMeta,
+        rdr: &mut PacketReader<Parsed, ()>,
+    ) -> GenPacketResult {
+        use smoltcp::time::Duration;
+        use smoltcp::wire::NdiscRouterFlags;
+
+        // Collect the src / dst IP addresses, which are needed to emit the
+        // resulting ICMPv6 packet using `smoltcp`.
+        let (src_ip, dst_ip) = if let Some(metadata) = meta.inner_ip6() {
+            (
+                IpAddress::Ipv6(Ipv6Address(metadata.src.bytes())),
+                IpAddress::Ipv6(Ipv6Address(metadata.dst.bytes())),
+            )
+        } else {
+            // Getting here implies the predicate matched, but that the
+            // extracted metadata indicates this isn't an IPv6 packet. That
+            // should be impossible, but we avoid panicking given the kernel
+            // context.
+            return Err(GenErr::Unexpected(format!(
+                "Expected IPv6 packet metadata, but found: {:?}",
+                meta
+            )));
+        };
+        let body = rdr.copy_remaining();
+        let src_pkt = Icmpv6Packet::new_checked(&body)?;
+        let src_ndisc =
+            Icmpv6Repr::parse(&src_ip, &dst_ip, &src_pkt, &Csum::ignored())?;
+
+        if !matches!(
+            src_ndisc,
+            Icmpv6Repr::Ndisc(NdiscRepr::RouterSolicit { .. })
+        ) {
+            // We should never hit this case because the predicate
+            // should have verified that we are dealing with an
+            // Router Solicitation. However, programming error could
+            // cause this to happen -- let's not take any chances.
+            return Err(GenErr::Unexpected(format!(
+                "expected a NDP Router Solicitation, got {} {}",
+                src_pkt.msg_type(),
+                src_pkt.msg_code()
+            )));
+        }
+
+        // RFC 4861 6.1.1 describes a number of validation steps routers are
+        // required to perform.
+        if src_pkt.msg_code() != 0 {
+            return Ok(AllowOrDeny::Deny);
+        }
+        if !src_pkt.verify_checksum(&src_ip, &dst_ip) {
+            return Ok(AllowOrDeny::Deny);
+        }
+        // NOTE: The router is required to check that there is no Link-Layer
+        // Address Option, if the solicitation is sent from the unspecified
+        // address. However, from the associated predicates, we know that this
+        // is only called if the source IPv6 address is a link-local address,
+        // and thus _not_ UNSPEC, so we skip that checking here.
+        //
+        // TODO-completeness: Check IP Hop Limit and ICMP length / option length
+
+        let flags = if self.managed_cfg {
+            NdiscRouterFlags::MANAGED
+        } else {
+            NdiscRouterFlags::empty()
+        };
+        const MAX_ROUTER_ADV_LIFETIME: Duration = Duration::from_secs(9_000);
+        const ZERO_DURATION: Duration = Duration::from_millis(0);
+        let advert = NdiscRepr::RouterAdvert {
+            hop_limit: u8::MAX,
+            flags,
+            // Use the maximum advertised lifetime as a default router.
+            router_lifetime: MAX_ROUTER_ADV_LIFETIME,
+            // Do not specify the reachable or retrans time. Clients will decide
+            // that for themselves at this point.
+            reachable_time: ZERO_DURATION,
+            retrans_time: ZERO_DURATION,
+            lladdr: Some(RawHardwareAddress::from_bytes(&self.mac.bytes())),
+            // TODO-completeness: Don't hardcode this.
+            //
+            // See https://github.com/oxidecomputer/opte/issues/263.
+            mtu: Some(1500),
+            // Indicate that there are no addresses considered on-link, other
+            // than the router's advertised link-local address. This will
+            // require all traffic from the client to go through OPTE.
+            prefix_info: None,
+        };
+        let reply = Icmpv6Repr::Ndisc(advert);
+
+        let reply_len = reply.buffer_len();
+        let mut ulp_body = vec![0u8; reply_len];
+        let mut advert_reply = Icmpv6Packet::new_unchecked(&mut ulp_body);
+        let mut csum = Csum::ignored();
+        csum.icmpv6 = Checksum::Tx;
+        reply.emit(
+            &IpAddress::Ipv6((*self.ip()).into()),
+            &src_ip,
+            &mut advert_reply,
+            &mut csum,
+        );
+
+        let mut ip = Ipv6Hdr::from(&Ipv6Meta {
+            src: *self.ip(),
+            // Safety: We match on this being Some(_) above, so unwrap is safe.
+            dst: meta.inner_ip6().unwrap().src,
+            proto: Protocol::ICMPv6,
+        });
+
+        // There are no extension headers, so the ULP is the only content.
+        ip.set_pay_len(reply_len as u16);
+
+        // The Ethernet frame should come from OPTE's virtual gateway MAC, and
+        // be destined for the client which sent us the packet.
+        let eth = EtherHdr::from(&EtherMeta {
+            dst: self.src_mac.into(),
+            src: self.mac.into(),
+            ether_type: ether::ETHER_TYPE_IPV6,
+        });
+
+        let mut pkt_bytes =
+            Vec::with_capacity(EtherHdr::SIZE + Ipv6Hdr::SIZE + reply_len);
+        pkt_bytes.extend_from_slice(&eth.as_bytes());
+        pkt_bytes.extend_from_slice(&ip.as_bytes());
+        pkt_bytes.extend_from_slice(&ulp_body);
+        Ok(AllowOrDeny::Allow(Packet::copy(&pkt_bytes)))
+    }
+}
+
+// Check if an ICMPv6 message is a valid Neighbor Solicitation
+//
+// See https://www.rfc-editor.org/rfc/rfc4861.html#section-7.1.1 for details on
+// the validations performed.
+//
+// Return the target address from the Neighbor Solicitation.
+fn validate_neighbor_solicitation(
+    rdr: &mut PacketReader<Parsed, ()>,
+    metadata: &Ipv6Meta,
+) -> Result<Ipv6Addr, GenErr> {
+    // First, check if this is in fact a NS message.
+    let smol_src = IpAddress::Ipv6(metadata.src.into());
+    let smol_dst = IpAddress::Ipv6(metadata.dst.into());
+    let body = rdr.copy_remaining();
+    let src_pkt = Icmpv6Packet::new_checked(&body)?;
+    let icmp =
+        Icmpv6Repr::parse(&smol_src, &smol_dst, &src_pkt, &Csum::ignored())?;
+
+    let (target_addr, has_ll_option) = match icmp {
+        Icmpv6Repr::Ndisc(NdiscRepr::NeighborSolicit {
+            lladdr,
+            target_addr,
+        }) => (Ipv6Addr::from(target_addr), lladdr.is_some()),
+        _ => {
+            // We should never hit this case because the predicate
+            // should have verified that we are dealing with a
+            // Neighbor Solicitation. However, programming error could
+            // cause this to happen -- let's not take any chances.
+            return Err(GenErr::Unexpected(format!(
+                "expected a NDP Neighbor Solicitation, got {} {}",
+                src_pkt.msg_type(),
+                src_pkt.msg_code()
+            )));
+        }
+    };
+
+    // The target cannot be a multicast address.
+    if target_addr.is_multicast() {
+        return Err(GenErr::Unexpected(String::from(
+            "Received NS with multicast target address.",
+        )));
+    }
+
+    // NS is only allowed from the unspecified address if the destination is a
+    // solicited-node multicast address.
+    if metadata.src == Ipv6Addr::ANY_ADDR
+        && !metadata.dst.is_solicited_node_multicast()
+    {
+        return Err(GenErr::Unexpected(String::from(
+            "Received NS from UNSPEC, but destination is not the solicited \
+            node multicast address.",
+        )));
+    }
+
+    // Cannot contain Link-Layer address option if from the unspecified address.
+    if metadata.src == Ipv6Addr::ANY_ADDR && has_ll_option {
+        return Err(GenErr::Unexpected(String::from(
+            "Received NS from UNSPEC, but message contains the \
+            Link-Layer Address option.",
+        )));
+    }
+
+    Ok(target_addr)
+}
+
+// Return the destination IP and a Neighbor Advertisement, based on the data
+// provided in a Neighbor Solicitation. If we should not generate an NA in
+// response to the NS, then `None` is returned.
+//
+// See https://www.rfc-editor.org/rfc/rfc4861.html#section-7.2.4 for details on
+// the validation and construction performed here.
+fn construct_neighbor_advert<'a>(
+    na: &'a NeighborAdvertisement,
+    target_addr: &'a Ipv6Addr,
+    src_ip: &'a Ipv6Addr,
+) -> Option<(Ipv6Addr, NdiscRepr<'a>)> {
+    // Drop the packet if the target address is not actually our own address.
+    if target_addr != na.ip() {
+        return None;
+    }
+
+    // Set the ROUTER flag, if required.
+    //
+    // Note from RFC 4861 Section 7.2.4 paragraph 2, we start with the OVERRIDE
+    // flag set. That says:
+    //
+    // > If the Target Address is either an anycast address or a unicast
+    // > address for which the node is providing proxy service, or the Target
+    // > Link-Layer Address option is not included, the Override flag SHOULD
+    // > be set to zero.  Otherwise, the Override flag SHOULD be set to one.
+    //
+    // We're never proxying or supporting anycast addresses, and we're always
+    // including the Link-Layer address option in the response. So we set
+    // OVERRIDE to 1.
+    let mut flags = NdiscNeighborFlags::OVERRIDE;
+    flags.set(NdiscNeighborFlags::ROUTER, na.is_router);
+
+    // Even though this is NA is in response to an NS, if the source IP is
+    // UNSPEC, we must _not_ set the SOLICITED flag.
+    let src_is_unspec = src_ip == &Ipv6Addr::ANY_ADDR;
+    flags.set(NdiscNeighborFlags::SOLICITED, !src_is_unspec);
+
+    // The destination IP address also depends on the source IP address.
+    //
+    // If the source is UNSPEC, we're required to send this to the all-nodes
+    // multicast group. Otherwise, we must unicast the NA back to the source.
+    let dst_ip = if src_is_unspec { Ipv6Addr::ALL_NODES } else { *src_ip };
+    Some((
+        dst_ip,
+        NdiscRepr::NeighborAdvert {
+            flags,
+            target_addr: Ipv6Address::from(*target_addr),
+            // Always include the Link-Layer address option.
+            lladdr: Some(RawHardwareAddress::from_bytes(&na.mac.bytes())),
+        },
+    ))
+}
+
+impl HairpinAction for NeighborAdvertisement {
+    fn implicit_preds(&self) -> (Vec<Predicate>, Vec<DataPredicate>) {
+        // The source IP must be a link-local IPv6 address, or, if
+        // `allow_unspec` is true, the unspecified address.
+        let source_addrs = if self.allow_unspec {
+            vec![
+                Ipv6AddrMatch::Prefix(Ipv6Cidr::LINK_LOCAL),
+                Ipv6AddrMatch::Exact(Ipv6Addr::ANY_ADDR),
+            ]
+        } else {
+            vec![Ipv6AddrMatch::Prefix(Ipv6Cidr::LINK_LOCAL)]
+        };
+
+        // There are a few MAC addresses we need to support:
+        // - Unicast directly to us
+        // - Multicast to the MAC derived from our solicited-node multicast
+        // group
+        let dest_macs = vec![
+            EtherAddrMatch::Exact(self.mac),
+            EtherAddrMatch::Exact(
+                self.ip().solicited_node_multicast().multicast_mac().unwrap(),
+            ),
+        ];
+
+        // The destination IP address must be either our unicast link-local
+        // address, or its solicited-node multicast group.
+        let dest_addrs = vec![
+            Ipv6AddrMatch::Exact(*self.ip()),
+            Ipv6AddrMatch::Exact(self.ip().solicited_node_multicast()),
+        ];
+
+        let hdr_preds = vec![
+            // We expect that the source MAC is the MAC provided to the client.
+            Predicate::InnerEtherSrc(vec![EtherAddrMatch::Exact(self.src_mac)]),
+            Predicate::InnerEtherDst(dest_macs),
+            Predicate::InnerSrcIp6(source_addrs),
+            Predicate::InnerDstIp6(dest_addrs),
+            // NDP runs over ICMPv6.
+            Predicate::InnerIpProto(vec![IpProtoMatch::Exact(
+                Protocol::ICMPv6,
+            )]),
+        ];
+
+        let data_preds = vec![
+            // This must be an actual Neighbor Solicitation message
+            DataPredicate::Icmpv6MsgType(MessageType::from(
+                Icmpv6Message::NeighborSolicit,
+            )),
+        ];
+
+        (hdr_preds, data_preds)
+    }
+
+    fn gen_packet(
+        &self,
+        meta: &PacketMeta,
+        rdr: &mut PacketReader<Parsed, ()>,
+    ) -> GenPacketResult {
+        // Sanity check that this is actually in IPv6 packet.
+        let metadata = meta.inner_ip6().ok_or_else(|| {
+            // Getting here implies the predicate matched, but that the
+            // extracted metadata indicates this isn't an IPv6 packet. That
+            // should be impossible, but we avoid panicking given the kernel
+            // context.
+            GenErr::Unexpected(format!(
+                "Expected IPv6 packet metadata, but found: {:?}",
+                meta
+            ))
+        })?;
+
+        // Validate the ICMPv6 packet is actually a Neighbor Solicitation, and
+        // that its data is appopriate.
+        let target_addr = validate_neighbor_solicitation(rdr, metadata)?;
+
+        // Build the NA, whose data depends on how we received the packet. If
+        // `None` is returned, the NS is not destined for us, and will be
+        // dropped.
+        let (dst_ip, advert) = match construct_neighbor_advert(
+            self,
+            &target_addr,
+            &metadata.src,
+        ) {
+            Some(data) => data,
+            None => return Ok(AllowOrDeny::Deny),
+        };
+
+        // Construct the actual bytes of the reply packet, and return it.
+        let reply = Icmpv6Repr::Ndisc(advert);
+        let reply_len = reply.buffer_len();
+        let mut ulp_body = vec![0u8; reply_len];
+        let mut advert_reply = Icmpv6Packet::new_unchecked(&mut ulp_body);
+        let mut csum = Csum::ignored();
+        csum.icmpv6 = Checksum::Tx;
+        reply.emit(
+            &IpAddress::Ipv6((*self.ip()).into()),
+            &IpAddress::Ipv6(dst_ip.into()),
+            &mut advert_reply,
+            &mut csum,
+        );
+
+        let mut ip = Ipv6Hdr::from(&Ipv6Meta {
+            src: *self.ip(),
+            dst: dst_ip,
+            proto: Protocol::ICMPv6,
+        });
+
+        // There are no extension headers, so the ULP is the only content.
+        ip.set_pay_len(reply_len as u16);
+
+        // While the frame must always be sent from the gateway, who the frame
+        // is addressed to depends on whether we should multicast the packet.
+        let dst_mac = dst_ip.multicast_mac().unwrap_or(self.src_mac);
+
+        // The Ethernet frame should come from OPTE's virtual gateway MAC, and
+        // be destined for the client which sent us the packet.
+        let eth = EtherHdr::from(&EtherMeta {
+            dst: dst_mac,
+            src: self.mac,
             ether_type: ether::ETHER_TYPE_IPV6,
         });
 

--- a/opte/src/engine/rule.rs
+++ b/opte/src/engine/rule.rs
@@ -310,7 +310,7 @@ impl Display for PortMatch {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Predicate {
     InnerEtherType(Vec<EtherTypeMatch>),
     InnerEtherDst(Vec<EtherAddrMatch>),
@@ -1407,7 +1407,7 @@ impl fmt::Debug for Action {
 }
 
 // TODO Use const generics to make this array?
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct RulePredicates {
     hdr_preds: Vec<Predicate>,
     data_preds: Vec<DataPredicate>,
@@ -1445,14 +1445,14 @@ impl Eq for RulePredicates {}
 
 pub trait RuleState {}
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Ready {
     hdr_preds: Vec<Predicate>,
     data_preds: Vec<DataPredicate>,
 }
 impl RuleState for Ready {}
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Finalized {
     preds: Option<RulePredicates>,
 }

--- a/oxide-vpc/.gitignore
+++ b/oxide-vpc/.gitignore
@@ -1,4 +1,5 @@
 gateway_icmpv[46]_ping.pcap
+gateway_*_advert_reply.pcap
 overlay_guest_to_guest-guest-1.pcap
 overlay_guest_to_guest-guest-2.pcap
 overlay_guest_to_guest-phys-1.pcap

--- a/oxide-vpc/src/engine/icmpv6.rs
+++ b/oxide-vpc/src/engine/icmpv6.rs
@@ -9,41 +9,224 @@
 cfg_if! {
     if #[cfg(all(not(feature = "std"), not(test)))] {
         use alloc::sync::Arc;
+        use alloc::vec::Vec;
     } else {
         use std::sync::Arc;
+        use std::vec::Vec;
     }
 }
 
+use crate::api::Ipv6Cfg;
 use crate::api::VpcCfg;
+use core::num::NonZeroU32;
+use core::result::Result;
+use opte::api::Ipv6Addr;
+use opte::api::Protocol;
 use opte::api::{Direction, OpteError};
+use opte::engine::ether::ETHER_TYPE_IPV6;
 use opte::engine::icmpv6::Icmpv6EchoReply;
+use opte::engine::icmpv6::MessageType;
+use opte::engine::icmpv6::NeighborAdvertisement;
+use opte::engine::icmpv6::RouterAdvertisement;
 use opte::engine::layer::Layer;
 use opte::engine::port::{PortBuilder, Pos};
+use opte::engine::rule::DataPredicate;
+use opte::engine::rule::EtherAddrMatch;
+use opte::engine::rule::EtherTypeMatch;
+use opte::engine::rule::Identity;
+use opte::engine::rule::IpProtoMatch;
+use opte::engine::rule::Ipv6AddrMatch;
+use opte::engine::rule::Predicate;
 use opte::engine::rule::{Action, Rule};
+use smoltcp::wire::Icmpv6Message;
 
 pub fn setup(
     pb: &mut PortBuilder,
     cfg: &VpcCfg,
-    ft_limit: core::num::NonZeroU32,
-) -> core::result::Result<(), OpteError> {
-    // The ICMPv6 layer only contains meaningful actions if the port is
-    // configured to support IPv6.
-    let ip_cfg = match cfg.ipv6_cfg() {
-        None => return Ok(()),
-        Some(cfg) => cfg,
-    };
+    ft_limit: NonZeroU32,
+) -> Result<(), OpteError> {
+    match cfg.ipv6_cfg() {
+        None => drop_all_icmpv6(pb, ft_limit),
+        Some(ip_cfg) => add_icmpv6_rules(pb, cfg, ip_cfg, ft_limit),
+    }
+}
 
-    let reply = Action::Hairpin(Arc::new(Icmpv6EchoReply {
-        // Map an Echo Request from guest (src) -> gateway (dst) to an Echo
-        // Reply from gateway (dst) -> guest (src).
-        src_mac: cfg.private_mac.into(),
-        src_ip: ip_cfg.private_ip,
-        dst_mac: cfg.gateway_mac.into(),
-        dst_ip: ip_cfg.gateway_ip,
-    }));
-    let mut icmp = Layer::new("icmpv6", pb.name(), vec![reply], ft_limit);
+// Explicitly drop any ICMPv6 traffic if the guest is not configured with an
+// IPv6 address.
+fn drop_all_icmpv6(
+    pb: &mut PortBuilder,
+    ft_limit: NonZeroU32,
+) -> Result<(), OpteError> {
+    let mut rule = Rule::new(1, Action::Deny);
+    rule.add_predicate(Predicate::InnerEtherType(vec![EtherTypeMatch::Exact(
+        ETHER_TYPE_IPV6,
+    )]));
+    rule.add_predicate(Predicate::InnerIpProto(vec![IpProtoMatch::Exact(
+        Protocol::ICMPv6,
+    )]));
+    let rule = rule.finalize();
 
-    let rule = Rule::new(1, icmp.action(0).unwrap().clone());
+    let mut icmp = Layer::new("icmpv6", pb.name(), vec![], ft_limit);
+    icmp.add_rule(Direction::In, rule.clone());
+    icmp.add_rule(Direction::Out, rule.clone());
+    pb.add_layer(icmp, Pos::Before("firewall"))
+}
+
+// Add support for ICMPv6:
+//
+// - Respond to echo requests from the guest to the gateway. The source address
+// may be either any link-local address in guest (since we can't know how they
+// generate that) or its assigned VPC-private address. The destination address
+// must be the link-local address we derive for OPTE, from the EUI-64 transform
+// on its MAC address.
+//
+// - Respond to NDP Router Solicitations from the guest to the gateway.
+//
+// - Respond to NDP Neighbor Solicitations from the guest to the gateway. This
+// includes solicitations unicast to the gateway, and also delivered to the
+// solicited-node multicast group.
+//
+// - Drop any other NDP traffic, inbound or outbound.
+//
+// - Pass through any other ICMPv6 traffic.
+fn add_icmpv6_rules(
+    pb: &mut PortBuilder,
+    cfg: &VpcCfg,
+    ip_cfg: &Ipv6Cfg,
+    ft_limit: NonZeroU32,
+) -> Result<(), OpteError> {
+    // We need to hairpin echo requests from either the VPC-private or
+    // link-local address of the guest, to OPTE's link-local.
+    let src_ips = [ip_cfg.private_ip, Ipv6Addr::from_eui64(&cfg.private_mac)];
+    let dst_ip = Ipv6Addr::from_eui64(&cfg.gateway_mac);
+    let n_pings = src_ips.len();
+    let mut actions = Vec::with_capacity(n_pings + 2);
+    for src_ip in src_ips.iter().copied() {
+        let echo = Action::Hairpin(Arc::new(Icmpv6EchoReply {
+            src_mac: cfg.private_mac,
+            src_ip,
+            dst_mac: cfg.gateway_mac,
+            dst_ip,
+        }));
+        actions.push(echo);
+    }
+
+    // Map an NDP Router Solicitation from the guest to a Router Advertisement
+    // from the OPTE virtual gateway's link-local IPv6 address.
+    let router_advert = Action::Hairpin(Arc::new(RouterAdvertisement::new(
+        // From the guest's private MAC.
+        cfg.private_mac,
+        // The MAC from which we respond, i.e., OPTE's MAC.
+        cfg.gateway_mac,
+        // "Managed Configuration", indicating the guest needs to use DHCPv6 to
+        // acquire an IPv6 address.
+        true,
+    )));
+    actions.push(router_advert);
+
+    // Map an NDP Neighbor Solicitation from the guest to a neighbor
+    // advertisement from the OPTE virtual gateway. Note that this is required
+    // per RFC 4861 so that the guest does not mark the neighbor failed.
+    let neighbor_advert =
+        Action::Hairpin(Arc::new(NeighborAdvertisement::new(
+            // From the guest's private MAC.
+            cfg.private_mac,
+            // To OPTE's MAC.
+            cfg.gateway_mac,
+            // Set the ROUTER flag to true.
+            true,
+            // Respond to solicitations from `::`
+            true,
+        )));
+    actions.push(neighbor_advert);
+
+    let n_actions = actions.len();
+    let mut icmp = Layer::new("icmpv6", pb.name(), actions, ft_limit);
+
+    // Add rules for the above actions.
+    for i in 0..n_actions {
+        let priority = u16::try_from(i + 1).unwrap();
+        let rule = Rule::new(priority, icmp.action(i).unwrap().clone());
+        icmp.add_rule(Direction::Out, rule.finalize());
+    }
+
+    // Add a high numeric priority rule to drop any ICMPv6 traffic.
+    let mut rule = Rule::new(u16::MAX, Action::Deny);
+    rule.add_predicate(Predicate::InnerIpProto(vec![IpProtoMatch::Exact(
+        Protocol::ICMPv6,
+    )]));
+    icmp.add_rule(Direction::In, rule.clone().finalize());
     icmp.add_rule(Direction::Out, rule.finalize());
+
+    // And then pass through unchanged any ICMPv6 Echo Request / Reply messages.
+    // These will not be matched by the ping rules above, meaning they're
+    // destined for somewhere else. We can add more exceptions to the Deny above
+    // as needed.
+    let priority = u16::try_from(n_actions + 1).unwrap();
+
+    // Outbound echo messages.
+    let mut rule = Rule::new(
+        priority,
+        Action::Static(Arc::new(Identity::new("allow-outbound-icmpv6-echo"))),
+    );
+    // IPv6 only.
+    rule.add_predicate(Predicate::InnerEtherType(vec![EtherTypeMatch::Exact(
+        ETHER_TYPE_IPV6,
+    )]));
+    // From client MAC.
+    rule.add_predicate(Predicate::InnerEtherSrc(vec![EtherAddrMatch::Exact(
+        cfg.private_mac,
+    )]));
+    // To OPTE MAC.
+    rule.add_predicate(Predicate::InnerEtherDst(vec![EtherAddrMatch::Exact(
+        cfg.gateway_mac,
+    )]));
+    // From client VPC-private IP, link-local cannot be used.
+    rule.add_predicate(Predicate::InnerSrcIp6(vec![Ipv6AddrMatch::Exact(
+        ip_cfg.private_ip,
+    )]));
+    // ICMPv6
+    rule.add_predicate(Predicate::InnerIpProto(vec![IpProtoMatch::Exact(
+        Protocol::ICMPv6,
+    )]));
+    // Supported message types.
+    rule.add_data_predicate(DataPredicate::Icmpv6MsgType(MessageType::from(
+        Icmpv6Message::EchoRequest,
+    )));
+    rule.add_data_predicate(DataPredicate::Icmpv6MsgType(MessageType::from(
+        Icmpv6Message::EchoReply,
+    )));
+    icmp.add_rule(Direction::Out, rule.finalize());
+
+    // Inbound echo mesages.
+    let mut rule = Rule::new(
+        priority,
+        Action::Static(Arc::new(Identity::new("allow-inbound-icmpv6-echo"))),
+    );
+    // IPv6 only.
+    rule.add_predicate(Predicate::InnerEtherType(vec![EtherTypeMatch::Exact(
+        ETHER_TYPE_IPV6,
+    )]));
+    // To client MAC. Note we don't have a predicate on the source MAC.
+    rule.add_predicate(Predicate::InnerEtherDst(vec![EtherAddrMatch::Exact(
+        cfg.private_mac,
+    )]));
+    // To client VPC-private IP, link-local cannot be used.
+    rule.add_predicate(Predicate::InnerDstIp6(vec![Ipv6AddrMatch::Exact(
+        ip_cfg.private_ip,
+    )]));
+    // ICMPv6
+    rule.add_predicate(Predicate::InnerIpProto(vec![IpProtoMatch::Exact(
+        Protocol::ICMPv6,
+    )]));
+    // Supported message types.
+    rule.add_data_predicate(DataPredicate::Icmpv6MsgType(MessageType::from(
+        Icmpv6Message::EchoRequest,
+    )));
+    rule.add_data_predicate(DataPredicate::Icmpv6MsgType(MessageType::from(
+        Icmpv6Message::EchoReply,
+    )));
+    icmp.add_rule(Direction::In, rule.finalize());
+
     pb.add_layer(icmp, Pos::Before("firewall"))
 }


### PR DESCRIPTION
- Adds types for handling expected NDP messages, including Router and Neigbor Solicitations and Advertisements
- Reworks the ICMPv6 layer for `oxide-vpc` to include better Echo support, and adds new NDP handling.