### PR TITLE
Print port state on test failure

### DIFF
--- a/opte/src/engine/ioctl.rs
+++ b/opte/src/engine/ioctl.rs
@@ -90,12 +90,12 @@ pub struct DumpUftReq {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct DumpUftResp {
-    pub uft_in_limit: u32,
-    pub uft_in_num_flows: u32,
-    pub uft_in: Vec<(InnerFlowId, FlowEntryDump)>,
-    pub uft_out_limit: u32,
-    pub uft_out_num_flows: u32,
-    pub uft_out: Vec<(InnerFlowId, FlowEntryDump)>,
+    pub in_limit: u32,
+    pub in_num_flows: u32,
+    pub in_flows: Vec<(InnerFlowId, FlowEntryDump)>,
+    pub out_limit: u32,
+    pub out_num_flows: u32,
+    pub out_flows: Vec<(InnerFlowId, FlowEntryDump)>,
 }
 
 impl CmdOk for DumpUftResp {}

--- a/opte/src/engine/mod.rs
+++ b/opte/src/engine/mod.rs
@@ -29,6 +29,8 @@ pub mod nat;
 #[macro_use]
 pub mod packet;
 pub mod port;
+#[cfg(any(feature = "std", test))]
+pub mod print;
 pub mod rule;
 pub mod snat;
 #[macro_use]

--- a/opte/src/engine/port.rs
+++ b/opte/src/engine/port.rs
@@ -805,21 +805,21 @@ impl Port {
             [PortState::Running, PortState::Paused, PortState::Restored],
         )?;
 
-        let uft_in_limit = data.uft_in.get_limit().get();
-        let uft_in_num_flows = data.uft_in.num_flows();
-        let uft_in = data.uft_in.dump();
+        let in_limit = data.uft_in.get_limit().get();
+        let in_num_flows = data.uft_in.num_flows();
+        let in_flows = data.uft_in.dump();
 
-        let uft_out_limit = data.uft_out.get_limit().get();
-        let uft_out_num_flows = data.uft_out.num_flows();
-        let uft_out = data.uft_out.dump();
+        let out_limit = data.uft_out.get_limit().get();
+        let out_num_flows = data.uft_out.num_flows();
+        let out_flows = data.uft_out.dump();
 
         Ok(ioctl::DumpUftResp {
-            uft_in_limit,
-            uft_in_num_flows,
-            uft_in,
-            uft_out_limit,
-            uft_out_num_flows,
-            uft_out,
+            in_limit,
+            in_num_flows,
+            in_flows,
+            out_limit,
+            out_num_flows,
+            out_flows,
         })
     }
 

--- a/opte/src/engine/print.rs
+++ b/opte/src/engine/print.rs
@@ -1,0 +1,154 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Print comannd responses in human-friendly manner.
+//!
+//! This is mostly just a place to hang printing routines so that they
+//! can be used by both opteadm and integration tests.
+
+use super::flow_table::FlowEntryDump;
+use super::ioctl::DumpLayerResp;
+use super::ioctl::DumpUftResp;
+use super::ioctl::ListLayersResp;
+use super::packet::InnerFlowId;
+use opte::engine::rule::RuleDump;
+use std::string::String;
+use std::string::ToString;
+use std::vec::Vec;
+
+/// Print a [`DumpLayerResp`].
+pub fn print_layer(resp: &DumpLayerResp) {
+    println!("Layer {}", resp.name);
+    print_hrb();
+    println!("Inbound Flows");
+    print_hr();
+    print_flow_header();
+    for (flow_id, flow_state) in &resp.ft_in {
+        print_flow(flow_id, flow_state);
+    }
+
+    println!("\nOutbound Flows");
+    print_hr();
+    print_flow_header();
+    for (flow_id, flow_state) in &resp.ft_out {
+        print_flow(flow_id, flow_state);
+    }
+
+    println!("\nInbound Rules");
+    print_hr();
+    print_rule_header();
+    for (id, rule) in &resp.rules_in {
+        print_rule(*id, rule);
+    }
+
+    println!("\nOutbound Rules");
+    print_hr();
+    print_rule_header();
+    for (id, rule) in &resp.rules_out {
+        print_rule(*id, rule);
+    }
+
+    println!("");
+}
+
+/// Print a [`ListLayersResp`].
+pub fn print_list_layers(resp: &ListLayersResp) {
+    println!(
+        "{:<12} {:<10} {:<10} {:<10}",
+        "NAME", "RULES IN", "RULES OUT", "FLOWS",
+    );
+
+    for desc in &resp.layers {
+        println!(
+            "{:<12} {:<10} {:<10} {:<10}",
+            desc.name, desc.rules_in, desc.rules_out, desc.flows,
+        );
+    }
+}
+
+/// Print a [`DumpUftResp`].
+pub fn print_uft(uft: &DumpUftResp) {
+    println!("UFT Inbound: {}/{}", uft.in_num_flows, uft.in_limit);
+    print_hr();
+    print_flow_header();
+    for (flow_id, flow_state) in &uft.in_flows {
+        print_flow(flow_id, flow_state);
+    }
+
+    println!("");
+    println!("UFT Outbound: {}/{}", uft.out_num_flows, uft.out_limit);
+    print_hr();
+    print_flow_header();
+    for (flow_id, flow_state) in &uft.out_flows {
+        print_flow(flow_id, flow_state);
+    }
+}
+
+/// Print the header for the [`print_rule()`] output.
+pub fn print_rule_header() {
+    println!("{:<8} {:<6} {:<48} {:<18}", "ID", "PRI", "PREDICATES", "ACTION");
+}
+
+/// Print a [`RuleDump`].
+pub fn print_rule(id: u64, rule: &RuleDump) {
+    let hdr_preds = rule
+        .predicates
+        .iter()
+        .map(|p| p.to_string())
+        .collect::<Vec<String>>()
+        .join(" ");
+
+    let data_preds = rule
+        .data_predicates
+        .iter()
+        .map(|p| p.to_string())
+        .collect::<Vec<String>>()
+        .join(" ");
+
+    let mut preds = format!("{} {}", hdr_preds, data_preds);
+
+    if preds == "" {
+        preds = "*".to_string();
+    }
+
+    println!("{:<8} {:<6} {:<48} {:<?}", id, rule.priority, preds, rule.action);
+}
+
+/// Print the header for the [`print_flow()`] output.
+pub fn print_flow_header() {
+    println!(
+        "{:<6} {:<16} {:<6} {:<16} {:<6} {:<8} {:<22}",
+        "PROTO", "SRC IP", "SPORT", "DST IP", "DPORT", "HITS", "ACTION"
+    );
+}
+
+/// Print information about a flow.
+pub fn print_flow(flow_id: &InnerFlowId, flow_entry: &FlowEntryDump) {
+    // For those types with custom Display implementations
+    // we need to first format in into a String before
+    // passing it to println in order for the format
+    // specification to be honored.
+    println!(
+        "{:<6} {:<16} {:<6} {:<16} {:<6} {:<8} {:<22}",
+        flow_id.proto.to_string(),
+        flow_id.src_ip.to_string(),
+        flow_id.src_port,
+        flow_id.dst_ip.to_string(),
+        flow_id.dst_port,
+        flow_entry.hits,
+        flow_entry.state_summary,
+    );
+}
+
+/// Print horizontal rule in bold.
+pub fn print_hrb() {
+    println!("{:=<70}", "=");
+}
+
+/// Print horizontal rule.
+pub fn print_hr() {
+    println!("{:-<70}", "-");
+}

