### PR TITLE
Add notion of default action

### DIFF
--- a/oxide-vpc/src/engine/firewall.rs
+++ b/oxide-vpc/src/engine/firewall.rs
@@ -29,7 +29,9 @@ use crate::api::RemFwRuleReq;
 use crate::api::SetFwRulesReq;
 use opte::api::Direction;
 use opte::api::OpteError;
+use opte::engine::layer::DefaultAction;
 use opte::engine::layer::Layer;
+use opte::engine::layer::LayerActions;
 use opte::engine::packet::InnerFlowId;
 use opte::engine::packet::Packet;
 use opte::engine::packet::Parsed;
@@ -168,7 +170,15 @@ impl Firewall {
             "fw".to_string(),
         )));
 
-        Layer::new(FW_LAYER_NAME, port_name, vec![allow], ft_limit)
+        // The firewall layer is meant as a filtering layer, and thus
+        // denies all traffic by default.
+        let actions = LayerActions {
+            actions: vec![allow],
+            default_in: DefaultAction::Deny,
+            default_out: DefaultAction::Deny,
+        };
+
+        Layer::new(FW_LAYER_NAME, port_name, actions, ft_limit)
     }
 }
 

--- a/oxide-vpc/src/engine/overlay.rs
+++ b/oxide-vpc/src/engine/overlay.rs
@@ -48,7 +48,9 @@ use opte::engine::headers::IpAddr;
 use opte::engine::ip4::Protocol;
 use opte::engine::ip6::Ipv6Addr;
 use opte::engine::ip6::Ipv6Meta;
+use opte::engine::layer::DefaultAction;
 use opte::engine::layer::Layer;
+use opte::engine::layer::LayerActions;
 use opte::engine::packet::InnerFlowId;
 use opte::engine::port::meta::ActionMeta;
 use opte::engine::port::meta::ActionMetaValue;
@@ -86,8 +88,14 @@ pub fn setup(
     // Action Index 1
     let decap = Action::Static(Arc::new(DecapAction::new()));
 
+    let actions = LayerActions {
+        actions: vec![encap, decap],
+        default_in: DefaultAction::Deny,
+        default_out: DefaultAction::Deny,
+    };
+
     let mut layer =
-        Layer::new(OVERLAY_LAYER_NAME, pb.name(), vec![encap, decap], ft_limit);
+        Layer::new(OVERLAY_LAYER_NAME, pb.name(), actions, ft_limit);
     let encap_rule = Rule::match_any(1, layer.action(0).unwrap().clone());
     layer.add_rule(Direction::Out, encap_rule);
     let decap_rule = Rule::match_any(1, layer.action(1).unwrap().clone());


### PR DESCRIPTION
Add the notion of a default action to a layer. In many cases, a layer is acting as either a filtering layer or a rewrite layer. A filtering layer provides an allow list of packets that may pass its boundary. A rewrite layer is meant to rewrite packets that match certain criteria, but otherwise let the packet pass untouched.

A default action specifies the action to take if a packet matches no rule in the layer. The default action can be that of allow or deny. Up to this point we've had an implicit default of allow, requiring filtering layers to maintain a rule denying any traffic that doesn't match the allow list. This mechanism for filtering was brittle because you have to remember to keep the deny rule in place. However, when allowing a control plane to replace all rules en masse it is easy to lose this rule by accident. By having the ability to specify a default action of deny, we can more easily make sure filtering layers (e.g. a firewall or router) do their job.

This work was spurred by my fear of losing the deny rule for the outbound side of the routing layer. It felt brittle (and odd) that it would be up to the control plane to write a rule to drop traffic going to the any address (`0.0.0.0/0`) if there is no IG for the given interface, especially since such a rule is not logically part of the API described by RFD 21. That is, the assumption in a router is that if there is no match, then there is no route, and the packet must be dropped. It feels weird to have control plane insert this an drop rule in the absence of an IG. This could also be done in the API offered by oxide-vpc, but that also felt just as odd and brittle. Instead, it felt best to have a default action.

While here I also added a reason value to the layer deny result.