### PR TITLE
Bring router::add_entry into common setup

### DIFF
--- a/oxide-vpc/src/engine/router.rs
+++ b/oxide-vpc/src/engine/router.rs
@@ -257,6 +257,10 @@ fn make_rule(
     Ok(rule.finalize())
 }
 
+/// Delete a router entry.
+///
+/// For the entry to be deleted it must match exactly for the
+/// destination [`IpCidr`] as well as its paired [`RouterTarget`].
 pub fn del_entry(
     port: &Port,
     dest: IpCidr,
@@ -274,6 +278,9 @@ pub fn del_entry(
     }
 }
 
+/// Add a router entry.
+///
+/// Route the [`IpCidr`] to the specified [`RouterTarget`].
 pub fn add_entry(
     port: &Port,
     dest: IpCidr,
@@ -281,6 +288,20 @@ pub fn add_entry(
 ) -> Result<NoResp, OpteError> {
     let rule = make_rule(dest, target)?;
     port.add_rule(ROUTER_LAYER_NAME, Direction::Out, rule)?;
+    Ok(NoResp::default())
+}
+
+/// Replace the current set of router entries with the set passed in.
+pub fn replace(
+    port: &Port,
+    entries: Vec<(IpCidr, RouterTarget)>,
+) -> Result<NoResp, OpteError> {
+    let mut out_rules = Vec::with_capacity(entries.len());
+    for (cidr, target) in entries {
+        out_rules.push(make_rule(cidr, target)?);
+    }
+
+    port.set_rules(ROUTER_LAYER_NAME, vec![], out_rules)?;
     Ok(NoResp::default())
 }
 

--- a/oxide-vpc/tests/common/mod.rs
+++ b/oxide-vpc/tests/common/mod.rs
@@ -124,3 +124,15 @@ pub fn http_tcp_syn_ack(src: &VpcCfg, dst: &VpcCfg) -> Packet<Parsed> {
     let eth = EtherHdr::new(EtherType::Ipv4, src.private_mac, src.gateway_mac);
     ulp_pkt(eth, ip4, tcp, &body)
 }
+
+/// Like `assert!`, except you also pass in the `PortAndVps` so that
+/// the port state is printed on failure.
+#[macro_export]
+macro_rules! chk {
+    ($pav:expr, $check:expr) => {
+        if !$check {
+            print_port(&$pav.port, &$pav.vpc_map);
+            panic!("assertion failed: {}", stringify!($check));
+        }
+    };
+}

--- a/oxide-vpc/tests/common/port_state.rs
+++ b/oxide-vpc/tests/common/port_state.rs
@@ -19,7 +19,12 @@ pub fn print_port(port: &Port, vpc_map: &VpcMappings) {
     print_v2p(&vpc_map.dump());
     println!("");
 
-    println!("Port: {} [{}]", port.name(), port.state());
+    println!(
+        "Port: {} [state: {}, epoch: {}]",
+        port.name(),
+        port.state(),
+        port.epoch()
+    );
     print_hrb();
 
     println!("");


### PR DESCRIPTION
For most tests, we want the gust to have a route to other guests in its subnet. Move the router::add_entry() call to the common setup, and replace routes for the tests that need a different setup.

Added a `chk!` macro. It's like `assert!` but takes the additional PortAndVps argument so that the port state is printed on failure.

Added `router::replace()` API to allow replacing all routes for a guest in one, atomic operation.

Removed `check_no_flows()` which was obsoleted by the `VpcPortState` mechanism.