### PR TITLE
Implements basic DHCPv6 support

### DIFF
--- a/dtrace/opte-port-process.d
+++ b/dtrace/opte-port-process.d
@@ -32,7 +32,7 @@ port-process-return {
 		num = 0;
 	}
 
-	this->af = this->flow->af;
+	this->af = this->flow_before->af;
 
 	if (this->af != AF_INET && this->af != AF_INET6) {
 		printf("BAD ADDRESS FAMILY: %d\n", this->af);

--- a/opte-api/src/dhcpv6.rs
+++ b/opte-api/src/dhcpv6.rs
@@ -1,0 +1,117 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Types for working with the DHCPv6
+
+use crate::Ipv6Addr;
+use crate::MacAddr;
+use core::fmt;
+use core::fmt::Display;
+
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::vec::Vec;
+        use alloc::string::String;
+    } else {
+        use std::vec::Vec;
+        use std::string::String;
+    }
+}
+
+/// An action for acting as a DHCPv6 server, leasing IPv6 addresses.
+#[derive(Clone, Debug)]
+pub struct Dhcpv6Action {
+    /// Expected MAC address of the client.
+    pub client_mac: MacAddr,
+
+    /// MAC address we advertise as the DHCP server.
+    pub server_mac: MacAddr,
+
+    /// IPv6 addresses leased to the client.
+    pub addrs: AddressInfo,
+
+    /// DNS servers the client should use.
+    pub dns_servers: Vec<Ipv6Addr>,
+
+    /// SNTP servers the client should use.
+    pub sntp_servers: Vec<Ipv6Addr>,
+}
+
+impl Dhcpv6Action {
+    /// Return an iterator over the actual leased IPv6 addresses.
+    pub fn addresses(&self) -> impl Iterator<Item = Ipv6Addr> + '_ {
+        self.addrs.addrs.iter().map(|lease| lease.addr)
+    }
+}
+
+impl Display for Dhcpv6Action {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let addr_list = self
+            .addresses()
+            .map(|addr| format!("{}", addr))
+            .collect::<Vec<_>>()
+            .join(",");
+        write!(f, "DHCPv6 IA Addrs: [{}]", addr_list)
+    }
+}
+
+/// A single leased IPv6 address, with associated lifetime.
+#[derive(Clone, Copy, Debug)]
+pub struct LeasedAddress {
+    /// The leased address.
+    pub addr: Ipv6Addr,
+
+    // The preferred lifetime for this address.
+    preferred: u32,
+
+    // The maximum valid lifetime for this address.
+    valid: u32,
+}
+
+impl LeasedAddress {
+    /// Construct an address lease with infinite lifetime.
+    pub fn infinite_lease(addr: Ipv6Addr) -> Self {
+        Self { addr, preferred: u32::MAX, valid: u32::MAX }
+    }
+
+    /// Construct a new leased address with checked lifetimes, in seconds.
+    ///
+    /// The preferred lifetime must be no longer than the valid lifetime.
+    pub fn new(
+        addr: Ipv6Addr,
+        preferred: u32,
+        valid: u32,
+    ) -> Result<Self, String> {
+        if valid < preferred {
+            return Err(String::from(
+                "Preferred lifetime must be >= valid lifetime",
+            ));
+        }
+        Ok(Self { addr, preferred, valid })
+    }
+
+    /// Return the valid lifetime, in seconds.
+    pub fn valid(&self) -> u32 {
+        self.valid
+    }
+
+    /// Return the preferred lifetime, in seconds.
+    pub fn preferred(&self) -> u32 {
+        self.preferred
+    }
+}
+
+/// Information about IPv6 addresses leased by OPTE.
+#[derive(Clone, Debug)]
+pub struct AddressInfo {
+    /// The set of addresses OPTE will lease.
+    pub addrs: Vec<LeasedAddress>,
+    /// The time (in seconds) after which the client should renew the lease.
+    ///
+    /// NOTE: This is used as both T1 and T2 in a Non-Temporary Address
+    /// Assignment.
+    pub renew: u32,
+}

--- a/opte-api/src/dhcpv6.rs
+++ b/opte-api/src/dhcpv6.rs
@@ -87,7 +87,7 @@ impl LeasedAddress {
     ) -> Result<Self, String> {
         if valid < preferred {
             return Err(String::from(
-                "Preferred lifetime must be >= valid lifetime",
+                "Preferred lifetime must be <= valid lifetime",
             ));
         }
         Ok(Self { addr, preferred, valid })

--- a/opte-api/src/ip.rs
+++ b/opte-api/src/ip.rs
@@ -5,9 +5,11 @@
 // Copyright 2022 Oxide Computer Company
 
 use super::mac::MacAddr;
+use core::convert::AsRef;
 use core::fmt;
 use core::fmt::Debug;
 use core::fmt::Display;
+use core::ops::Deref;
 use core::result;
 use core::str::FromStr;
 use serde::Deserialize;
@@ -191,7 +193,7 @@ impl SubnetRouterPair {
         bytes[pos] = self.subnet.prefix_len();
         pos += 1;
         let n = self.subnet_encode_len();
-        let subnet_bytes = self.subnet.ip().bytes();
+        let subnet_bytes = &self.subnet.ip();
         for i in 0..n {
             bytes[pos] = subnet_bytes[i as usize];
             pos += 1;
@@ -418,7 +420,7 @@ impl From<smoltcp::wire::Ipv4Address> for Ipv4Addr {
 
 impl From<Ipv4Addr> for smoltcp::wire::Ipv4Address {
     fn from(ip: Ipv4Addr) -> Self {
-        Self::from_bytes(&ip.bytes())
+        Self::from_bytes(&ip)
     }
 }
 
@@ -475,6 +477,19 @@ impl Display for Ipv4Addr {
 impl Debug for Ipv4Addr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Ipv4Addr {{ inner: {} }}", self)
+    }
+}
+
+impl AsRef<[u8]> for Ipv4Addr {
+    fn as_ref(&self) -> &[u8] {
+        &self.inner
+    }
+}
+
+impl Deref for Ipv4Addr {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 
@@ -647,7 +662,7 @@ impl From<smoltcp::wire::Ipv6Address> for Ipv6Addr {
 impl From<Ipv6Addr> for smoltcp::wire::Ipv6Address {
     fn from(ip: Ipv6Addr) -> Self {
         // Safety: This panics, but we know bytes is exactly 16 octets.
-        Self::from_bytes(&ip.bytes())
+        Self::from_bytes(&ip)
     }
 }
 
@@ -684,6 +699,19 @@ impl FromStr for Ipv6Addr {
             .parse::<smoltcp::wire::Ipv6Address>()
             .map_err(|_| String::from("Invalid IPv6 address"))?;
         Ok(ip.into())
+    }
+}
+
+impl AsRef<[u8]> for Ipv6Addr {
+    fn as_ref(&self) -> &[u8] {
+        &self.inner
+    }
+}
+
+impl Deref for Ipv6Addr {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 

--- a/opte-api/src/lib.rs
+++ b/opte-api/src/lib.rs
@@ -33,6 +33,7 @@ cfg_if! {
 }
 
 pub mod cmd;
+pub mod dhcpv6;
 pub mod encap;
 pub mod ip;
 pub mod mac;
@@ -40,6 +41,7 @@ pub mod ndp;
 pub mod ulp;
 
 pub use cmd::*;
+pub use dhcpv6::*;
 pub use encap::*;
 pub use ip::*;
 pub use mac::*;
@@ -54,7 +56,7 @@ pub use ulp::*;
 ///
 /// We rely on CI and the check-api-version.sh script to verify that
 /// this number is incremented anytime the oxide-api code changes.
-pub const API_VERSION: u64 = 15;
+pub const API_VERSION: u64 = 16;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Direction {

--- a/opte-api/src/mac.rs
+++ b/opte-api/src/mac.rs
@@ -4,9 +4,11 @@
 
 // Copyright 2022 Oxide Computer Company
 
+use core::convert::AsRef;
 use core::fmt;
 use core::fmt::Debug;
 use core::fmt::Display;
+use core::ops::Deref;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -57,6 +59,19 @@ impl From<[u8; 6]> for MacAddr {
 impl From<&[u8; 6]> for MacAddr {
     fn from(bytes: &[u8; 6]) -> Self {
         Self { inner: bytes.clone() }
+    }
+}
+
+impl AsRef<[u8]> for MacAddr {
+    fn as_ref(&self) -> &[u8] {
+        &self.inner
+    }
+}
+
+impl Deref for MacAddr {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 

--- a/opte/src/engine/checksum.rs
+++ b/opte/src/engine/checksum.rs
@@ -59,30 +59,8 @@ impl Checksum {
             self.inner = (self.inner >> 16) + (self.inner & 0xFFFF);
         }
 
-        let sum = (self.inner & 0xFFFF) as u16;
-        if sum == 0 {
-            [0xFF, 0xFF]
-        } else {
-            sum.to_ne_bytes()
-        }
+        ((self.inner & 0xFFFF) as u16).to_ne_bytes()
     }
-}
-
-// Small test to ensure we return all ones when the computed checksum is
-// actually zero.
-//
-// The values of 0 and all ones (0xFFFF) are equivalent in one's-complement
-// arithmetic. The UDP specification indicates that the former of these two is
-// reserved for cases where the checksum is either not computed or irrelevant.
-// If the _computed_ checksum happens to be all zeros, we should instead
-// transmit all ones.
-//
-// See https://www.rfc-editor.org/rfc/rfc768.html.
-#[cfg(test)]
-#[test]
-fn test_zero_computed_cksum_is_all_ones() {
-    const BUF: [u8; 4] = [0u8; 4];
-    assert_eq!(Checksum::compute(&BUF).finalize(), [0xFF, 0xFF]);
 }
 
 impl From<HeaderChecksum> for Checksum {

--- a/opte/src/engine/dhcpv6/mod.rs
+++ b/opte/src/engine/dhcpv6/mod.rs
@@ -1,0 +1,295 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Core implementation of DHCPv6 protocol.
+//!
+//! RFC 8415 is the main RFC describing the protocol and its options. Other
+//! useful RFCs are 3646, which describes how DNS servers are transmitted in
+//! DHCPv6, and 4075, which covers SNTP servers.
+//!
+//! DHCPv6 is conceptually simple: clients request some configuration data from
+//! servers. The devil is in the details though, and there are a lot of them for
+//! DHCPv6.
+//!
+//! Transport
+//! ---------
+//!
+//! DHCPv6 runs over UDP. Servers listen on well-known multicast addresses,
+//! `ff02::1:2` and `ff05::1:3`, at port 547. Clients send messages from port
+//! 546.
+//!
+//! Message types
+//! -------------
+//!
+//! There are a lot of message types in DHCPv6, which can be used to request
+//! configuration data, renew that data, inform clients of changes, and a lot
+//! more. These are described in detail in RFC 8415 section 7.3, with the full
+//! list available
+//! [here](https://www.iana.org/assignments/dhcpv6-parameters/dhcpv6-parameters.xhtml#dhcpv6-parameters-1).
+//!
+//! The most important options for us are:
+//!
+//! - Solicit: Used by clients to discover servers.
+//! - Advertise: Used by servers to announce themselves to clients.
+//! - Request: Request specific kinds of data from servers.
+//! - Reply: Send specific kinds of data to clients.
+//! - Renew: Sent by clients to renew leases for addresses.
+//!
+//! Options
+//! -------
+//!
+//! Most important data in DHCPv6 is sent in Options. These are just type- and
+//! length-delimited bytes, where the type determines the interpretation of
+//! those bytes. There are a huge number of these, but as with message types,
+//! we're mostly concerned with a small subset:
+//!
+//! - Client ID: A unique identifier for a client.
+//! - Server ID: A unique identifier for a server.
+//! - Non-Temporary Address: A permanent set of one or more IPv6 addresses.
+//! - Temporary Address: A temporary set of one or more IPv6 addresses.
+//! - IA Address: A single IPv6 address, with its lifetimes.
+//! - Option Request: A list of Option codes for requested options.
+//! - Elapsed Time: The duration a client has been trying to talk to the server.
+//! - Rapid Commit: An option that tells the server to commit data to a client,
+//! without waiting for a second ACK sequence of messages.
+//! - DNS Servers: A list of IPv6 addresses for DNS servers the client can use.
+//! - SNTP Servers: A list of IPv6 addresses for SNTP servers the client can
+//! use.
+//!
+//! See the `options` module for more details on the encoding of these in a
+//! message.
+//!
+//! DHCPv6 Unique Identifiers (DUID)
+//! --------------------------------
+//!
+//! These are unique, opaque byte arrays that identify peers, both clients and
+//! servers. They are formed from information such as MAC addresses, timestamps,
+//! or UUIDs, though they're really just used for comparison, to uniquely ID a
+//! peer. This is the contents of a Client ID or Server ID option.
+
+pub mod options;
+pub mod protocol;
+pub use protocol::MessageType;
+
+use core::convert::AsRef;
+use core::ops::Deref;
+pub use opte_api::dhcpv6::AddressInfo;
+pub use opte_api::dhcpv6::Dhcpv6Action;
+pub use opte_api::dhcpv6::LeasedAddress;
+use opte_api::Ipv6Addr;
+use opte_api::MacAddr;
+
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::borrow::Cow;
+    } else {
+        use std::borrow::Cow;
+    }
+}
+
+/// The All-DHCP-Relay-Agents-And-Servers IPv6 address.
+pub const ALL_RELAYS_AND_SERVERS: Ipv6Addr =
+    Ipv6Addr::from_const([0xff02, 0, 0, 0, 0, 0, 1, 2]);
+
+/// The All-DHCP-Servers IPv6 address.
+pub const ALL_SERVERS: Ipv6Addr =
+    Ipv6Addr::from_const([0xff05, 0, 0, 0, 0, 0, 1, 3]);
+
+/// The UDP port on which DHCPv6 servers listen.
+pub const SERVER_PORT: u16 = 547;
+
+/// The UDP port from which clients transmit.
+pub const CLIENT_PORT: u16 = 546;
+
+/// An identifier for a single transaction, a request-reply pair in the DHCPv6
+/// protocol.
+///
+/// See https://www.rfc-editor.org/rfc/rfc8415.html#section-8 for details, but
+/// this is just an opaque 3-octet ID.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TransactionId<'a>(pub Cow<'a, [u8]>);
+
+impl<'a> TransactionId<'a> {
+    pub const SIZE: usize = 3;
+}
+
+impl<'a> Deref for TransactionId<'a> {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a> AsRef<[u8]> for TransactionId<'a> {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl<'a> From<&'a [u8; 3]> for TransactionId<'a> {
+    fn from(buf: &'a [u8; 3]) -> Self {
+        Self(Cow::from(buf.as_slice()))
+    }
+}
+
+/// A lifetime describes the duration over which data such as addresses are
+/// valid. These are encoded in messages as a u32.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Lifetime(pub u32);
+
+impl Lifetime {
+    const INFINITE: Self = Self(u32::MAX);
+
+    pub fn infinite() -> Self {
+        Self::INFINITE
+    }
+
+    pub fn is_infinite(&self) -> bool {
+        self == &Self::INFINITE
+    }
+}
+
+impl Default for Lifetime {
+    fn default() -> Self {
+        Self::infinite()
+    }
+}
+
+/// An error during DHCPv6 operations.
+#[derive(Clone, Debug)]
+pub enum Error {
+    /// Not enough bytes to parse the desired type.
+    Truncated,
+    /// Unsupported parameter or value.
+    Unsupported,
+    /// Invalid data, e.g., non-UTF8 status code messages.
+    InvalidData,
+}
+
+/// A DHCPv6 Unique Identifier (DUID).
+///
+/// DUIDs are used to identify peers in an exchange, both clients and servers.
+/// There are a number of formats, but in general peers are supposed to treat
+/// them as opaque byte arrays. We support copying any DUID format from a client
+/// message, however we only _generate_ DUIDs in the Link-Layer Address format,
+/// i.e., just from a MAC address.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Duid<'a>(pub Cow<'a, [u8]>);
+
+impl<'a> Duid<'a> {
+    const TYPE_LL: u8 = 3;
+    const HW_TYPE_ETHER: u8 = 1;
+    // Length of Ethernet addr, plus two u16 words for the DUID type and the
+    // hardware type.
+    const LL_LEN: usize =
+        crate::engine::ether::ETHER_ADDR_LEN + 2 * core::mem::size_of::<u16>();
+
+    fn buffer_len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn copy_into<'b>(&'a self, buf: &'b mut [u8]) -> Result<(), Error>
+    where
+        'b: 'a,
+    {
+        if buf.len() < self.buffer_len() {
+            return Err(Error::Truncated);
+        }
+        buf[0..self.buffer_len()].copy_from_slice(&self.0);
+        Ok(())
+    }
+
+    /// Return `true` if the provided DUID matches the Link-Layer Address DUID
+    /// we construct for a server, based on its MAC address.
+    pub fn is_duid_ll_mac(&self, mac: &MacAddr) -> bool {
+        let data = &self.0;
+        if data.len() < Self::LL_LEN {
+            return false;
+        }
+        if data[0] != 0 || data[1] != Self::TYPE_LL {
+            return false;
+        }
+        if data[2] != 0 || data[3] != Self::HW_TYPE_ETHER {
+            return false;
+        }
+        &data[4..] == mac.as_ref()
+    }
+}
+
+impl<'a> From<&'a MacAddr> for Duid<'a> {
+    fn from(mac: &'a MacAddr) -> Self {
+        let mut buf = vec![0; Self::LL_LEN];
+        buf[1] = Self::TYPE_LL;
+        buf[3] = Self::HW_TYPE_ETHER;
+        buf[4..].copy_from_slice(mac.as_ref());
+        Self(Cow::from(buf))
+    }
+}
+
+#[cfg(test)]
+pub mod test_data {
+    // A packet snooped from a Linux DHCPv6 client, sending a well-formed
+    // Solicit message with no Rapid Commit option.
+    //
+    // This is an Ethernet frame, IPv6 header with no extension headers, UDP
+    // header, and a Solicit message contained.
+    pub const TEST_SOLICIT_PACKET: &'static [u8] =
+        b"\x33\x33\x00\x01\x00\x02\xa8\x40\x25\xfa\xdd\x0b\x86\xdd\x60\x0a\
+        \xea\xa7\x00\x40\x11\x01\xfe\x80\x00\x00\x00\x00\x00\x00\xaa\x40\
+        \x25\xff\xfe\xfa\xdd\x0b\xff\x02\x00\x00\x00\x00\x00\x00\x00\x00\
+        \x00\x00\x00\x01\x00\x02\x02\x22\x02\x23\x00\x40\x80\x86\x01\xb3\
+        \xe0\x09\x00\x01\x00\x0e\x00\x01\x00\x01\x2a\xc9\xf2\x2d\xa8\x40\
+        \x25\xfa\xdd\x0b\x00\x06\x00\x08\x00\x17\x00\x18\x00\x27\x00\x1f\
+        \x00\x08\x00\x02\x00\x00\x00\x03\x00\x0c\x25\xfa\xdd\x0b\x00\x00\
+        \x0e\x10\x00\x00\x15\x18";
+
+    pub fn test_solicit_packet_solicit_message() -> &'static [u8] {
+        &TEST_SOLICIT_PACKET[62..]
+    }
+
+    pub fn test_solicit_packet_xid() -> &'static [u8] {
+        &TEST_SOLICIT_PACKET[63..66]
+    }
+
+    pub fn test_solicit_packet_client_id() -> &'static [u8] {
+        &TEST_SOLICIT_PACKET[66..84]
+    }
+
+    pub fn test_solicit_packet_client_duid() -> &'static [u8] {
+        &TEST_SOLICIT_PACKET[70..84]
+    }
+
+    pub fn test_solicit_packet_iana() -> &'static [u8] {
+        &TEST_SOLICIT_PACKET[102..]
+    }
+
+    pub fn test_solicit_packet_option_request() -> &'static [u8] {
+        &TEST_SOLICIT_PACKET[84..96]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Cow;
+    use super::Duid;
+    use super::MacAddr;
+    use std::vec::Vec;
+
+    #[test]
+    fn test_duid_from_mac() {
+        let mac: MacAddr = [0xa8, 0x40, 0x25, 0x01, 0x02, 0x03].into();
+        let duid = Duid::from(&mac);
+
+        let data = &duid.0;
+        assert_eq!(data[1], Duid::TYPE_LL);
+        assert_eq!(data[3], Duid::HW_TYPE_ETHER);
+        assert_eq!(&data[4..], mac.as_ref());
+
+        // Sanity check that comparison works.
+        let buf = Cow::from(Vec::from(&data[..]));
+        assert_eq!(duid, Duid(buf));
+    }
+}

