### PR TITLE
Create common module for integration tests

### DIFF
--- a/opte/src/engine/headers.rs
+++ b/opte/src/engine/headers.rs
@@ -137,6 +137,14 @@ macro_rules! assert_ip {
 }
 
 impl IpHdr {
+    /// Return the bytes of the header.
+    pub fn as_bytes(&self) -> Vec<u8> {
+        match self {
+            Self::Ip4(ip4) => ip4.as_bytes(),
+            Self::Ip6(ip6) => ip6.as_bytes(),
+        }
+    }
+
     /// Return the total length of the header.
     ///
     /// In the case of IPv6, this includes any extension headers.

--- a/oxide-vpc/tests/common/icmp.rs
+++ b/oxide-vpc/tests/common/icmp.rs
@@ -1,0 +1,146 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Routines for ICMP testing.
+
+use opte::api::*;
+use opte::engine::ether::*;
+use opte::engine::ip4::*;
+use opte::engine::ip6::*;
+use opte::engine::packet::*;
+use smoltcp::wire::Icmpv4Packet;
+use smoltcp::wire::Icmpv4Repr;
+use smoltcp::wire::Icmpv6Packet;
+use smoltcp::wire::Icmpv6Repr;
+use smoltcp::wire::Ipv6Address;
+
+pub enum IcmpEchoType {
+    Req,
+    Reply,
+}
+
+pub fn gen_icmp_echo_req(
+    eth_src: MacAddr,
+    eth_dst: MacAddr,
+    ip_src: IpAddr,
+    ip_dst: IpAddr,
+    ident: u16,
+    seq_no: u16,
+    data: &[u8],
+) -> Packet<Parsed> {
+    match (ip_src, ip_dst) {
+        (IpAddr::Ip4(src), IpAddr::Ip4(dst)) => {
+            gen_icmpv4_echo_req(eth_src, eth_dst, src, dst, ident, seq_no, data)
+        }
+        (IpAddr::Ip6(src), IpAddr::Ip6(dst)) => {
+            gen_icmpv6_echo_req(eth_src, eth_dst, src, dst, ident, seq_no, data)
+        }
+        (_, _) => panic!("IP src and dst versions must match"),
+    }
+}
+
+pub fn gen_icmpv4_echo_req(
+    eth_src: MacAddr,
+    eth_dst: MacAddr,
+    ip_src: Ipv4Addr,
+    ip_dst: Ipv4Addr,
+    ident: u16,
+    seq_no: u16,
+    data: &[u8],
+) -> Packet<Parsed> {
+    let etype = IcmpEchoType::Req;
+    gen_icmp_echo(etype, eth_src, eth_dst, ip_src, ip_dst, ident, seq_no, data)
+}
+
+pub fn gen_icmp_echo_reply(
+    eth_src: MacAddr,
+    eth_dst: MacAddr,
+    ip_src: Ipv4Addr,
+    ip_dst: Ipv4Addr,
+    ident: u16,
+    seq_no: u16,
+    data: &[u8],
+) -> Packet<Parsed> {
+    let etype = IcmpEchoType::Reply;
+    gen_icmp_echo(etype, eth_src, eth_dst, ip_src, ip_dst, ident, seq_no, data)
+}
+
+pub fn gen_icmp_echo(
+    etype: IcmpEchoType,
+    eth_src: MacAddr,
+    eth_dst: MacAddr,
+    ip_src: Ipv4Addr,
+    ip_dst: Ipv4Addr,
+    ident: u16,
+    seq_no: u16,
+    data: &[u8],
+) -> Packet<Parsed> {
+    let icmp = match etype {
+        IcmpEchoType::Req => Icmpv4Repr::EchoRequest { ident, seq_no, data },
+        IcmpEchoType::Reply => Icmpv4Repr::EchoReply { ident, seq_no, data },
+    };
+    let mut icmp_bytes = vec![0u8; icmp.buffer_len()];
+    let mut icmp_pkt = Icmpv4Packet::new_unchecked(&mut icmp_bytes);
+    let _ = icmp.emit(&mut icmp_pkt, &Default::default());
+
+    let mut ip4 = Ipv4Hdr::from(&Ipv4Meta {
+        src: ip_src,
+        dst: ip_dst,
+        proto: Protocol::ICMP,
+    });
+    ip4.set_total_len(ip4.hdr_len() as u16 + icmp.buffer_len() as u16);
+    ip4.compute_hdr_csum();
+    let eth = EtherHdr::from(&EtherMeta {
+        dst: eth_dst,
+        src: eth_src,
+        ether_type: ETHER_TYPE_IPV4,
+    });
+
+    let mut pkt_bytes =
+        Vec::with_capacity(EtherHdr::SIZE + ip4.hdr_len() + icmp.buffer_len());
+    pkt_bytes.extend_from_slice(&eth.as_bytes());
+    pkt_bytes.extend_from_slice(&ip4.as_bytes());
+    pkt_bytes.extend_from_slice(&icmp_bytes);
+    Packet::copy(&pkt_bytes).parse().unwrap()
+}
+
+pub fn gen_icmpv6_echo_req(
+    eth_src: MacAddr,
+    eth_dst: MacAddr,
+    ip_src: Ipv6Addr,
+    ip_dst: Ipv6Addr,
+    ident: u16,
+    seq_no: u16,
+    data: &[u8],
+) -> Packet<Parsed> {
+    let req = Icmpv6Repr::EchoRequest { ident, seq_no, data };
+    let mut body_bytes = vec![0u8; req.buffer_len()];
+    let mut req_pkt = Icmpv6Packet::new_unchecked(&mut body_bytes);
+    let _ = req.emit(
+        &Ipv6Address::from_bytes(&ip_src).into(),
+        &Ipv6Address::from_bytes(&ip_dst).into(),
+        &mut req_pkt,
+        &Default::default(),
+    );
+    let mut ip6 = Ipv6Hdr::from(&Ipv6Meta {
+        src: ip_src,
+        dst: ip_dst,
+        proto: Protocol::ICMPv6,
+    });
+    ip6.set_total_len(ip6.hdr_len() as u16 + req.buffer_len() as u16);
+    let eth = EtherHdr::from(&EtherMeta {
+        dst: eth_dst,
+        src: eth_src,
+        ether_type: ETHER_TYPE_IPV6,
+    });
+
+    let mut pkt_bytes =
+        Vec::with_capacity(EtherHdr::SIZE + ip6.hdr_len() + req.buffer_len());
+    pkt_bytes.extend_from_slice(&eth.as_bytes());
+    pkt_bytes.extend_from_slice(&ip6.as_bytes());
+    pkt_bytes.extend_from_slice(&body_bytes);
+    Packet::copy(&pkt_bytes).parse().unwrap()
+}

--- a/oxide-vpc/tests/common/mod.rs
+++ b/oxide-vpc/tests/common/mod.rs
@@ -1,0 +1,118 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Common routines for integration tests.
+
+pub mod icmp;
+pub mod pcap;
+pub mod port_state;
+
+use opte::api::MacAddr;
+use opte::engine::checksum::HeaderChecksum;
+use opte::engine::ether::EtherHdr;
+use opte::engine::ether::EtherType;
+use opte::engine::headers::IpHdr;
+use opte::engine::headers::UlpHdr;
+use opte::engine::ip4::Ipv4Addr;
+use opte::engine::ip4::Ipv4Hdr;
+use opte::engine::ip4::UlpCsumOpt;
+use opte::engine::packet::Packet;
+use opte::engine::packet::Parsed;
+use opte::engine::tcp::TcpFlags;
+use opte::engine::tcp::TcpHdr;
+use oxide_vpc::api::VpcCfg;
+
+// This is the MAC address that OPTE uses to act as the virtual gateway.
+pub const GW_MAC_ADDR: MacAddr =
+    MacAddr::from_const([0xA8, 0x40, 0x25, 0xFF, 0x77, 0x77]);
+
+pub fn ulp_pkt<I: Into<IpHdr>, U: Into<UlpHdr>>(
+    eth: EtherHdr,
+    ip: I,
+    ulp: U,
+    body: &[u8],
+) -> Packet<Parsed> {
+    let mut bytes = vec![];
+    bytes.extend_from_slice(&eth.as_bytes());
+    bytes.extend_from_slice(&ip.into().as_bytes());
+    bytes.extend_from_slice(&ulp.into().as_bytes());
+    bytes.extend_from_slice(&body);
+    Packet::copy(&bytes).parse().unwrap()
+}
+
+// Generate a packet representing the start of a TCP handshake for a
+// telnet session from src to dst.
+pub fn tcp_telnet_syn(src: &VpcCfg, dst: &VpcCfg) -> Packet<Parsed> {
+    let body = vec![];
+    let mut tcp = TcpHdr::new(7865, 23);
+    tcp.set_flags(TcpFlags::SYN);
+    tcp.set_seq(4224936861);
+    let mut ip4 = Ipv4Hdr::new_tcp(
+        &mut tcp,
+        &body,
+        src.ipv4_cfg().unwrap().private_ip,
+        dst.ipv4_cfg().unwrap().private_ip,
+    );
+    ip4.compute_hdr_csum();
+    let tcp_csum =
+        ip4.compute_ulp_csum(UlpCsumOpt::Full, &tcp.as_bytes(), &body);
+    tcp.set_csum(HeaderChecksum::from(tcp_csum).bytes());
+    let eth = EtherHdr::new(EtherType::Ipv4, src.private_mac, src.gateway_mac);
+    ulp_pkt(eth, ip4, tcp, &body)
+}
+
+// Generate a packet representing the start of a TCP handshake for an
+// HTTP request from src to dst.
+pub fn http_tcp_syn(src: &VpcCfg, dst: &VpcCfg) -> Packet<Parsed> {
+    http_tcp_syn2(
+        src.private_mac,
+        src.ipv4_cfg().unwrap().private_ip,
+        dst.ipv4_cfg().unwrap().private_ip,
+    )
+}
+
+// Generate a packet representing the start of a TCP handshake for an
+// HTTP request from src to dst.
+pub fn http_tcp_syn2(
+    eth_src: MacAddr,
+    ip_src: Ipv4Addr,
+    ip_dst: Ipv4Addr,
+) -> Packet<Parsed> {
+    let body = vec![];
+    let mut tcp = TcpHdr::new(44490, 80);
+    tcp.set_flags(TcpFlags::SYN);
+    tcp.set_seq(2382112979);
+    let mut ip4 = Ipv4Hdr::new_tcp(&mut tcp, &body, ip_src, ip_dst);
+    ip4.compute_hdr_csum();
+    let tcp_csum =
+        ip4.compute_ulp_csum(UlpCsumOpt::Full, &tcp.as_bytes(), &body);
+    tcp.set_csum(HeaderChecksum::from(tcp_csum).bytes());
+    // Any packet from the guest is always addressed to the gateway.
+    let eth = EtherHdr::new(EtherType::Ipv4, eth_src, GW_MAC_ADDR);
+    ulp_pkt(eth, ip4, tcp, &body)
+}
+
+// Generate a packet representing the SYN+ACK reply to `http_tcp_syn()`,
+// from g1 to g2.
+pub fn http_tcp_syn_ack(src: &VpcCfg, dst: &VpcCfg) -> Packet<Parsed> {
+    let body = vec![];
+    let mut tcp = TcpHdr::new(80, 44490);
+    tcp.set_flags(TcpFlags::SYN | TcpFlags::ACK);
+    tcp.set_seq(44161351);
+    tcp.set_ack(2382112980);
+    let mut ip4 = Ipv4Hdr::new_tcp(
+        &mut tcp,
+        &body,
+        src.ipv4_cfg().unwrap().private_ip,
+        dst.ipv4_cfg().unwrap().private_ip,
+    );
+    ip4.compute_hdr_csum();
+    let tcp_csum =
+        ip4.compute_ulp_csum(UlpCsumOpt::Full, &tcp.as_bytes(), &body);
+    tcp.set_csum(HeaderChecksum::from(tcp_csum).bytes());
+    let eth = EtherHdr::new(EtherType::Ipv4, src.private_mac, src.gateway_mac);
+    ulp_pkt(eth, ip4, tcp, &body)
+}

--- a/oxide-vpc/tests/common/pcap.rs
+++ b/oxide-vpc/tests/common/pcap.rs
@@ -1,0 +1,77 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Routines for building packet capture files.
+
+use opte::engine::packet::*;
+use pcap_parser::pcap;
+use pcap_parser::pcap::LegacyPcapBlock;
+use pcap_parser::pcap::PcapHeader;
+use pcap_parser::Linktype;
+use pcap_parser::ToVec;
+use std::fs::File;
+use std::io::Write;
+
+#[allow(dead_code)]
+fn get_header(offset: &[u8]) -> (&[u8], PcapHeader) {
+    match pcap::parse_pcap_header(offset) {
+        Ok((new_offset, header)) => (new_offset, header),
+        Err(e) => panic!("failed to get header: {:?}", e),
+    }
+}
+
+#[allow(dead_code)]
+fn next_block(offset: &[u8]) -> (&[u8], LegacyPcapBlock) {
+    match pcap::parse_pcap_frame(offset) {
+        Ok((new_offset, block)) => {
+            // We always want access to the entire packet.
+            assert_eq!(block.origlen, block.caplen);
+            (new_offset, block)
+        }
+
+        Err(e) => panic!("failed to get next block: {:?}", e),
+    }
+}
+
+/// Build a packet capture file from a series of [`Packet<T>`].
+pub struct PcapBuilder {
+    file: File,
+}
+
+impl PcapBuilder {
+    /// Create a new pcap builder, writing all captures to `path`.
+    pub fn new(path: &str) -> Self {
+        let mut file = File::create(path).unwrap();
+
+        let mut hdr = PcapHeader {
+            magic_number: 0xa1b2c3d4,
+            version_major: 2,
+            version_minor: 4,
+            thiszone: 0,
+            sigfigs: 0,
+            snaplen: 1500,
+            network: Linktype::ETHERNET,
+        };
+
+        file.write_all(&hdr.to_vec().unwrap()).unwrap();
+
+        Self { file }
+    }
+
+    /// Add a packet to the capture.
+    pub fn add_pkt(&mut self, pkt: &Packet<Parsed>) {
+        let pkt_bytes = PacketReader::new(&pkt, ()).copy_remaining();
+        let mut block = LegacyPcapBlock {
+            ts_sec: 7777,
+            ts_usec: 7777,
+            caplen: pkt_bytes.len() as u32,
+            origlen: pkt_bytes.len() as u32,
+            data: &pkt_bytes,
+        };
+
+        self.file.write_all(&block.to_vec().unwrap()).unwrap();
+    }
+}

--- a/oxide-vpc/tests/common/port_state.rs
+++ b/oxide-vpc/tests/common/port_state.rs
@@ -1,0 +1,292 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Routines for verifying various Port state.
+
+use opte::engine::port::PortState;
+use std::collections::BTreeMap;
+
+/// Track various bits of Port state for the purpose of verifying
+/// certain events occur when traffic crosses the port or an
+/// administration command is procssed. This type should be
+/// manipulated by the macros that follow.
+///
+/// # Counts
+///
+/// Each entry in the `counts` map represents some type of particular
+/// port state which has a count associated with it. When a port's
+/// overall state is asserted we make sure that its internal state
+/// matches these counts.
+///
+/// `<layer>.rules_{in,out}`: The expected number of rules in a given
+/// direction in a given layer. This does not apply to the UFT, as
+/// it's just a flow table, there are no rules.
+///
+/// `<layer>.flows_{in,out}`: The expected number of entries in the
+/// flow table in a given direction in a given layer. The number of
+/// UFT flows is stored under `uft.flows_{in,out}`.
+///
+/// # Epoch
+///
+/// Tracks the current `epoch` value of the port.
+///
+/// # Port State
+///
+/// This tracks the current `PortState` value of the port.
+///
+/// NOTE: This word state is a bit overloaded here. The purpose of
+/// VpcPortState is to track the overall state of the Port, where
+/// `PortState` is just one piece of that overall state.
+pub struct VpcPortState {
+    pub counts: BTreeMap<String, u32>,
+    pub epoch: u64,
+    pub port_state: PortState,
+}
+
+impl VpcPortState {
+    pub fn new() -> Self {
+        Self {
+            counts: BTreeMap::from(
+                [
+                    ("arp.rules_in", 0),
+                    ("arp.rules_out", 0),
+                    ("fw.flows_in", 0),
+                    ("fw.flows_out", 0),
+                    ("fw.rules_in", 0),
+                    ("fw.rules_out", 0),
+                    ("icmp.rules_in", 0),
+                    ("icmp.rules_out", 0),
+                    ("nat.flows_in", 0),
+                    ("nat.flows_out", 0),
+                    ("nat.rules_in", 0),
+                    ("nat.rules_out", 0),
+                    ("router.rules_in", 0),
+                    ("router.rules_out", 0),
+                    ("uft.flows_in", 0),
+                    ("uft.flows_out", 0),
+                ]
+                .map(|(name, val)| (name.to_string(), val)),
+            ),
+            epoch: 1,
+            port_state: PortState::Ready,
+        }
+    }
+}
+
+/// Assert that the port's current overall state matches the expected
+/// state stored in the VpcPortState.
+#[macro_export]
+macro_rules! assert_port {
+    ($pav:expr) => {
+        for (field, expected_val) in $pav.vps.counts.iter() {
+            let actual_val = match field.as_str() {
+                "arp.rules_in" => $pav.port.num_rules("arp", In),
+                "arp.rules_out" => $pav.port.num_rules("arp", Out),
+                "fw.flows_in" => $pav.port.num_flows("firewall", In),
+                "fw.flows_out" => $pav.port.num_flows("firewall", Out),
+                "fw.rules_in" => $pav.port.num_rules("firewall", In),
+                "fw.rules_out" => $pav.port.num_rules("firewall", Out),
+                "icmp.rules_in" => $pav.port.num_rules("icmp", In),
+                "icmp.rules_out" => $pav.port.num_rules("icmp", Out),
+                "nat.flows_in" => $pav.port.num_flows("nat", In),
+                "nat.flows_out" => $pav.port.num_flows("nat", Out),
+                "nat.rules_in" => $pav.port.num_rules("nat", In),
+                "nat.rules_out" => $pav.port.num_rules("nat", Out),
+                "router.rules_in" => $pav.port.num_rules("router", In),
+                "router.rules_out" => $pav.port.num_rules("router", Out),
+                "uft.flows_in" => $pav.port.num_flows("uft", In),
+                "uft.flows_out" => $pav.port.num_flows("uft", Out),
+                f => todo!("implement check for field: {}", f),
+            };
+            assert!(
+                *expected_val == actual_val,
+                "field value mismatch: field: {}, expected: {}, actual: {}",
+                field,
+                expected_val,
+                actual_val,
+            );
+        }
+
+        {
+            let expected = $pav.vps.epoch;
+            let actual = $pav.port.epoch();
+            assert!(
+                expected == actual,
+                "epoch mismatch: expected: {}, actual: {}",
+                expected,
+                actual,
+            );
+        }
+
+        {
+            let expected = $pav.vps.port_state;
+            let actual = $pav.port.state();
+            assert!(
+                expected == actual,
+                "port state mismatch: expected: {}, actual: {}",
+                expected,
+                actual,
+            );
+        }
+    };
+}
+
+/// Increment a field in the `VpcPortState.counts` map.
+#[macro_export]
+macro_rules! incr_field {
+    ($vps:expr, $field:expr) => {
+        match $vps.counts.get_mut($field) {
+            Some(v) => *v += 1,
+            None => assert!(false, "field does not exist: {}", $field),
+        }
+    };
+}
+
+/// Decrement a field in the `VpcPortState.counts` map.
+#[macro_export]
+macro_rules! decr_field {
+    ($vps:expr, $field:expr) => {
+        match $vps.counts.get_mut($field) {
+            Some(v) => *v -= 1,
+            None => assert!(false, "field does not exist: {}", $field),
+        }
+    };
+}
+
+/// Increment a list of fields in the `VpcPortState.counts` map.
+#[macro_export]
+macro_rules! incr_na {
+    ($port_and_vps:expr, $fields:expr) => {
+        for f in $fields {
+            match f {
+                "epoch" => $port_and_vps.vps.epoch += 1,
+                _ => incr_field!($port_and_vps.vps, f),
+            }
+        }
+    };
+}
+
+/// Increment a list of fields in the `VpcPortState.counts` map and
+/// assert the port state.
+#[macro_export]
+macro_rules! incr {
+    ($port_and_vps:expr, $fields:expr) => {
+        incr_na!($port_and_vps, $fields);
+        assert_port!($port_and_vps);
+    };
+}
+
+/// Decrement a list of fields in the `VpcPortState.counts` map.
+#[macro_export]
+macro_rules! decr_na {
+    ($port_and_vps:expr, $fields:expr) => {
+        for f in $fields {
+            match f {
+                // You can never decrement the epoch.
+                _ => decr_field!($port_and_vps.vps, f),
+            }
+        }
+    };
+}
+
+/// Set the value of a field in the `VpcPortState.counts` map.
+#[macro_export]
+macro_rules! set_field {
+    ($port_and_vps:expr, $field:expr, $val:expr) => {
+        match $port_and_vps.vps.counts.get_mut($field) {
+            Some(v) => *v = $val,
+            None => assert!(false, "field does not exist: {}", $field),
+        }
+    };
+}
+
+/// Set multiple fields at once.
+///
+/// ```
+/// set_fields!(pav, "epcoh=M,fw.rules_in=N");
+/// ```
+#[macro_export]
+macro_rules! set_fields {
+    ($port_and_vps:expr, $fields:expr) => {
+        for f in $fields {
+            match f.split_once("=") {
+                Some(("epoch", val)) => {
+                    $port_and_vps.vps.epoch += val.parse::<u64>().unwrap();
+                }
+
+                Some((field, val)) => {
+                    set_field!($port_and_vps, field, val.parse().unwrap());
+                }
+
+                _ => panic!("malformed field expr: {}", f),
+            }
+        }
+    };
+}
+
+/// Update the `VpcPortState` and assert.
+///
+/// ```
+/// update!(g1, ["incr:epoch,fw.flows_out,fw.flows_in,uft.flows_out"])
+/// ```
+#[macro_export]
+macro_rules! update {
+    ($port_and_vps:expr, $instructions:expr) => {
+        for inst in $instructions {
+            match inst.split_once(":") {
+                Some(("incr", fields)) => {
+                    // Convert "field1,field2,field3" to ["field1",
+                    // "field2, "field3"]
+                    let fields_arr: Vec<&str> = fields.split(",").collect();
+                    incr_na!($port_and_vps, fields_arr);
+                }
+
+                Some(("set", fields)) => {
+                    let fields_arr: Vec<&str> = fields.split(",").collect();
+                    set_fields!($port_and_vps, fields_arr);
+                }
+
+                Some(("decr", fields)) => {
+                    let fields_arr: Vec<&str> = fields.split(",").collect();
+                    decr_na!($port_and_vps, fields_arr);
+                }
+
+                Some((op, _)) => {
+                    panic!("unknown op: {} instruction: {}", op, inst);
+                }
+
+                _ => panic!("malformed instruction: {}", inst),
+            }
+        }
+
+        assert_port!($port_and_vps);
+    };
+}
+
+/// Set all flow counts to zero.
+#[macro_export]
+macro_rules! zero_flows {
+    ($port_and_vps:expr) => {
+        for (field, count) in $port_and_vps.vps.counts.iter_mut() {
+            match field.as_str() {
+                "fw.flows_in" | "fw.flows_out" => *count = 0,
+                "nat.flows_in" | "nat.flows_out" => *count = 0,
+                "router.flows_in" | "router.flows_out" => *count = 0,
+                "uft.flows_in" | "uft.flows_out" => *count = 0,
+                &_ => (),
+            }
+        }
+    };
+}
+
+/// Set the expected PortState of the port and assert.
+#[macro_export]
+macro_rules! set_state {
+    ($port_and_vps:expr, $port_state:expr) => {
+        $port_and_vps.vps.port_state = $port_state;
+        assert_port!($port_and_vps);
+    };
+}


### PR DESCRIPTION
Start moving some of the shared routines used in the integration tests to a common module. There's still more to move, but this is a good start.