--- a/oxide-vpc/src/api.rs
+++ b/oxide-vpc/src/api.rs
@@ -201,6 +201,12 @@ impl VpcCfg {
         }
     }
 
+    #[cfg(any(feature = "test-help", test))]
+    /// Return the physical address of the guest.
+    pub fn phys_addr(&self) -> PhysNet {
+        PhysNet { ether: self.private_mac, ip: self.phys_ip, vni: self.vni }
+    }
+
     #[cfg(not(any(feature = "test-help", test)))]
     /// Return the IPv4 SNAT config, if it exists.
     pub fn snat(&self) -> Option<&SNat4Cfg> {

--- a/oxide-vpc/src/engine/mod.rs
+++ b/oxide-vpc/src/engine/mod.rs
@@ -12,4 +12,6 @@ pub mod icmp;
 pub mod icmpv6;
 pub mod nat;
 pub mod overlay;
+#[cfg(any(feature = "std", test))]
+pub mod print;
 pub mod router;

--- a/oxide-vpc/src/engine/print.rs
+++ b/oxide-vpc/src/engine/print.rs
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2022 Oxide Computer Company
+
+//! Functions for printing comannd responses.
+//!
+//! This is mostly just a place to hang printing routines so that they
+//! can be used by both opteadm and integration tests.
+
+use crate::api::GuestPhysAddr;
+use crate::api::Ipv4Addr;
+use crate::api::Ipv6Addr;
+use crate::engine::overlay::DumpVirt2PhysResp;
+use opte::engine::print::*;
+
+/// Print the header for the [`print_v2p()`] output.
+fn print_v2p_header() {
+    println!("{:<24} {:<17} {}", "VPC IP", "VPC MAC ADDR", "UNDERLAY IP");
+}
+
+/// Print a [`DumpVirt2PhysResp`].
+pub fn print_v2p(resp: &DumpVirt2PhysResp) {
+    println!("Virtual to Physical Mappings");
+    print_hrb();
+    for vpc in &resp.mappings {
+        println!("");
+        println!("VPC {}", vpc.vni);
+        print_hr();
+        println!("");
+        println!("IPv4 mappings");
+        print_hr();
+        print_v2p_header();
+        for pair in &vpc.ip4 {
+            print_v2p_ip4(pair);
+        }
+
+        println!("");
+        println!("IPv6 mappings");
+        print_hr();
+        print_v2p_header();
+        for pair in &vpc.ip6 {
+            print_v2p_ip6(pair);
+        }
+    }
+}
+
+fn print_v2p_ip4((src, phys): &(Ipv4Addr, GuestPhysAddr)) {
+    let eth = format!("{}", phys.ether);
+    println!(
+        "{:<24} {:<17} {}",
+        std::net::Ipv4Addr::from(src.bytes()),
+        eth,
+        std::net::Ipv6Addr::from(phys.ip.bytes()),
+    );
+}
+
+fn print_v2p_ip6((src, phys): &(Ipv6Addr, GuestPhysAddr)) {
+    let eth = format!("{}", phys.ether);
+    println!(
+        "{:<24} {:<17} {}",
+        std::net::Ipv6Addr::from(src.bytes()),
+        eth,
+        std::net::Ipv6Addr::from(phys.ip.bytes()),
+    );
+}


### PR DESCRIPTION
When an integration test fails, it's useful to have the various Port state printed in a human-friendly manner, similar to how one would inspect the port with opteadm.

In order to avoid duplicated code we move the print routines into their respective crates so that they may be shared by both the integration test as well as opteadm.

I also modified the integration test to create a global VpcMappings, just like xde currently does. This keeps it closer to how xde currently works and also reduces the amount of code one needs to write per test.