--- a/opte/src/engine/dhcpv6/mod.rs
+++ b/opte/src/engine/dhcpv6/mod.rs
@@ -68,7 +68,7 @@
 //! These are unique, opaque byte arrays that identify peers, both clients and
 //! servers. They are formed from information such as MAC addresses, timestamps,
 //! or UUIDs, though they're really just used for comparison, to uniquely ID a
-//! peer. This is the contents of a Client ID or Server ID option.
+//! peer. This is the content of a Client ID or Server ID option.
 
 pub mod options;
 pub mod protocol;

--- a/opte/src/engine/dhcpv6/options.rs
+++ b/opte/src/engine/dhcpv6/options.rs
@@ -1,0 +1,1064 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Support for DHCPv6 Options
+//!
+//! The majority of data transferred in DHCPv6 is done so via Options. They have
+//! a simple format:
+//!
+//! 0                   1                   2                   3
+//!  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+//! +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//! |          option-code          |           option-len          |
+//! +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//! |                          option-data                          |
+//! |                      (option-len octets)                      |
+//! +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//!
+//! The option-code defines the interpretation of option-data. For example, if
+//! option-code is `OPTION_CLIENTID`, numeric value 1, then option-data is a
+//! DUID identifying a single client in a message exchange. Options are also
+//! used to transmit leased IP addresses, DNS servers, and pretty much
+//! everything else of note.
+//!
+//! Clients are expected to submit the options they would like the server to
+//! provide them with in both Solicit and Request messages. Clients can either
+//! do so by submitting an actual option, formatted like above, or by sending
+//! just the option-code of the option they want in a special "Option Request
+//! option". See below for details.
+//!
+//! Information Associations
+//! ------------------------
+//!
+//! An Information Assocation (IA) is DHCPv6's fancy way of referring data that
+//! is associated with or committed to a particular client. For example, an IPv6
+//! address leased to a client is one IA.
+//!
+//! Notes
+//! -----
+//!
+//! RFC 8415 sec 21 describes options in general, with each option in a
+//! subsection.
+
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::vec::Vec;
+        use alloc::borrow::Cow;
+        use alloc::str::from_utf8;
+    } else {
+        use std::vec::Vec;
+        use std::str::from_utf8;
+        use std::borrow::Cow;
+    }
+}
+
+use super::Duid;
+use super::Error;
+use super::Lifetime;
+use core::mem::size_of;
+use core::ops::Range;
+use opte_api::Ipv6Addr;
+
+/// A DHCPv6 Option code.
+///
+/// Note that we don't support every option (there are a lot), and unsupported
+/// options are captured in the `Other` variant. See
+/// https://www.iana.org/assignments/dhcpv6-parameters/dhcpv6-parameters.xhtml#dhcpv6-parameters-2
+/// for a complete list of option codes.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Code {
+    /// The option contains a client DUID.
+    ClientId,
+    /// The option contains a server DUID.
+    ServerId,
+    /// A Non-Temporary Address Information Association
+    IaNa,
+    /// A Temporary Address Information Association.
+    IaTa,
+    /// An actual IPv6 address.
+    ///
+    /// These must be encapsulated in IaNa or IaTa options.
+    IaAddr,
+    /// The option contains a list of option-codes.
+    OptionRequest,
+    /// The option contains the elapsed time since a client began its current
+    /// transaction, in 10ms increments.
+    ElapsedTime,
+    /// The option contains a status code and message referring to the current
+    /// message or option in which it appears. See
+    /// https://www.rfc-editor.org/rfc/rfc8415.html#section-21.13 for a list of
+    /// the codes and messages.
+    StatusCode,
+    /// An option indicating that the client would like data to be committed
+    /// immediately, bypassing the normal acknowledgement message sequence.
+    RapidCommit,
+    /// The option contains a list of IPv6 addresses the client can use for DNS
+    /// servers.
+    ///
+    /// This option is specified in RFC 3646.
+    DnsServers,
+    /// The option contains a list of domains that the client should use when
+    /// resolving names via DNS that are not fully-qualified.
+    ///
+    /// This option is specified in RFC 3646.
+    DomainList,
+    /// The option contains a list of IPv6 addresses the client can use for SNTP
+    /// servers.
+    ///
+    /// This option is specified in RFC 4075.
+    SntpServers,
+    /// Any other option, which is unsupported and uninterpreted.
+    Other(u16),
+}
+
+impl Code {
+    const SIZE: usize = size_of::<u16>();
+}
+
+impl From<Code> for u16 {
+    fn from(code: Code) -> u16 {
+        use Code::*;
+        match code {
+            ClientId => 1,
+            ServerId => 2,
+            IaNa => 3,
+            IaTa => 4,
+            IaAddr => 5,
+            OptionRequest => 6,
+            ElapsedTime => 8,
+            StatusCode => 13,
+            RapidCommit => 14,
+            DnsServers => 23,
+            DomainList => 24,
+            SntpServers => 31,
+            Other(x) => x,
+        }
+    }
+}
+
+impl From<u16> for Code {
+    fn from(x: u16) -> Code {
+        use Code::*;
+        match x {
+            1 => ClientId,
+            2 => ServerId,
+            3 => IaNa,
+            4 => IaTa,
+            5 => IaAddr,
+            6 => OptionRequest,
+            8 => ElapsedTime,
+            13 => StatusCode,
+            14 => RapidCommit,
+            23 => DnsServers,
+            24 => DomainList,
+            31 => SntpServers,
+            x => Other(x),
+        }
+    }
+}
+
+/// An Information Association Identifier (IAID).
+///
+/// Information Associations are a confusing way of describing data that has
+/// been assigned or committed to a client by a server. The most important kind
+/// of IA is an address that a server leases to a client.
+///
+/// IAIDs are supposed to be unique for each client and IA type. For example,
+/// the IAIDs for the IPv6 addresses leased to two clients must be different, as
+/// must the IAIDs for the the Non-Temporary addresses and delegate prefixes for
+/// the same client. Other than that, it's just a unique integer.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct IaId(pub u32);
+
+/// Constants used for IAIDs of various types.
+///
+/// IDs are supposed to be unique between type and client. There is only one
+/// client, so there only needs to be one ID per IA type.
+pub const IANA_ID: IaId = IaId(1);
+pub const IATA_ID: IaId = IaId(2);
+
+/// A raw, uninterpreted DHCPv6 option.
+///
+/// Most options are not supported, but we're required to simply ingore those.
+/// This type is used to store uninterpreted options in messages received from
+/// clients.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RawOption<'a>(pub Cow<'a, [u8]>);
+
+impl<'a> RawOption<'a> {
+    // NOTE: This includes _only_ the length of the raw data itself.
+    fn buffer_len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn copy_into(&self, buf: &'a mut [u8]) -> Result<(), Error> {
+        if buf.len() < self.buffer_len() {
+            return Err(Error::Truncated);
+        }
+        buf.copy_from_slice(&self.0);
+        Ok(())
+    }
+}
+
+/// A single DHCPv6 option.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Option<'a> {
+    ClientId(Duid<'a>),
+    ServerId(Duid<'a>),
+    IaNa(IaNa<'a>),
+    IaTa(IaTa<'a>),
+    IaAddr(IaAddr<'a>),
+    OptionRequest(OptionRequest<'a>),
+    ElapsedTime(ElapsedTime),
+    Status(Status<'a>),
+    RapidCommit,
+    DnsServers(IpList<'a>),
+    DomainList(Cow<'a, [u8]>),
+    SntpServers(IpList<'a>),
+    Other { code: Code, data: RawOption<'a> },
+}
+
+impl<'a> Option<'a> {
+    const CODE: Range<usize> = 0..2;
+    const LEN: Range<usize> = 2..4;
+    const DATA_START: usize = 4;
+
+    /// Return the code associated with this Option.
+    pub fn code(&self) -> Code {
+        match self {
+            Option::ClientId(_) => Code::ClientId,
+            Option::ServerId(_) => Code::ServerId,
+            Option::IaNa(_) => Code::IaNa,
+            Option::IaTa(_) => Code::IaTa,
+            Option::IaAddr(_) => Code::IaAddr,
+            Option::OptionRequest(_) => Code::OptionRequest,
+            Option::ElapsedTime(_) => Code::ElapsedTime,
+            Option::Status(_) => Code::StatusCode,
+            Option::RapidCommit => Code::RapidCommit,
+            Option::DnsServers(_) => Code::DnsServers,
+            Option::DomainList(_) => Code::DomainList,
+            Option::SntpServers(_) => Code::SntpServers,
+            Option::Other { code, .. } => *code,
+        }
+    }
+
+    fn data_len(&self) -> usize {
+        match self {
+            Option::ClientId(inner) => inner.buffer_len(),
+            Option::ServerId(inner) => inner.buffer_len(),
+            Option::IaNa(inner) => inner.buffer_len(),
+            Option::IaTa(inner) => inner.buffer_len(),
+            Option::IaAddr(inner) => inner.buffer_len(),
+            Option::OptionRequest(inner) => inner.buffer_len(),
+            Option::ElapsedTime(inner) => inner.buffer_len(),
+            Option::Status(inner) => inner.buffer_len(),
+            Option::RapidCommit => 0,
+            Option::DnsServers(inner) => inner.buffer_len(),
+            Option::DomainList(inner) => inner.len(),
+            Option::SntpServers(inner) => inner.buffer_len(),
+            Option::Other { data, .. } => data.buffer_len(),
+        }
+    }
+
+    /// Return the length of a buffer required to completely serialize this
+    /// option.
+    pub fn buffer_len(&self) -> usize {
+        size_of::<u16>() * 2 + self.data_len()
+    }
+
+    /// Copy the data corresponding to this Option into the given buffer. If the
+    /// buffer isn't large enough, an Err is returned. The appropriate size can
+    /// be determined with `Option::buffer_len()`.
+    pub fn copy_into(&self, buf: &mut [u8]) -> Result<(), Error> {
+        if buf.len() < self.buffer_len() {
+            return Err(Error::Truncated);
+        }
+        let code = self.code();
+        buf[Self::CODE].copy_from_slice(&u16::from(self.code()).to_be_bytes());
+        let data_len =
+            u16::try_from(self.data_len()).map_err(|_| Error::Truncated)?;
+        buf[Self::LEN].copy_from_slice(&data_len.to_be_bytes());
+
+        // Check for the Rapid Commit option first. That has a zero actual data,
+        // and so the indexing below would fail in that case.
+        if matches!(code, Code::RapidCommit) {
+            return Ok(());
+        }
+
+        let data = &mut buf[Self::DATA_START..];
+        match self {
+            Option::ClientId(inner) => inner.copy_into(data),
+            Option::ServerId(inner) => inner.copy_into(data),
+            Option::IaNa(inner) => inner.copy_into(data),
+            Option::IaTa(inner) => inner.copy_into(data),
+            Option::IaAddr(inner) => inner.copy_into(data),
+            Option::OptionRequest(inner) => inner.copy_into(data),
+            Option::ElapsedTime(inner) => inner.copy_into(data),
+            Option::Status(inner) => inner.copy_into(data),
+            Option::RapidCommit => unreachable!(),
+            Option::DnsServers(inner) => inner.copy_into(data),
+            Option::DomainList(inner) => {
+                data.copy_from_slice(inner);
+                Ok(())
+            }
+            Option::SntpServers(inner) => inner.copy_into(data),
+            Option::Other { data: d, .. } => d.copy_into(data),
+        }
+    }
+
+    /// Parse out an Option from a byte array, if possible.
+    pub fn from_bytes(buf: &'a [u8]) -> Result<Self, Error> {
+        // Options must have a type / length.
+        if buf.len() < Self::DATA_START {
+            return Err(Error::Truncated);
+        }
+
+        // Sanity check the option-data length.
+        //
+        // Safety: The unwraps are safe since we above check that the buffer has
+        // at least the code and length.
+        let code =
+            Code::from(u16::from_be_bytes(buf[Self::CODE].try_into().unwrap()));
+        let len = u16::from_be_bytes(buf[Self::LEN].try_into().unwrap());
+        let ulen = usize::from(len);
+        if buf.len() < Self::DATA_START + ulen {
+            return Err(Error::Truncated);
+        }
+
+        // Check for the Rapid Commit option first. The indexing below is
+        // invalid in that case, since the option-data is actually empty.
+        if matches!(code, Code::RapidCommit) {
+            return Ok(Option::RapidCommit);
+        }
+
+        let indices = Self::DATA_START..(Self::DATA_START + ulen);
+        let data = &buf[indices];
+        match code {
+            Code::ClientId => Ok(Option::ClientId(Duid(data.into()))),
+            Code::ServerId => Ok(Option::ServerId(Duid(data.into()))),
+            Code::IaNa => IaNa::from_bytes(data).map(Option::IaNa),
+            Code::IaTa => IaTa::from_bytes(data).map(Option::IaTa),
+            Code::IaAddr => IaAddr::from_bytes(data).map(Option::IaAddr),
+            Code::OptionRequest => {
+                OptionRequest::from_bytes(data).map(Option::OptionRequest)
+            }
+            Code::ElapsedTime => {
+                data.try_into().map_err(|_| Error::Truncated).map(|t| {
+                    Option::ElapsedTime(ElapsedTime(u16::from_be_bytes(t)))
+                })
+            }
+            Code::StatusCode => Status::from_bytes(data).map(Option::Status),
+            Code::RapidCommit => unreachable!(),
+            Code::DnsServers => {
+                IpList::from_bytes(data).map(Option::DnsServers)
+            }
+            Code::DomainList => Ok(Option::DomainList(data.into())),
+            Code::SntpServers => {
+                IpList::from_bytes(data).map(Option::SntpServers)
+            }
+            Code::Other(_) => {
+                Ok(Option::Other { code, data: RawOption(data.into()) })
+            }
+        }
+    }
+}
+
+/// An Information Association of a single IPv6 address.
+///
+/// This option contains one IP address leased to a client. It's encapsulated in
+/// either an `IaNa` or `IaTa` option.
+#[derive(Clone, Debug, PartialEq)]
+pub struct IaAddr<'a> {
+    pub addr: Ipv6Addr,
+    pub preferred: Lifetime,
+    pub valid: Lifetime,
+    pub options: Vec<Option<'a>>,
+}
+
+impl<'a> IaAddr<'a> {
+    const ADDR: Range<usize> = 0..16;
+    const PREF: Range<usize> = 16..20;
+    const VALID: Range<usize> = 20..24;
+    const OPTIONS: usize = 24;
+
+    pub fn infinite_lease(addr: Ipv6Addr) -> Self {
+        Self {
+            addr,
+            preferred: Lifetime::infinite(),
+            valid: Lifetime::infinite(),
+            options: vec![],
+        }
+    }
+
+    fn option_len(&self) -> usize {
+        self.options.iter().map(|x| x.buffer_len()).sum()
+    }
+
+    fn buffer_len(&self) -> usize {
+        self.addr.len() + size_of::<Lifetime>() * 2 + self.option_len()
+    }
+
+    fn copy_into(&self, buf: &mut [u8]) -> Result<(), Error> {
+        if buf.len() < self.buffer_len() {
+            return Err(Error::Truncated);
+        }
+        buf[Self::ADDR].copy_from_slice(&self.addr);
+        buf[Self::PREF].copy_from_slice(&self.preferred.0.to_be_bytes());
+        buf[Self::VALID].copy_from_slice(&self.valid.0.to_be_bytes());
+
+        let mut start = Self::OPTIONS;
+        for opt in &self.options {
+            let len = opt.buffer_len();
+            opt.copy_into(&mut buf[start..start + len])?;
+            start += len;
+        }
+        Ok(())
+    }
+
+    fn from_bytes(buf: &'a [u8]) -> Result<Self, Error> {
+        if buf.len() < Self::OPTIONS {
+            return Err(Error::Truncated);
+        }
+
+        // Safety: The length check above guarantees we have enough bytes here.
+        let arr: [u8; 16] = buf[Self::ADDR].try_into().unwrap();
+        let addr = Ipv6Addr::from(arr);
+
+        // Safety: The length check above guarantees we have enough bytes here.
+        let arr = buf[Self::PREF].try_into().unwrap();
+        let preferred = Lifetime(u32::from_be_bytes(arr));
+        let arr = buf[Self::VALID].try_into().unwrap();
+        let valid = Lifetime(u32::from_be_bytes(arr));
+
+        let mut options = Vec::new();
+        let mut start = Self::OPTIONS;
+        while start < buf.len() {
+            let opt = Option::from_bytes(&buf[start..])?;
+            start += opt.buffer_len();
+            options.push(opt);
+        }
+        Ok(Self { addr, preferred, valid, options })
+    }
+}
+
+/// An Identity Association for a Non-Temporary Address.
+///
+/// This option encapsulates an IP address leased to a client by a server.
+#[derive(Clone, Debug, PartialEq)]
+pub struct IaNa<'a> {
+    /// The ID for this IA.
+    pub id: IaId,
+    /// The time interval after which the client should contact the server that
+    /// leased the address to renew it or lease a new one.
+    pub t1: Lifetime,
+    /// The time interval after which the client should contact _any_ server to
+    /// lease a new address.
+    pub t2: Lifetime,
+    /// The data for this option. The most prominent case is the `IaAddr`
+    /// option, which has the actual IP address, though technically others can
+    /// be included as well.
+    pub options: Vec<Option<'a>>,
+}
+
+impl<'a> IaNa<'a> {
+    const ID: Range<usize> = 0..4;
+    const T1: Range<usize> = 4..8;
+    const T2: Range<usize> = 8..12;
+    const OPTIONS: usize = 12;
+
+    pub fn infinite_lease(addr: Ipv6Addr) -> Self {
+        let ia_addr = IaAddr::infinite_lease(addr);
+        Self {
+            id: IANA_ID,
+            t1: Lifetime::infinite(),
+            t2: Lifetime::infinite(),
+            options: vec![Option::IaAddr(ia_addr)],
+        }
+    }
+
+    fn buffer_len(&self) -> usize {
+        let option_len: usize =
+            self.options.iter().map(|x| x.buffer_len()).sum();
+        size_of::<IaId>() + 2 * size_of::<Lifetime>() + option_len
+    }
+
+    fn from_bytes(buf: &'a [u8]) -> Result<Self, Error> {
+        if buf.len() < Self::OPTIONS {
+            return Err(Error::Truncated);
+        }
+        // Safety: We've just confirmed there are at least 12 bytes, so the
+        // below unwraps are all safe.
+        let id = IaId(u32::from_be_bytes(buf[Self::ID].try_into().unwrap()));
+        let t1 =
+            Lifetime(u32::from_be_bytes(buf[Self::T1].try_into().unwrap()));
+        let t2 =
+            Lifetime(u32::from_be_bytes(buf[Self::T2].try_into().unwrap()));
+
+        // Parse out any embedded options.
+        //
+        // This should include an IAAddr, but who knows.
+        let mut start = Self::OPTIONS;
+        let mut options = Vec::new();
+        while start < buf.len() {
+            let next_option = Option::from_bytes(&buf[start..])?;
+            start += next_option.buffer_len();
+            options.push(next_option);
+        }
+        Ok(Self { id, t1, t2, options })
+    }
+
+    fn copy_into(&self, buf: &mut [u8]) -> Result<(), Error> {
+        if buf.len() < self.buffer_len() {
+            return Err(Error::Truncated);
+        }
+        let id = self.id.0.to_be_bytes();
+        buf[Self::ID].copy_from_slice(&id);
+        let t1 = self.t1.0.to_be_bytes();
+        buf[Self::T1].copy_from_slice(&t1);
+        let t2 = self.t2.0.to_be_bytes();
+        buf[Self::T2].copy_from_slice(&t2);
+        let mut i = Self::OPTIONS;
+        for opt in &self.options {
+            opt.copy_into(&mut buf[i..])?;
+            i += opt.buffer_len();
+        }
+        Ok(())
+    }
+}
+
+/// An Identity Association for a Temporary Address.
+///
+/// Temporary addresses are part of SLAAC, see
+/// https://www.rfc-editor.org/rfc/rfc4941 for more details.
+#[derive(Clone, Debug, PartialEq)]
+pub struct IaTa<'a> {
+    pub id: IaId,
+    pub options: Vec<Option<'a>>,
+}
+
+impl<'a> IaTa<'a> {
+    const ID: Range<usize> = 0..4;
+    const OPTIONS: usize = 4;
+
+    pub fn new(addr: Ipv6Addr) -> Self {
+        let ia_addr = IaAddr::infinite_lease(addr);
+        Self { id: IATA_ID, options: vec![Option::IaAddr(ia_addr)] }
+    }
+
+    fn option_len(&self) -> usize {
+        self.options.iter().map(|x| x.buffer_len()).sum()
+    }
+
+    fn buffer_len(&self) -> usize {
+        size_of::<IaId>() + self.option_len()
+    }
+
+    fn from_bytes(buf: &'a [u8]) -> Result<Self, Error> {
+        if buf.len() < Self::OPTIONS {
+            return Err(Error::Truncated);
+        }
+        // Safety: We've just confirmed there are at least 4 bytes, so the
+        // below unwrap is safe.
+        let id = IaId(u32::from_be_bytes(buf[Self::ID].try_into().unwrap()));
+
+        // Parse out any embedded options.
+        //
+        // This should include an IAAddr, but who knows.
+        let mut start = Self::OPTIONS;
+        let mut options = Vec::new();
+        while start < buf.len() {
+            let next_option = Option::from_bytes(&buf[start..])?;
+            start += next_option.buffer_len();
+            options.push(next_option);
+        }
+        Ok(Self { id, options })
+    }
+
+    fn copy_into(&self, buf: &mut [u8]) -> Result<(), Error> {
+        if buf.len() < self.buffer_len() {
+            return Err(Error::Truncated);
+        }
+        let id = self.id.0.to_be_bytes();
+        buf[Self::ID].copy_from_slice(&id);
+        let mut i = Self::OPTIONS;
+        for opt in &self.options {
+            opt.copy_into(&mut buf[i..])?;
+            i += opt.buffer_len();
+        }
+        Ok(())
+    }
+}
+
+/// An Option Request option is a list of option-codes.
+///
+/// This is used by clients to request particular Options from the server. In
+/// some cases, those options are themselves written into the message. E.g., for
+/// an IANA, clients write out the full option including code, length, and data.
+///
+/// For others, such as DNS serves, clients request that but including its
+/// option-code in an Option Request option.
+///
+/// See Table 4, here https://www.rfc-editor.org/rfc/rfc8415.html#section-24,
+/// for the list of options that must or must not be included in an
+/// OptionRequest.
+#[derive(Clone, Debug, PartialEq)]
+pub struct OptionRequest<'a>(pub Cow<'a, [Code]>);
+
+impl<'a> OptionRequest<'a> {
+    pub fn contains(&self, code: Code) -> bool {
+        self.0.contains(&code)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Code> {
+        self.0.iter()
+    }
+
+    fn buffer_len(&self) -> usize {
+        self.0.len() * Code::SIZE
+    }
+
+    fn copy_into(&self, buf: &'a mut [u8]) -> Result<(), Error> {
+        if buf.len() < self.buffer_len() {
+            return Err(Error::Truncated);
+        }
+        let mut start = 0;
+        let mut end = Code::SIZE;
+        for code in self.0.iter() {
+            let bytes = u16::from(*code).to_be_bytes();
+            buf[start..end].copy_from_slice(&bytes);
+            start = end;
+            end += Code::SIZE;
+        }
+        Ok(())
+    }
+
+    fn from_bytes(buf: &'a [u8]) -> Result<Self, Error> {
+        if buf.len() % Code::SIZE != 0 {
+            return Err(Error::Truncated);
+        }
+        let count = buf.len() / Code::SIZE;
+        let mut codes = Vec::with_capacity(count);
+        for i in 0..count {
+            let word = u16::from_be_bytes([
+                buf[Code::SIZE * i],
+                buf[Code::SIZE * i + 1],
+            ]);
+            codes.push(Code::from(word));
+        }
+        Ok(Self(Cow::from(codes)))
+    }
+}
+
+/// The Elapsed Time option must be included in client messages, and provides
+/// the time (in units of 10ms) since the client began the current transaction.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ElapsedTime(pub u16);
+
+impl ElapsedTime {
+    fn buffer_len(&self) -> usize {
+        size_of::<u16>()
+    }
+
+    fn copy_into(&self, buf: &mut [u8]) -> Result<(), Error> {
+        if buf.len() < self.buffer_len() {
+            return Err(Error::Truncated);
+        }
+        let x = self.0.to_be_bytes();
+        buf[0] = x[0];
+        buf[1] = x[1];
+        Ok(())
+    }
+
+    /// Return the Duration this elapsed time represents.
+    pub fn as_duration(&self) -> core::time::Duration {
+        core::time::Duration::from_millis(self.0 as u64 * 10)
+    }
+}
+
+/// A status code contained in a Status option.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum StatusCode {
+    Success,
+    UnspecFail,
+    NoAddrsAvail,
+    NoBinding,
+    NotOnLink,
+    UseMulticast,
+    NoPrefixAvail,
+    Other(u16),
+}
+
+impl From<u16> for StatusCode {
+    fn from(x: u16) -> Self {
+        use StatusCode::*;
+        match x {
+            0 => Success,
+            1 => UnspecFail,
+            2 => NoAddrsAvail,
+            3 => NoBinding,
+            4 => NotOnLink,
+            5 => UseMulticast,
+            6 => NoPrefixAvail,
+            x => Other(x),
+        }
+    }
+}
+
+impl From<StatusCode> for u16 {
+    fn from(code: StatusCode) -> u16 {
+        use StatusCode::*;
+        match code {
+            Success => 0,
+            UnspecFail => 1,
+            NoAddrsAvail => 2,
+            NoBinding => 3,
+            NotOnLink => 4,
+            UseMulticast => 5,
+            NoPrefixAvail => 6,
+            Other(x) => x,
+        }
+    }
+}
+
+/// A Status Option indicates the status of the thing it's contained in. If
+/// that's a standalone option, it's the status of the message; if in another
+/// option, the status of that option.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Status<'a> {
+    pub code: StatusCode,
+    pub message: &'a str,
+}
+
+impl<'a> Status<'a> {
+    const CODE: Range<usize> = 0..2;
+    const MSG: usize = 2;
+
+    fn buffer_len(&self) -> usize {
+        size_of::<u16>() + self.message.len()
+    }
+
+    fn copy_into(&self, buf: &mut [u8]) -> Result<(), Error> {
+        if buf.len() < self.buffer_len() {
+            return Err(Error::Truncated);
+        }
+        let code = u16::from(self.code).to_be_bytes();
+        buf[0] = code[0];
+        buf[1] = code[1];
+        buf[2..].copy_from_slice(self.message.as_bytes());
+        Ok(())
+    }
+
+    fn from_bytes(buf: &'a [u8]) -> Result<Self, Error> {
+        if buf.len() < Self::MSG {
+            return Err(Error::Truncated);
+        }
+        // Safety: The condition above guarantees there are enough bytes for
+        // this unwrap to not panic.
+        let code = StatusCode::from(u16::from_be_bytes(
+            buf[Self::CODE].try_into().unwrap(),
+        ));
+
+        // Take any further bytes as the status message.
+        let message = from_utf8(buf.get(Self::MSG..).unwrap_or(&[]))
+            .map_err(|_| Error::InvalidData)?;
+        Ok(Self { code, message })
+    }
+}
+
+/// A list of IPv6 addresses.
+///
+/// This is used in DNS Server options, and others where just a list of addresses
+/// is required.
+#[derive(Clone, Debug, PartialEq)]
+pub struct IpList<'a>(pub Cow<'a, [Ipv6Addr]>);
+
+impl<'a> From<&'a [Ipv6Addr]> for IpList<'a> {
+    fn from(addrs: &'a [Ipv6Addr]) -> Self {
+        Self(Cow::from(addrs))
+    }
+}
+
+impl<'a> IpList<'a> {
+    fn buffer_len(&self) -> usize {
+        size_of::<Ipv6Addr>() * self.0.len()
+    }
+
+    fn from_bytes(buf: &'a [u8]) -> Result<Self, Error> {
+        const SIZE: usize = size_of::<Ipv6Addr>();
+        if buf.len() % SIZE != 0 {
+            return Err(Error::Truncated);
+        }
+        let count = buf.len() / SIZE;
+        let mut start = 0;
+        let mut addrs = Vec::with_capacity(count);
+        while start < buf.len() {
+            let arr: [u8; SIZE] = buf[start..start + SIZE]
+                .try_into()
+                .map_err(|_| Error::Truncated)?;
+            start += SIZE;
+            addrs.push(Ipv6Addr::from(arr));
+        }
+        Ok(Self(Cow::from(addrs)))
+    }
+
+    fn copy_into(&self, buf: &mut [u8]) -> Result<(), Error> {
+        const SIZE: usize = size_of::<Ipv6Addr>();
+        if buf.len() < self.buffer_len() {
+            return Err(Error::Truncated);
+        }
+        let mut start = 0;
+        let mut end = SIZE;
+        for addr in self.0.iter() {
+            buf[start..end].copy_from_slice(&addr);
+            start = end;
+            end += SIZE;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Code;
+    use super::Duid;
+    use super::ElapsedTime;
+    use super::IaNa;
+    use super::IaTa;
+    use super::IpList;
+    use super::Ipv6Addr;
+    use super::Lifetime;
+    use super::Option;
+    use super::OptionRequest;
+    use super::Status;
+    use super::StatusCode;
+    use crate::engine::dhcpv6::test_data;
+
+    #[test]
+    fn test_iana() {
+        let addr = Ipv6Addr::from_const([0xfd00, 0, 0, 0, 1, 2, 3, 4]);
+        let iana = IaNa::infinite_lease(addr);
+        assert_eq!(iana.id, super::IANA_ID);
+        let opt = &iana.options[0];
+        if let Option::IaAddr(inner) = &opt {
+            assert_eq!(inner.addr, addr);
+            assert_eq!(inner.preferred, Lifetime::infinite());
+            assert_eq!(inner.valid, Lifetime::infinite());
+            assert!(inner.options.is_empty());
+        } else {
+            panic!("Expected an IaAddr option");
+        }
+
+        let opt = Option::IaNa(iana);
+        let mut buf = vec![0; opt.buffer_len()];
+        opt.copy_into(&mut buf).unwrap();
+        let new = Option::from_bytes(&buf).unwrap();
+        assert_eq!(opt, new);
+    }
+
+    #[test]
+    fn test_iata() {
+        let addr = Ipv6Addr::from_const([0xfd00, 0, 0, 0, 1, 2, 3, 4]);
+        let iata = IaTa::new(addr);
+        let opt = Option::IaTa(iata);
+        let mut buf = vec![0; opt.buffer_len()];
+        opt.copy_into(&mut buf).unwrap();
+        let new = Option::from_bytes(&buf).unwrap();
+        assert_eq!(opt, new);
+    }
+
+    #[test]
+    fn test_raw_option_from_bytes() {
+        let original_data = &[0, 1, 2, 3];
+        let mut buf = vec![0u8; 4 + original_data.len()];
+        buf[1] = 200;
+        buf[3] = original_data.len() as u8;
+        buf[4..].copy_from_slice(original_data);
+
+        let opt = Option::from_bytes(&buf).unwrap();
+        if let Option::Other { code, data } = &opt {
+            assert_eq!(code, code);
+            assert_eq!(data.0, original_data.as_ref());
+        } else {
+            panic!("Expected a raw option");
+        }
+
+        let mut out = vec![0; opt.buffer_len()];
+        opt.copy_into(&mut out).unwrap();
+        assert_eq!(buf, out);
+    }
+
+    #[test]
+    fn test_client_id() {
+        let duid = Duid(vec![0, 1, 2].into());
+        let id = Option::ClientId(duid.clone());
+
+        let mut buf = vec![0u8; id.buffer_len()];
+        id.copy_into(&mut buf).unwrap();
+
+        let opt = Option::from_bytes(&buf).unwrap();
+        assert_eq!(opt.code(), Code::ClientId);
+        if let Option::ClientId(inner) = &opt {
+            assert_eq!(inner, &duid);
+        } else {
+            panic!("Expected a client ID option");
+        }
+
+        let mut out = vec![0; opt.buffer_len()];
+        opt.copy_into(&mut out).unwrap();
+        assert_eq!(buf, out);
+    }
+
+    #[test]
+    fn test_server_id() {
+        let duid = Duid(vec![0, 1, 2].into());
+        let id = Option::ServerId(duid.clone());
+
+        let mut buf = vec![0u8; id.buffer_len()];
+        id.copy_into(&mut buf).unwrap();
+
+        let opt = Option::from_bytes(&buf).unwrap();
+        assert_eq!(opt.code(), Code::ServerId);
+        if let Option::ServerId(inner) = &opt {
+            assert_eq!(inner, &duid);
+        } else {
+            panic!("Expected a server ID option");
+        }
+
+        let mut out = vec![0; opt.buffer_len()];
+        opt.copy_into(&mut out).unwrap();
+        assert_eq!(buf, out);
+    }
+
+    #[test]
+    fn test_status() {
+        let message = "an error message";
+        let code = StatusCode::UnspecFail;
+        let sts = Status { code, message };
+        let opt = Option::Status(sts);
+
+        let mut buf = vec![0; opt.buffer_len()];
+        opt.copy_into(&mut buf).unwrap();
+
+        let new = Option::from_bytes(&buf).unwrap();
+        assert_eq!(opt, new);
+        if let Option::Status(s) = &new {
+            assert_eq!(s.code, code);
+            assert_eq!(s.message, message);
+        } else {
+            panic!("Expected a Status option");
+        }
+    }
+
+    #[test]
+    fn test_elapsed_time() {
+        let time = ElapsedTime(100);
+        let opt = Option::ElapsedTime(time);
+
+        let mut buf = vec![0; opt.buffer_len()];
+        opt.copy_into(&mut buf).unwrap();
+
+        let new = Option::from_bytes(&buf).unwrap();
+        assert_eq!(opt, new);
+        if let Option::ElapsedTime(t) = &opt {
+            assert_eq!(t.0, time.0);
+        } else {
+            panic!("Expected an Elapsed Time option");
+        }
+    }
+
+    #[test]
+    fn test_rapid_commit() {
+        let opt = Option::RapidCommit;
+        let mut buf = vec![0; opt.buffer_len()];
+        opt.copy_into(&mut buf).unwrap();
+        let new = Option::from_bytes(&buf).unwrap();
+        assert_eq!(opt, new);
+    }
+
+    #[test]
+    fn test_ip_list_bad_length_fails() {
+        let buf = [0u8; std::mem::size_of::<Ipv6Addr>() + 1];
+        assert!(IpList::from_bytes(&buf).is_err());
+    }
+
+    #[test]
+    fn test_dns_servers() {
+        let addrs = vec![
+            Ipv6Addr::from_const([0xfd00, 0, 0, 0, 0, 0, 0, 1]),
+            Ipv6Addr::from_const([0xfd00, 0, 0, 0, 0, 0, 0, 2]),
+        ];
+        let opt = Option::DnsServers(IpList(addrs.into()));
+
+        let mut buf = vec![0; opt.buffer_len()];
+        opt.copy_into(&mut buf).unwrap();
+        let new = Option::from_bytes(&buf).unwrap();
+        assert_eq!(opt, new);
+    }
+
+    #[test]
+    fn test_sntp_servers() {
+        let addrs = vec![
+            Ipv6Addr::from_const([0xfd00, 0, 0, 0, 0, 0, 0, 1]),
+            Ipv6Addr::from_const([0xfd00, 0, 0, 0, 0, 0, 0, 2]),
+        ];
+        let opt = Option::SntpServers(IpList(addrs.into()));
+
+        let mut buf = vec![0; opt.buffer_len()];
+        opt.copy_into(&mut buf).unwrap();
+        let new = Option::from_bytes(&buf).unwrap();
+        assert_eq!(opt, new);
+    }
+
+    #[test]
+    fn test_option_request() {
+        let codes = [Code::SntpServers, Code::DomainList, Code::Other(100)];
+        let opt = Option::OptionRequest(OptionRequest(codes.as_slice().into()));
+        let mut buf = vec![0; opt.buffer_len()];
+        opt.copy_into(&mut buf).unwrap();
+        let new = Option::from_bytes(&buf).unwrap();
+        assert_eq!(opt, new);
+    }
+
+    #[test]
+    fn test_parse_snooped_iana() {
+        let opt =
+            Option::from_bytes(test_data::test_solicit_packet_iana()).unwrap();
+        if let Option::IaNa(inner) = opt {
+            assert_eq!(inner.id.0, 0x25fadd0b);
+            assert_eq!(inner.t1.0, 3600);
+            assert_eq!(inner.t2.0, 5400);
+        } else {
+            panic!("Expected an IANA");
+        }
+    }
+
+    #[test]
+    fn test_parse_snooped_option_request() {
+        let opt =
+            Option::from_bytes(test_data::test_solicit_packet_option_request())
+                .unwrap();
+        if let Option::OptionRequest(inner) = opt {
+            assert!(inner.contains(Code::DnsServers));
+            assert!(inner.contains(Code::DomainList));
+            assert!(inner.contains(Code::SntpServers));
+            assert!(inner.contains(Code::Other(0x27)));
+        } else {
+            panic!("Expected an Option Request");
+        }
+    }
+
+    #[test]
+    fn test_parse_snooped_client_id() {
+        let opt =
+            Option::from_bytes(test_data::test_solicit_packet_client_id())
+                .unwrap();
+        if let Option::ClientId(duid) = opt {
+            assert_eq!(duid.0, test_data::test_solicit_packet_client_duid());
+        } else {
+            panic!("Expected a Client ID");
+        }
+    }
+}

--- a/opte/src/engine/dhcpv6/protocol.rs
+++ b/opte/src/engine/dhcpv6/protocol.rs
@@ -1,0 +1,676 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Implementation of the main message types for DHCPv6.
+
+use super::TransactionId;
+use crate::engine::checksum::HeaderChecksum;
+use crate::engine::dhcpv6::options::Code as OptionCode;
+use crate::engine::dhcpv6::options::IaAddr;
+use crate::engine::dhcpv6::options::IaNa;
+use crate::engine::dhcpv6::options::IpList;
+use crate::engine::dhcpv6::options::Option as Dhcpv6Option;
+use crate::engine::dhcpv6::options::Status;
+use crate::engine::dhcpv6::options::StatusCode;
+use crate::engine::dhcpv6::Duid;
+use crate::engine::dhcpv6::Lifetime;
+use crate::engine::dhcpv6::ALL_RELAYS_AND_SERVERS;
+use crate::engine::dhcpv6::ALL_SERVERS;
+use crate::engine::dhcpv6::CLIENT_PORT;
+use crate::engine::dhcpv6::SERVER_PORT;
+use crate::engine::ether::EtherHdr;
+use crate::engine::ether::EtherMeta;
+use crate::engine::ether::ETHER_TYPE_IPV6;
+use crate::engine::ip6::Ipv6Hdr;
+use crate::engine::ip6::Ipv6Meta;
+use crate::engine::ip6::UlpCsumOpt;
+use crate::engine::packet::Packet;
+use crate::engine::packet::PacketMeta;
+use crate::engine::packet::PacketRead;
+use crate::engine::packet::PacketReader;
+use crate::engine::packet::Parsed;
+use crate::engine::rule::AllowOrDeny;
+use crate::engine::rule::DataPredicate;
+use crate::engine::rule::EtherAddrMatch;
+use crate::engine::rule::GenPacketResult;
+use crate::engine::rule::HairpinAction;
+use crate::engine::rule::IpProtoMatch;
+use crate::engine::rule::Ipv6AddrMatch;
+use crate::engine::rule::PortMatch;
+use crate::engine::rule::Predicate;
+use crate::engine::udp::UdpHdr;
+use crate::engine::udp::UdpMeta;
+use core::fmt;
+use core::ops::Range;
+use opte_api::dhcpv6::Dhcpv6Action;
+use opte_api::Ipv6Addr;
+use opte_api::Ipv6Cidr;
+use opte_api::MacAddr;
+use opte_api::Protocol;
+use serde::Deserialize;
+use serde::Serialize;
+
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::vec::Vec;
+    } else {
+        use std::vec::Vec;
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum MessageType {
+    Solicit,
+    Advertise,
+    Request,
+    Confirm,
+    Renew,
+    Reply,
+    InformationRequest,
+    Other(u8),
+}
+
+impl fmt::Display for MessageType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use MessageType::*;
+        match self {
+            Other(x) => write!(f, "Other({})", x),
+            other => write!(
+                f,
+                "{}",
+                match other {
+                    Solicit => "Solicit",
+                    Advertise => "Advertise",
+                    Request => "Request",
+                    Confirm => "Confirm",
+                    Renew => "Renew",
+                    Reply => "Reply",
+                    InformationRequest => "InformationRequest",
+                    _ => unreachable!(),
+                }
+            ),
+        }
+    }
+}
+
+impl From<u8> for MessageType {
+    fn from(x: u8) -> Self {
+        use MessageType::*;
+        match x {
+            1 => Solicit,
+            2 => Advertise,
+            3 => Request,
+            4 => Confirm,
+            5 => Renew,
+            7 => Reply,
+            11 => InformationRequest,
+            x => Other(x),
+        }
+    }
+}
+
+impl From<MessageType> for u8 {
+    fn from(mt: MessageType) -> Self {
+        use MessageType::*;
+        match mt {
+            Solicit => 1,
+            Advertise => 2,
+            Request => 3,
+            Confirm => 4,
+            Renew => 5,
+            Reply => 7,
+            InformationRequest => 11,
+            Other(x) => x,
+        }
+    }
+}
+
+/// A DHCPv6 message.
+///
+/// All DHCPv6 transactions occur through this type. Clients send messages,
+/// usually requesting information about available servers or that particular
+/// data be assigned to them. (The latter occurs through options.) Servers
+/// respond with the same format, according to the protocol laid out in RFC
+/// 8415, section 18.
+#[derive(Clone, Debug)]
+pub struct Message<'a> {
+    /// The [`MessageType`] of this message.
+    pub typ: MessageType,
+    /// The transaction ID for this message.
+    pub xid: TransactionId<'a>,
+    /// The options contained in this message.
+    pub options: Vec<Dhcpv6Option<'a>>,
+}
+
+impl<'a> Message<'a> {
+    const TYPE: usize = 0;
+    const XID: Range<usize> = 1..4;
+    const DATA: usize = 4;
+
+    /// Parse a message from the provided bytes, if it is valid. If not, return
+    /// `None`.
+    pub fn from_bytes(buf: &'a [u8]) -> Option<Self> {
+        if buf.len() <= Self::DATA {
+            return None;
+        }
+        let typ = MessageType::from(buf[Self::TYPE]);
+        let xid = TransactionId(buf[Self::XID].into());
+        let mut start = Self::DATA;
+        let mut options = Vec::new();
+        while start < buf.len() {
+            let opt = Dhcpv6Option::from_bytes(&buf[start..]).ok()?;
+            start += opt.buffer_len();
+            options.push(opt);
+        }
+        Some(Self { typ, xid, options })
+    }
+
+    /// Return the Client DUID in the message, if any.
+    pub fn client_duid(&self) -> Option<&Duid<'a>> {
+        if let Dhcpv6Option::ClientId(duid) =
+            self.find_option(OptionCode::ClientId)?
+        {
+            Some(duid)
+        } else {
+            None
+        }
+    }
+
+    /// Return the Server DUID in the message, if any.
+    pub fn server_duid(&self) -> Option<&Duid<'a>> {
+        if let Dhcpv6Option::ServerId(duid) =
+            self.find_option(OptionCode::ServerId)?
+        {
+            Some(duid)
+        } else {
+            None
+        }
+    }
+
+    /// Return `true` if the message contains an option of the given type.
+    pub fn has_option(&self, code: OptionCode) -> bool {
+        self.find_option(code).is_some()
+    }
+
+    /// Return the _first_ contained option of the provided type, or `None` if
+    /// the message does not contain such an option.
+    pub fn find_option(&self, code: OptionCode) -> Option<&Dhcpv6Option<'a>> {
+        self.options.iter().find(|opt| opt.code() == code)
+    }
+
+    /// Return an iterator over options of the provided type.
+    pub fn option_iter(
+        &self,
+        code: OptionCode,
+    ) -> impl Iterator<Item = &Dhcpv6Option<'a>> {
+        self.options.iter().filter(move |opt| opt.code() == code)
+    }
+
+    fn option_len(&self) -> usize {
+        self.options.iter().map(|opt| opt.buffer_len()).sum()
+    }
+
+    /// Return the total length of the buffer required to contain the bytes of
+    /// this DHCPv6 message.
+    pub fn buffer_len(&self) -> usize {
+        core::mem::size_of::<u8>() + TransactionId::SIZE + self.option_len()
+    }
+
+    /// Write this message into the provided buffer. If the buffer is not large
+    /// enough, `None` is returned. The minimum size can be retrieved with
+    /// `Message::buffer_len()`.
+    pub fn copy_into(&self, buf: &mut [u8]) -> Option<()> {
+        let len = self.buffer_len();
+        if buf.len() < len {
+            return None;
+        }
+        buf[Self::TYPE] = u8::from(self.typ);
+        buf[Self::XID].copy_from_slice(&self.xid.0);
+        let mut start = Self::DATA;
+        for opt in &self.options {
+            opt.copy_into(&mut buf[start..]).ok()?;
+            start += opt.buffer_len();
+        }
+        Some(())
+    }
+}
+
+// General packet header predicates to identify a DHCPv6 message from client to
+// a server.
+fn dhcpv6_server_predicates(client_mac: &MacAddr) -> Vec<Predicate> {
+    // NOTE: We do not predicate receipt of DHCP messages on the Layer 2
+    // address. See RFC 8415 Section 14.2
+    // (https://www.rfc-editor.org/rfc/rfc8415.html#section-14), which
+    // specifically says:
+    //
+    // > DHCP servers SHOULD NOT check to see whether the Layer 2 address
+    // > used was multicast or not, as long as the Layer 3 address was
+    // > correct.
+
+    vec![
+        // Request must come from the guest's MAC address
+        Predicate::InnerEtherSrc(vec![EtherAddrMatch::Exact(*client_mac)]),
+        // Request must come from a link-local address
+        Predicate::InnerSrcIp6(vec![Ipv6AddrMatch::Prefix(
+            Ipv6Cidr::LINK_LOCAL,
+        )]),
+        // Must be destined to one of the supported IPv6 multicast addresses.
+        Predicate::InnerDstIp6(vec![
+            Ipv6AddrMatch::Exact(ALL_RELAYS_AND_SERVERS),
+            Ipv6AddrMatch::Exact(ALL_SERVERS),
+        ]),
+        // DHCPv6 runs over UDP
+        Predicate::InnerIpProto(vec![IpProtoMatch::Exact(Protocol::UDP)]),
+        // Request must be from the client port
+        Predicate::InnerSrcPort(vec![PortMatch::Exact(CLIENT_PORT)]),
+        // and destined to the server port
+        Predicate::InnerDstPort(vec![PortMatch::Exact(SERVER_PORT)]),
+    ]
+}
+
+// Panics: This panics if `msg` does not have a Client ID option in it.
+fn generate_reply_options<'a>(
+    action: &'a Dhcpv6Action,
+    msg: &'a Message,
+) -> Vec<Dhcpv6Option<'a>> {
+    // We always send the Client ID that was included in the original message,
+    // along with our Server ID option.
+    let mut options = vec![
+        server_id(action),
+        // Safety: Callers are supposed to check that `msg` has a Client ID
+        // option in it already.
+        msg.find_option(OptionCode::ClientId).unwrap().clone(),
+    ];
+
+    // If requested, provide the list of DNS servers.
+    if let Some(Dhcpv6Option::OptionRequest(oro)) =
+        msg.find_option(OptionCode::OptionRequest)
+    {
+        if oro.contains(OptionCode::DnsServers) {
+            let opt = Dhcpv6Option::DnsServers(IpList::from(
+                action.dns_servers.as_slice(),
+            ));
+            options.push(opt);
+        }
+    }
+
+    // Add the leased address(es), if they were requested, along with the IAID
+    // provided by the client.
+    //
+    // TODO-correctness: The client can technically include many of these, so
+    // `find_option` isn't enough, we need to find _all_ such options.
+    if let Some(Dhcpv6Option::IaNa(requested_iana)) =
+        msg.find_option(OptionCode::IaNa)
+    {
+        let ia_addrs = action
+            .addrs
+            .addrs
+            .iter()
+            .map(|lease| {
+                Dhcpv6Option::IaAddr(IaAddr {
+                    addr: lease.addr,
+                    valid: Lifetime(lease.valid()),
+                    preferred: Lifetime(lease.preferred()),
+                    options: vec![],
+                })
+            })
+            .collect();
+        let iana = IaNa {
+            id: requested_iana.id,
+            t1: Lifetime(action.addrs.renew),
+            t2: Lifetime(action.addrs.renew),
+            options: ia_addrs,
+        };
+        options.push(Dhcpv6Option::IaNa(iana));
+    }
+
+    options
+}
+
+// Handle a Solicit or Request message.
+//
+// This results in a Reply message or and Advertise, depending on the message
+// type and its options:
+//
+// - Solicit -> Reply
+// - Advertise + Rapid Commit -> Reply
+//
+// A reply to be sent back to the client is returned in `Some(_)`. If the
+// message should be dropped, `None` is returned instead.
+fn process_solicit_or_request_message<'a>(
+    action: &'a Dhcpv6Action,
+    client_msg: &'a Message<'a>,
+) -> Option<Message<'a>> {
+    // Solicit messages must not have a Server ID, while Request messages _must_
+    // have a Server ID that matches our own.
+    let maybe_server_id = client_msg.server_duid();
+    match (client_msg.typ, maybe_server_id) {
+        (MessageType::Solicit, Some(_)) => return None,
+        (MessageType::Request, None) => return None,
+        (MessageType::Request, Some(server_id))
+            if !server_id.is_duid_ll_mac(&action.server_mac) =>
+        {
+            return None
+        }
+        _ => {}
+    }
+
+    // Must include an Elapsed Time option.
+    if !client_msg.has_option(OptionCode::ElapsedTime) {
+        return None;
+    }
+
+    // Must have a Client ID option.
+    if !client_msg.has_option(OptionCode::ClientId) {
+        return None;
+    }
+
+    // Generate all the options we'll send back to the client.
+    let options = generate_reply_options(action, &client_msg);
+
+    // Set the message type.
+    //
+    // If the client sends a Solicit with Rapid Commit, we have to send back a
+    // Reply. Otherwise we send an Advertise message, but it still contains all
+    // the data we _would_ lease to the client.
+    let reply_type = if client_msg.typ == MessageType::Request
+        || (client_msg.typ == MessageType::Solicit
+            && client_msg.has_option(OptionCode::RapidCommit))
+    {
+        MessageType::Reply
+    } else {
+        MessageType::Advertise
+    };
+    Some(Message { typ: reply_type, xid: client_msg.xid.clone(), options })
+}
+
+// Return the server's DUID itself.
+fn server_duid<'a>(action: &'a Dhcpv6Action) -> Duid<'a> {
+    Duid::from(&action.server_mac)
+}
+
+// Return the DHCPv6 Option containing the server's DUID.
+fn server_id<'a>(action: &'a Dhcpv6Action) -> Dhcpv6Option<'a> {
+    Dhcpv6Option::ServerId(server_duid(action))
+}
+
+// Handle a Confirm message.
+//
+// See https://www.rfc-editor.org/rfc/rfc8415.html#section-18.3.3 for details of
+// how servers are required to process such messages. Section 16.5 also includes
+// a bit of information about validation.
+//
+// A reply to be sent back to the client is returned in `Some(_)`. If the
+// message should be dropped, `None` is returned instead.
+fn process_confirm_message<'a>(
+    action: &'a Dhcpv6Action,
+    client_msg: &'a Message<'a>,
+) -> Option<Message<'a>> {
+    // Client must include a Client ID.
+    let client_id = client_msg.find_option(OptionCode::ClientId)?;
+
+    // Client must not include a Server ID.
+    if client_msg.has_option(OptionCode::ServerId) {
+        return None;
+    }
+
+    // Client must include an Elapsed Time.
+    if !client_msg.has_option(OptionCode::ElapsedTime) {
+        return None;
+    }
+
+    let mut reply_options = vec![server_id(action), client_id.clone()];
+
+    // The client should be sending us IAs for each IPv6 address we've leased to
+    // them.
+    //
+    // If there are _no_ addresses at all, either no IANA option, or that option
+    // contains no IA Address options, we don't send a reply, and just drop the
+    // packet.
+    let iana = client_msg.find_option(OptionCode::IaNa)?;
+    if let Dhcpv6Option::IaNa(IaNa { options, .. }) = &iana {
+        if options.is_empty() {
+            return None;
+        }
+
+        // Check that we have the IP addresses "on file". If not, send back a
+        // message indicating that the requested addresses are not on-link.
+        //
+        // NOTE: This may not be exactly right, based on the reading of RFC 8415
+        // Section 18.3.3 paragraph 2. That states:
+        //
+        // > When the server receives a Confirm message, the server determines
+        // > whether the addresses in the Confirm message are appropriate for
+        // > the link to which the client is attached.  If all of the addresses
+        // > in the Confirm message pass this test, the server returns a status
+        // > of Success.
+        //
+        // If the client sends us a message that's on-link, but that we've not
+        // leased: (1) that's really weird, and (2) it's not obvious how we
+        // should respond. For now, we send back NotOnLink.
+        let mut no_addresses = true;
+        for option in options.iter() {
+            if let Dhcpv6Option::IaNa(IaNa { options: inner_opt, .. }) = option
+            {
+                for opt in inner_opt.iter() {
+                    if let Dhcpv6Option::IaAddr(IaAddr { addr, .. }) = opt {
+                        // We've found at least one IA with an address.
+                        no_addresses = false;
+                        if !action.addresses().any(|a| &a == addr) {
+                            // Send back NotOnLink
+                            reply_options.push(Dhcpv6Option::Status(Status {
+                                code: StatusCode::NotOnLink,
+                                message: "Address(es) not on link",
+                            }));
+                            return Some(Message {
+                                typ: MessageType::Reply,
+                                xid: client_msg.xid.clone(),
+                                options: reply_options,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        // If we found no addresses at all, we have to drop the packet.
+        if no_addresses {
+            return None;
+        }
+
+        // All addresses in the Confirm message match those stored in the
+        // `Action`, so things all look good. Send back a success.
+        reply_options.push(Dhcpv6Option::Status(Status {
+            code: StatusCode::Success,
+            message: "",
+        }));
+        Some(Message {
+            typ: MessageType::Reply,
+            xid: client_msg.xid.clone(),
+            options: reply_options,
+        })
+    } else {
+        unreachable!("DHCPv6 Message::find_option returned wrong type.");
+    }
+}
+
+// Process a DHCPv6 message from the a client.
+fn process_client_message<'a>(
+    action: &'a Dhcpv6Action,
+    _meta: &'a PacketMeta,
+    client_msg: &'a Message<'a>,
+) -> Option<Message<'a>> {
+    match client_msg.typ {
+        MessageType::Solicit | MessageType::Request => {
+            process_solicit_or_request_message(action, &client_msg)
+        }
+        MessageType::Confirm => process_confirm_message(action, &client_msg),
+        // TODO-completeness: Handle other message types.
+        //
+        // This is pretty low-priority right now. Conforming clients must use
+        // the lifetimes we provide in leased addresses, which are currently
+        // infinite. However, if we change that, or find some client
+        // implementations don't adhere to the standard, we should add that
+        // support here.
+        _ => None,
+    }
+}
+
+// Construct a reply packet from the action, given the provided metadata from
+// the request and the actual DHCPv6 message to send out.
+fn generate_packet<'a>(
+    action: &Dhcpv6Action,
+    meta: &PacketMeta,
+    msg: &'a Message<'a>,
+) -> GenPacketResult {
+    let eth = EtherHdr::from(&EtherMeta {
+        dst: action.client_mac,
+        src: action.server_mac,
+        ether_type: ETHER_TYPE_IPV6,
+    });
+
+    let mut ip = Ipv6Hdr::from(&Ipv6Meta {
+        src: Ipv6Addr::from_eui64(&action.server_mac),
+        // Safety: We're only here if the predicates match, one of which is
+        // IPv6.
+        dst: meta.inner_ip6().unwrap().src,
+        proto: Protocol::UDP,
+    });
+    ip.set_pay_len((msg.buffer_len() + UdpHdr::SIZE) as u16);
+
+    let mut udp = UdpHdr::from(&UdpMeta { src: SERVER_PORT, dst: CLIENT_PORT });
+    udp.set_pay_len(msg.buffer_len() as u16);
+
+    // Allocate a buffer into which we'll copy the packet.
+    let reply_len =
+        msg.buffer_len() + UdpHdr::SIZE + Ipv6Hdr::SIZE + EtherHdr::SIZE;
+    let mut buf = vec![0; reply_len];
+
+    // Copy the Ethernet header.
+    let mut start = 0;
+    let mut end = EtherHdr::SIZE;
+    buf[start..end].copy_from_slice(&eth.as_bytes());
+
+    // Copy the IPv6 header.
+    start = end;
+    end += Ipv6Hdr::SIZE;
+    buf[start..end].copy_from_slice(&ip.as_bytes());
+
+    // Copy in the DHCP message itself.
+    //
+    // We do this first for the checksum computation. The message can be written
+    // into a buffer, which we already have in `buf`. Do that first, then use
+    // that buffer for the checksum computation, and _then_ write in the UDP
+    // header which includes that checksum.
+    let dhcp_start = end + UdpHdr::SIZE;
+    msg.copy_into(&mut buf[dhcp_start..]).unwrap();
+
+    // Compute the UDP checksum, and write in the resulting header that includes
+    // it.
+    let cksum = ip.compute_ulp_csum(
+        UlpCsumOpt::Full,
+        &udp.as_bytes(),
+        &buf[dhcp_start..],
+    );
+    udp.set_csum(HeaderChecksum::from(cksum).bytes());
+    start = end;
+    end += UdpHdr::SIZE;
+    buf[start..end].copy_from_slice(&udp.as_bytes());
+
+    Ok(AllowOrDeny::Allow(Packet::copy(&buf)))
+}
+
+impl HairpinAction for Dhcpv6Action {
+    fn implicit_preds(&self) -> (Vec<Predicate>, Vec<DataPredicate>) {
+        let hdr_preds = dhcpv6_server_predicates(&self.client_mac);
+        (hdr_preds, vec![])
+    }
+
+    // This does all the heavy lifting for processing DHCPv6 messages from
+    // clients. The main reason we don't have an action per-reply is that we can
+    // get different replies from the same request type, depending on the data
+    // within them (the options).
+    //
+    // Specifically, a Solicit message can result in either an Advertise or a
+    // Request from the server. The former is emitted if the Rapid Commit option
+    // is _not_ set, the latter if it is. That Request is the same as if the
+    // client had instead submitted a Request message, rather than Solicit
+    //
+    // Rather than put this logic into DataPredicates, we just parse the packet
+    // here and reply accordingly. So the `Dhcpv6Action` is really a full
+    // server, to the extent we emulate one.
+    fn gen_packet(
+        &self,
+        meta: &PacketMeta,
+        rdr: &mut PacketReader<Parsed, ()>,
+    ) -> GenPacketResult {
+        let body = rdr.copy_remaining();
+        if let Some(client_msg) = Message::from_bytes(&body) {
+            if let Some(reply) = process_client_message(self, meta, &client_msg)
+            {
+                generate_packet(self, meta, &reply)
+            } else {
+                Ok(AllowOrDeny::Deny)
+            }
+        } else {
+            Ok(AllowOrDeny::Deny)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::dhcpv6_server_predicates;
+    use super::Dhcpv6Option;
+    use super::MacAddr;
+    use super::Message;
+    use super::MessageType;
+    use super::OptionCode;
+    use super::Packet;
+    use crate::engine::dhcpv6::test_data;
+    use crate::engine::port::meta::ActionMeta;
+
+    // Test that we correctly parse out the entire Solicit message from a
+    // snooped packet.
+    //
+    // Most of the expected data here was verified with Wireshark.
+    #[test]
+    fn test_parse_snooped_solicit_message() {
+        let msg = Message::from_bytes(
+            test_data::test_solicit_packet_solicit_message(),
+        )
+        .unwrap();
+        assert_eq!(msg.typ, MessageType::Solicit);
+        assert_eq!(msg.xid.0.as_ref(), test_data::test_solicit_packet_xid());
+        if let Dhcpv6Option::ClientId(opt) =
+            msg.find_option(OptionCode::ClientId).unwrap()
+        {
+            assert_eq!(opt.0, test_data::test_solicit_packet_client_duid());
+        } else {
+            panic!("Expected a Client ID option");
+        }
+        assert_eq!(msg.options.len(), 4);
+        assert!(msg.has_option(OptionCode::ElapsedTime));
+        assert!(msg.has_option(OptionCode::OptionRequest));
+        assert!(msg.has_option(OptionCode::IaNa));
+    }
+
+    #[test]
+    fn test_predicates_match_snooped_solicit_message() {
+        let pkt = Packet::copy(test_data::TEST_SOLICIT_PACKET).parse().unwrap();
+        let pmeta = pkt.meta();
+        let ameta = ActionMeta::new();
+        let client_mac =
+            MacAddr::from_const([0xa8, 0x40, 0x25, 0xfa, 0xdd, 0x0b]);
+        for pred in dhcpv6_server_predicates(&client_mac) {
+            assert!(
+                pred.is_match(&pmeta, &ameta),
+                "Expected predicate to match snooped Solicit test packet: {}",
+                pred
+            );
+        }
+    }
+}

--- a/opte/src/engine/dhcpv6/protocol.rs
+++ b/opte/src/engine/dhcpv6/protocol.rs
@@ -215,15 +215,19 @@ impl<'a> Message<'a> {
     /// Return `true` if this contains the Rapid Commit option, either at the
     /// top-level, or inside the Option Request container option.
     pub fn has_rapid_commit(&self) -> bool {
-        // Look for top-level option.
-        self.has_option(OptionCode::RapidCommit) || {
-            if let Some(Dhcpv6Option::OptionRequest(opts)) =
-                self.find_option(OptionCode::OptionRequest)
-            {
-                opts.contains(OptionCode::RapidCommit)
-            } else {
-                false
-            }
+        // Look for top-level option first.
+        if self.has_option(OptionCode::RapidCommit) {
+            return true;
+        }
+
+        // Look for the Rapid Commit option contained in the Option Request
+        // option.
+        if let Some(Dhcpv6Option::OptionRequest(opts)) =
+            self.find_option(OptionCode::OptionRequest)
+        {
+            opts.contains(OptionCode::RapidCommit)
+        } else {
+            false
         }
     }
 

--- a/opte/src/engine/icmpv6.rs
+++ b/opte/src/engine/icmpv6.rs
@@ -316,7 +316,7 @@ impl HairpinAction for RouterAdvertisement {
             // that for themselves at this point.
             reachable_time: ZERO_DURATION,
             retrans_time: ZERO_DURATION,
-            lladdr: Some(RawHardwareAddress::from_bytes(&self.mac.bytes())),
+            lladdr: Some(RawHardwareAddress::from_bytes(&self.mac)),
             // TODO-completeness: Don't hardcode this.
             //
             // See https://github.com/oxidecomputer/opte/issues/263.
@@ -480,7 +480,7 @@ fn construct_neighbor_advert<'a>(
             flags,
             target_addr: Ipv6Address::from(*target_addr),
             // Always include the Link-Layer address option.
-            lladdr: Some(RawHardwareAddress::from_bytes(&na.mac.bytes())),
+            lladdr: Some(RawHardwareAddress::from_bytes(&na.mac)),
         },
     ))
 }

--- a/opte/src/engine/ip4.rs
+++ b/opte/src/engine/ip4.rs
@@ -322,8 +322,15 @@ macro_rules! assert_ip4 {
     };
 }
 
+/// Options for computing a ULP checksum.
+#[derive(Clone, Copy, Debug)]
 pub enum UlpCsumOpt {
+    /// Compute a partial checksum, using only the pseudo-header.
+    ///
+    /// This is intended in situations in which computing the checksum of the
+    /// body itself can be offloaded to hardware.
     Partial,
+    /// Compute the full checksum, including the pseudo-header and body.
     Full,
 }
 
@@ -335,10 +342,6 @@ impl Ipv4Hdr {
         let raw = Ipv4HdrRaw::from(self);
         bytes.extend_from_slice(raw.as_bytes());
         bytes
-    }
-
-    fn compute_pseudo_csum(&self) -> Checksum {
-        Checksum::compute(&self.pseudo_bytes())
     }
 
     pub fn compute_hdr_csum(&mut self) {
@@ -356,7 +359,7 @@ impl Ipv4Hdr {
         match opt {
             UlpCsumOpt::Partial => todo!("implement partial csum"),
             UlpCsumOpt::Full => {
-                let mut csum = self.compute_pseudo_csum();
+                let mut csum = self.pseudo_csum();
                 csum.add(ulp_hdr);
                 csum.add(body);
                 csum
@@ -417,8 +420,8 @@ impl Ipv4Hdr {
     /// Return the pseudo header bytes.
     pub fn pseudo_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(12);
-        bytes.extend_from_slice(&self.src.bytes());
-        bytes.extend_from_slice(&self.dst.bytes());
+        bytes.extend_from_slice(&self.src);
+        bytes.extend_from_slice(&self.dst);
         let len_bytes = (self.ulp_len() as u16).to_be_bytes();
         bytes.extend_from_slice(&[
             0u8,
@@ -457,16 +460,16 @@ impl Ipv4Hdr {
         // XXX Might be nice to have Checksum work on iterator of u8
         // instead, then we could chain slice iterators together.
         let mut old: FVec<u8, 10> = FVec::new();
-        old.extend_from_slice(&self.src.bytes()).unwrap();
-        old.extend_from_slice(&self.dst.bytes()).unwrap();
+        old.extend_from_slice(&self.src).unwrap();
+        old.extend_from_slice(&self.dst).unwrap();
         old.extend_from_slice(&[0, self.proto as u8]).unwrap();
         csum.sub(&old);
         let _ = csum.finalize();
 
         // Add new bytes.
         let mut new: FVec<u8, 10> = FVec::new();
-        new.extend_from_slice(&meta.src.bytes()).unwrap();
-        new.extend_from_slice(&meta.dst.bytes()).unwrap();
+        new.extend_from_slice(&meta.src).unwrap();
+        new.extend_from_slice(&meta.dst).unwrap();
         new.extend_from_slice(&[0, meta.proto as u8]).unwrap();
         csum.add(&new);
 

--- a/opte/src/engine/ip4.rs
+++ b/opte/src/engine/ip4.rs
@@ -330,7 +330,8 @@ pub enum UlpCsumOpt {
     /// This is intended in situations in which computing the checksum of the
     /// body itself can be offloaded to hardware.
     Partial,
-    /// Compute the full checksum, including the pseudo-header and body.
+    /// Compute the full checksum, including the pseudo-header, ULP header and
+    /// the ULP body.
     Full,
 }
 

--- a/opte/src/engine/mod.rs
+++ b/opte/src/engine/mod.rs
@@ -10,6 +10,7 @@
 pub mod arp;
 pub mod checksum;
 pub mod dhcp;
+pub mod dhcpv6;
 #[macro_use]
 pub mod ether;
 pub mod flow_table;

--- a/opte/src/engine/packet.rs
+++ b/opte/src/engine/packet.rs
@@ -529,6 +529,15 @@ impl PacketMeta {
     pub fn is_inner_tcp(&self) -> bool {
         self.inner.is_tcp()
     }
+
+    /// Return the inner UDP metadata, if the inner ULP is UDP.
+    /// Otherwise return `None`.
+    pub fn inner_udp(&self) -> Option<&UdpMeta> {
+        match &self.inner.ulp {
+            Some(UlpMeta::Udp(udp)) => Some(udp),
+            _ => None,
+        }
+    }
 }
 
 /// A network packet.

--- a/oxide-vpc/.gitignore
+++ b/oxide-vpc/.gitignore
@@ -4,3 +4,4 @@ overlay_guest_to_guest-guest-1.pcap
 overlay_guest_to_guest-guest-2.pcap
 overlay_guest_to_guest-phys-1.pcap
 overlay_guest_to_guest-phys-2.pcap
+dhcpv6_solicit_reply.pcap

--- a/oxide-vpc/src/api.rs
+++ b/oxide-vpc/src/api.rs
@@ -102,6 +102,7 @@ pub struct Ipv6Cfg {
     /// networks, including other VPC guests as well as external networks and
     /// the internet. Essentially, this is the IPv6 address of OPTE itself,
     /// which is acting as the gateway to the guest.
+    //
     // TODO-remove: The current plan is to use only the link-local address for
     // OPTE as the virtual gateway, populated by NDP. Assuming we move forward
     // with that, this should be removed.

--- a/oxide-vpc/src/api.rs
+++ b/oxide-vpc/src/api.rs
@@ -102,6 +102,9 @@ pub struct Ipv6Cfg {
     /// networks, including other VPC guests as well as external networks and
     /// the internet. Essentially, this is the IPv6 address of OPTE itself,
     /// which is acting as the gateway to the guest.
+    // TODO-remove: The current plan is to use only the link-local address for
+    // OPTE as the virtual gateway, populated by NDP. Assuming we move forward
+    // with that, this should be removed.
     pub gateway_ip: Ipv6Addr,
 
     /// The source NAT configuration for making outbound connections

--- a/oxide-vpc/src/engine/dhcpv6.rs
+++ b/oxide-vpc/src/engine/dhcpv6.rs
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Implements DHCPv6 as supported in the Oxide VPC environment.
+
+use crate::api::VpcCfg;
+use core::num::NonZeroU32;
+use opte::api::Direction;
+use opte::api::Ipv6Addr;
+use opte::api::OpteError;
+use opte::engine::dhcpv6::AddressInfo;
+use opte::engine::dhcpv6::Dhcpv6Action;
+use opte::engine::dhcpv6::LeasedAddress;
+use opte::engine::layer::Layer;
+use opte::engine::port::PortBuilder;
+use opte::engine::port::Pos;
+use opte::engine::rule::Action;
+use opte::engine::rule::HairpinAction;
+use opte::engine::rule::Rule;
+
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::sync::Arc;
+    } else {
+        use std::sync::Arc;
+    }
+}
+
+pub fn setup(
+    pb: &mut PortBuilder,
+    cfg: &VpcCfg,
+    ft_limit: NonZeroU32,
+) -> Result<(), OpteError> {
+    // This layer contains no actions if the client has not been configured with
+    // IPv6 support.
+    let ip_cfg = match cfg.ipv6_cfg() {
+        None => return Ok(()),
+        Some(c) => c,
+    };
+
+    // The main DHCPv6 server action, which currently just leases the
+    // VPC-private IP addresses to the client.
+    let addrs = AddressInfo {
+        addrs: vec![LeasedAddress::infinite_lease(ip_cfg.private_ip)],
+        renew: u32::MAX,
+    };
+    let action = Dhcpv6Action {
+        client_mac: cfg.private_mac,
+        server_mac: cfg.gateway_mac,
+        addrs,
+        dns_servers: vec![
+            // CloudFlare
+            Ipv6Addr::from_const([0x2606, 0x4700, 0x4700, 0, 0, 0, 0, 0x1111]),
+            Ipv6Addr::from_const([0x2606, 0x4700, 0x4700, 0, 0, 0, 0, 0x1001]),
+            // Google
+            Ipv6Addr::from_const([0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8888]),
+            Ipv6Addr::from_const([0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8844]),
+        ],
+        sntp_servers: vec![],
+    };
+
+    // Clone predicates, since they're used in the static rule below to drop all
+    // inbound DHCPv6.
+    let is_dhcp = action.implicit_preds().0.clone();
+
+    let server = Action::Hairpin(Arc::new(action));
+    let mut dhcp = Layer::new("dhcpv6", pb.name(), vec![server], ft_limit);
+    let rule = Rule::new(1, dhcp.action(0).unwrap().clone());
+    dhcp.add_rule(Direction::Out, rule.finalize());
+
+    // Static rule to drop all inbound DHCPv6 traffic.
+    let mut rule = Rule::new(1, Action::Deny);
+    rule.add_predicates(is_dhcp);
+    dhcp.add_rule(Direction::In, rule.finalize());
+
+    pb.add_layer(dhcp, Pos::Before("firewall"))
+}

--- a/oxide-vpc/src/engine/dhcpv6.rs
+++ b/oxide-vpc/src/engine/dhcpv6.rs
@@ -59,7 +59,7 @@ fn drop_all_dhcpv6(
     // Predicates identifying any traffic destined for a DHCPv6 server.
     let predicates = vec![
         // Destined for the server multicast IP address.
-        Predicate::InnerSrcIp6(vec![
+        Predicate::InnerDstIp6(vec![
             Ipv6AddrMatch::Exact(ALL_RELAYS_AND_SERVERS),
             Ipv6AddrMatch::Exact(ALL_SERVERS),
         ]),

--- a/oxide-vpc/src/engine/mod.rs
+++ b/oxide-vpc/src/engine/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod arp;
 pub mod dhcp;
+pub mod dhcpv6;
 pub mod firewall;
 pub mod icmp;
 pub mod icmpv6;

--- a/oxide-vpc/tests/integration_tests.rs
+++ b/oxide-vpc/tests/integration_tests.rs
@@ -3078,6 +3078,16 @@ fn test_reply_to_dhcpv6_solicit_or_reply() {
                     );
                 }
 
+                // In the case of Solicit + Rapid Commit, we are required to
+                // send the Rapid Commit option back in our reply.
+                if has_rapid_commit
+                    && msg_type == dhcpv6::protocol::MessageType::Solicit
+                {
+                    assert!(
+                        reply.has_option(dhcpv6::options::Code::RapidCommit)
+                    );
+                }
+
                 // Regardless of the message type, we are supposed to include
                 // answers for each Option the client requested (and that we
                 // support). That's mostly just the actual VPC-private IPv6 address.

--- a/oxide-vpc/tests/integration_tests.rs
+++ b/oxide-vpc/tests/integration_tests.rs
@@ -31,6 +31,7 @@ use opte::engine::arp::ArpEth4PayloadRaw;
 use opte::engine::arp::ArpHdrRaw;
 use opte::engine::arp::ARP_HDR_SZ;
 use opte::engine::checksum::HeaderChecksum;
+use opte::engine::dhcpv6;
 use opte::engine::ether::EtherHdr;
 use opte::engine::ether::EtherHdrRaw;
 use opte::engine::ether::EtherMeta;
@@ -491,6 +492,8 @@ fn oxide_net_builder(
 
     firewall::setup(&mut pb, fw_limit).expect("failed to add firewall layer");
     dhcp::setup(&mut pb, cfg, one_limit).expect("failed to add dhcp layer");
+    oxide_vpc::engine::dhcpv6::setup(&mut pb, cfg, one_limit)
+        .expect("failed to add dhcpv6 layer");
     icmp::setup(&mut pb, cfg, one_limit).expect("failed to add icmp layer");
     icmpv6::setup(&mut pb, cfg, one_limit).expect("failed to add icmpv6 layer");
     arp::setup(&mut pb, cfg, one_limit).expect("failed to add arp layer");
@@ -1108,8 +1111,8 @@ fn gen_icmpv6_echo_req(
     let mut body_bytes = vec![0u8; req.buffer_len()];
     let mut req_pkt = Icmpv6Packet::new_unchecked(&mut body_bytes);
     let _ = req.emit(
-        &Ipv6Address::from_bytes(ip_src.bytes().as_slice()).into(),
-        &Ipv6Address::from_bytes(ip_dst.bytes().as_slice()).into(),
+        &Ipv6Address::from_bytes(&ip_src).into(),
+        &Ipv6Address::from_bytes(&ip_dst).into(),
         &mut req_pkt,
         &Default::default(),
     );
@@ -2310,8 +2313,8 @@ fn test_guest_to_gateway_icmpv6_ping(
             assert_eq!(ip6.dst, src_ip);
             assert_eq!(ip6.proto, Protocol::ICMPv6);
             (
-                Ipv6Address::from_bytes(ip6.src.bytes().as_slice()),
-                Ipv6Address::from_bytes(ip6.dst.bytes().as_slice()),
+                Ipv6Address::from_bytes(&ip6.src),
+                Ipv6Address::from_bytes(&ip6.dst),
             )
         }
         ip4 => panic!("expected inner IPv6 metadata, got IPv4: {:?}", ip4),
@@ -2354,7 +2357,7 @@ fn gen_router_solicitation(src_mac: &MacAddr) -> Packet<Parsed> {
     let dst_mac = dst_ip.multicast_mac().unwrap();
 
     let solicit = NdiscRepr::RouterSolicit {
-        lladdr: Some(RawHardwareAddress::from_bytes(&src_mac.bytes())),
+        lladdr: Some(RawHardwareAddress::from_bytes(&src_mac)),
     };
     let req = Icmpv6Repr::Ndisc(solicit);
     let mut body_bytes = vec![0u8; req.buffer_len()];
@@ -2465,8 +2468,8 @@ fn gateway_router_advert_reply() {
             );
             assert_eq!(ip6.proto, Protocol::ICMPv6);
             (
-                Ipv6Address::from_bytes(ip6.src.bytes().as_slice()),
-                Ipv6Address::from_bytes(expected_dst.bytes().as_slice()),
+                Ipv6Address::from_bytes(&ip6.src),
+                Ipv6Address::from_bytes(&expected_dst),
             )
         }
         ip4 => panic!("expected inner IPv6 metadata, got IPv4: {:?}", ip4),
@@ -2497,7 +2500,7 @@ fn gateway_router_advert_reply() {
             assert_eq!(retrans_time, Duration::from_millis(0));
             assert_eq!(
                 lladdr.expect("Expected a Link-Layer Address option"),
-                RawHardwareAddress::from_bytes(&g1_cfg.gateway_mac.bytes())
+                RawHardwareAddress::from_bytes(&g1_cfg.gateway_mac)
             );
             assert_eq!(mtu, Some(1500));
             assert!(prefix_info.is_none());
@@ -2515,7 +2518,7 @@ fn gateway_router_advert_reply() {
 fn generate_neighbor_solicitation(info: &SolicitInfo) -> Packet<Parsed> {
     let solicit = NdiscRepr::NeighborSolicit {
         target_addr: Ipv6Address::from(info.target_addr),
-        lladdr: info.lladdr.map(|x| RawHardwareAddress::from_bytes(&x.bytes())),
+        lladdr: info.lladdr.map(|x| RawHardwareAddress::from_bytes(&x)),
     };
     let req = Icmpv6Repr::Ndisc(solicit);
     let mut body = vec![0u8; req.buffer_len()];
@@ -2817,7 +2820,7 @@ fn validate_hairpin_advert(
         assert_eq!(target_addr, na.target_addr.into());
         assert_eq!(
             lladdr,
-            na.lladdr.map(|x| RawHardwareAddress::from_bytes(&x.bytes()))
+            na.lladdr.map(|x| RawHardwareAddress::from_bytes(&x))
         );
     } else {
         panic!(
@@ -2864,5 +2867,262 @@ fn test_gateway_neighbor_advert_reply() {
                 );
             }
         };
+    }
+}
+
+// Build a packet from a DHCPv6 message, from a client to server.
+fn packet_from_client_dhcpv6_message<'a>(
+    cfg: &VpcCfg,
+    msg: &dhcpv6::protocol::Message<'a>,
+) -> Packet<Parsed> {
+    let eth = EtherHdr::from(&EtherMeta {
+        dst: dhcpv6::ALL_RELAYS_AND_SERVERS.multicast_mac().unwrap(),
+        src: cfg.private_mac,
+        ether_type: ETHER_TYPE_IPV6,
+    });
+
+    let mut ip = Ipv6Hdr::from(&Ipv6Meta {
+        src: Ipv6Addr::from_eui64(&cfg.private_mac),
+        dst: dhcpv6::ALL_RELAYS_AND_SERVERS,
+        proto: Protocol::UDP,
+    });
+    ip.set_pay_len((msg.buffer_len() + UdpHdr::SIZE) as u16);
+
+    let mut udp = UdpHdr::from(&UdpMeta {
+        src: dhcpv6::CLIENT_PORT,
+        dst: dhcpv6::SERVER_PORT,
+    });
+    udp.set_pay_len(msg.buffer_len() as u16);
+
+    write_dhcpv6_packet(eth, ip, udp, msg)
+}
+
+fn write_dhcpv6_packet<'a>(
+    eth: EtherHdr,
+    ip: Ipv6Hdr,
+    udp: UdpHdr,
+    msg: &dhcpv6::protocol::Message<'a>,
+) -> Packet<Parsed> {
+    // Allocate a buffer into which we'll copy the packet.
+    let reply_len =
+        msg.buffer_len() + UdpHdr::SIZE + Ipv6Hdr::SIZE + EtherHdr::SIZE;
+    let mut buf = vec![0; reply_len];
+
+    // Copy the Ethernet header.
+    let mut start = 0;
+    let mut end = EtherHdr::SIZE;
+    buf[start..end].copy_from_slice(&eth.as_bytes());
+
+    // Copy the IPv6 header.
+    start = end;
+    end += Ipv6Hdr::SIZE;
+    buf[start..end].copy_from_slice(&ip.as_bytes());
+
+    // Copy the UDP header.
+    start = end;
+    end += UdpHdr::SIZE;
+    buf[start..end].copy_from_slice(&udp.as_bytes());
+
+    // Copy in the remainder, which is the DHCPv6 message itself.
+    start = end;
+    msg.copy_into(&mut buf[start..]).unwrap();
+
+    // Make a packet
+    Packet::copy(&buf).parse().unwrap()
+}
+
+// Assert the essential details of a DHCPv6 exchange. The client request is in
+// `request_pkt`, and the server reply in `reply_pkt`.
+//
+// This asserts that the Ethernet, IPv6, and UDP metadata correct. It also
+// verifies the basics of any DHCPv6 exchange:
+//
+// - The server must copy the client's Transaction ID verbatim.
+// - The server must copy the client's ID option verbatim.
+// - The server must include its own Server ID option.
+fn verify_dhcpv6_essentials<'a>(
+    cfg: &VpcCfg,
+    request_pkt: &Packet<Parsed>,
+    request: &dhcpv6::protocol::Message<'a>,
+    reply_pkt: &Packet<Parsed>,
+    reply: &dhcpv6::protocol::Message<'a>,
+) {
+    let request_meta = request_pkt.meta();
+    let reply_meta = reply_pkt.meta();
+    let request_ether = request_meta.inner_ether().unwrap();
+    let reply_ether = reply_meta.inner_ether().unwrap();
+    assert_eq!(
+        request_ether.dst,
+        dhcpv6::ALL_RELAYS_AND_SERVERS.multicast_mac().unwrap()
+    );
+    assert_eq!(request_ether.src, reply_ether.dst);
+
+    let request_ip = request_meta.inner_ip6().unwrap();
+    let reply_ip = reply_meta.inner_ip6().unwrap();
+    assert_eq!(request_ip.src, Ipv6Addr::from_eui64(&cfg.private_mac));
+    assert_eq!(request_ip.dst, dhcpv6::ALL_RELAYS_AND_SERVERS);
+    assert_eq!(request_ip.proto, Protocol::UDP);
+    assert_eq!(reply_ip.dst, request_ip.src);
+    assert_eq!(reply_ip.src, Ipv6Addr::from_eui64(&cfg.gateway_mac));
+    assert_eq!(reply_ip.proto, Protocol::UDP);
+
+    let request_udp = request_meta.inner_udp().unwrap();
+    let reply_udp = reply_meta.inner_udp().unwrap();
+    assert_eq!(request_udp.src, dhcpv6::CLIENT_PORT);
+    assert_eq!(request_udp.dst, dhcpv6::SERVER_PORT);
+    assert_eq!(reply_udp.dst, dhcpv6::CLIENT_PORT);
+    assert_eq!(reply_udp.src, dhcpv6::SERVER_PORT);
+
+    // Verify the details of the DHCPv6 exchange itself.
+    assert_eq!(reply.xid, request.xid);
+    assert!(reply.has_option(dhcpv6::options::Code::ServerId));
+    let client_id =
+        request.find_option(dhcpv6::options::Code::ClientId).unwrap();
+    assert_eq!(
+        client_id,
+        reply.find_option(dhcpv6::options::Code::ClientId).unwrap()
+    );
+}
+
+// Test that we reply to a DHCPv6 Solicit or Request message with the right
+// reply.
+//
+// A Request should result in a Reply message with all the data the client
+// requested (that the server supports).
+//
+// A Solicit message normally generates an Advertise message. But if the Solicit
+// message also contains the Rapid Commit option, the server is supposed to
+// respond with a Reply instead.
+//
+// In both cases, the contained data is the same. (That's so that the client
+// could use the data from more than one server to decide which one to actually
+// make a subsequent Request to.)
+#[test]
+fn test_reply_to_dhcpv6_solicit_or_reply() {
+    let g1_cfg = g1_cfg();
+    let v2p = Arc::new(Virt2Phys::new());
+    let mut ameta = ActionMeta::new();
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, v2p.clone());
+    g1.port.start();
+    set_state!(g1, PortState::Running);
+    let mut pcap = PcapBuilder::new("dhcpv6_solicit_reply.pcap");
+
+    let requested_iana = dhcpv6::options::IaNa {
+        id: dhcpv6::options::IaId(0xff7),
+        t1: dhcpv6::Lifetime(3600),
+        t2: dhcpv6::Lifetime(6200),
+        options: vec![],
+    };
+    let base_options = vec![
+        dhcpv6::options::Option::ClientId(dhcpv6::Duid::from(
+            &g1_cfg.private_mac,
+        )),
+        dhcpv6::options::Option::ElapsedTime(dhcpv6::options::ElapsedTime(10)),
+        dhcpv6::options::Option::IaNa(requested_iana.clone()),
+    ];
+
+    for msg_type in [
+        dhcpv6::protocol::MessageType::Solicit,
+        dhcpv6::protocol::MessageType::Request,
+    ] {
+        for has_rapid_commit in [false, true] {
+            let mut options = base_options.clone();
+            if has_rapid_commit {
+                options.push(dhcpv6::options::Option::RapidCommit);
+            }
+            // Request messages must include the Server ID we're making the
+            // request to.
+            if msg_type == dhcpv6::protocol::MessageType::Request {
+                options.push(dhcpv6::options::Option::ServerId(
+                    dhcpv6::Duid::from(&g1_cfg.gateway_mac),
+                ));
+            }
+            let request = dhcpv6::protocol::Message {
+                typ: msg_type,
+                xid: dhcpv6::TransactionId::from(&[0u8, 1, 2]),
+                options,
+            };
+            let mut request_pkt =
+                packet_from_client_dhcpv6_message(&g1_cfg, &request);
+            pcap.add_pkt(&request_pkt);
+            let res =
+                g1.port.process(Out, &mut request_pkt, &mut ameta).unwrap();
+            if let Hairpin(hp) = res {
+                let reply_pkt = hp.parse().unwrap();
+                pcap.add_pkt(&reply_pkt);
+
+                let body = reply_pkt.get_body_rdr().copy_remaining();
+                let reply =
+                    dhcpv6::protocol::Message::from_bytes(&body).unwrap();
+                verify_dhcpv6_essentials(
+                    &g1_cfg,
+                    &request_pkt,
+                    &request,
+                    &reply_pkt,
+                    &reply,
+                );
+
+                // Verify the message type of the reply:
+                //
+                // Solicit - Rapid Commit -> Advertise
+                // Solicit + Rapid Commit -> Reply
+                // Request + either -> Reply
+                if has_rapid_commit
+                    || msg_type == dhcpv6::protocol::MessageType::Request
+                {
+                    assert_eq!(reply.typ, dhcpv6::protocol::MessageType::Reply);
+                } else {
+                    assert_eq!(
+                        reply.typ,
+                        dhcpv6::protocol::MessageType::Advertise
+                    );
+                }
+
+                // Regardless of the message type, we are supposed to include
+                // answers for each Option the client requested (and that we
+                // support). That's mostly just the actual VPC-private IPv6 address.
+                let iana =
+                    reply.find_option(dhcpv6::options::Code::IaNa).unwrap();
+                if let dhcpv6::options::Option::IaNa(dhcpv6::options::IaNa {
+                    id,
+                    t1,
+                    t2,
+                    options,
+                }) = iana
+                {
+                    assert_eq!(id, &requested_iana.id);
+                    assert!(t1.is_infinite());
+                    assert!(t2.is_infinite());
+                    assert!(!options.is_empty());
+
+                    if let Some(dhcpv6::options::Option::IaAddr(
+                        dhcpv6::options::IaAddr {
+                            addr,
+                            valid,
+                            preferred,
+                            options: opts,
+                        },
+                    )) = options.first()
+                    {
+                        assert_eq!(
+                            addr,
+                            &g1_cfg.ipv6_cfg().unwrap().private_ip
+                        );
+                        assert!(valid.is_infinite());
+                        assert!(preferred.is_infinite());
+                        assert!(opts.is_empty());
+                    } else {
+                        panic!(
+                            "Expected an IA Addr option, found {:#?}",
+                            options
+                        );
+                    }
+                } else {
+                    panic!("Expected an IANA option, found {:?}", iana);
+                }
+            } else {
+                panic!("Expected a Hairpin, found {:?}", res);
+            }
+        }
     }
 }

--- a/oxide-vpc/tests/integration_tests.rs
+++ b/oxide-vpc/tests/integration_tests.rs
@@ -2998,7 +2998,7 @@ fn verify_dhcpv6_essentials<'a>(
 // could use the data from more than one server to decide which one to actually
 // make a subsequent Request to.)
 #[test]
-fn test_reply_to_dhcpv6_solicit_or_reply() {
+fn test_reply_to_dhcpv6_solicit_or_request() {
     let g1_cfg = g1_cfg();
     let v2p = Arc::new(Virt2Phys::new());
     let mut ameta = ActionMeta::new();

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -82,6 +82,7 @@ use oxide_vpc::api::SetVirt2PhysReq;
 use oxide_vpc::api::VpcCfg;
 use oxide_vpc::engine::arp;
 use oxide_vpc::engine::dhcp;
+use oxide_vpc::engine::dhcpv6;
 use oxide_vpc::engine::firewall;
 use oxide_vpc::engine::icmp;
 use oxide_vpc::engine::icmpv6;
@@ -1951,6 +1952,7 @@ fn new_port(
     // XXX some layers have no need for LFT, perhaps have two types
     // of Layer: one with, one without?
     dhcp::setup(&mut pb, &cfg, FT_LIMIT_ONE.unwrap())?;
+    dhcpv6::setup(&mut pb, &cfg, FT_LIMIT_ONE.unwrap())?;
     icmp::setup(&mut pb, &cfg, FT_LIMIT_ONE.unwrap())?;
     icmpv6::setup(&mut pb, &cfg, FT_LIMIT_ONE.unwrap())?;
     arp::setup(&mut pb, &cfg, FT_LIMIT_ONE.unwrap())?;


### PR DESCRIPTION
- Adds core support for DHCPv6 types, including DUIDs, Options, and the various message types.
- Adds an OPTE API action for describing DHCPv6 emulation in OPTE, with the addresses to be leased, their lifetimes, and a few other options.
- Implements the DHCPv6 protocol inside the `Dhcpv6Action::gen_packet` method.
- Adds helper implementations of `AsRef` and `Deref` to MAC and IPv6 addresses, for referring to those as byte arrays without an additional copy.
- Adds ULP checksum computation to IPv6, and fixes small edge-case with computed checksums of zero.
- Adds a bunch of units for DHCPv6, mostly for serialization/deserialization, including test data from a packet capture.
- Adds integration tests verifying the core DHCPv6 protocol for leasing addresses, including Solicit -> Advertise -> Request -> Reply, and Solicit -> Reply.