### PR TITLE
Implement UFT pairing

### DIFF
--- a/opte/src/engine/headers.rs
+++ b/opte/src/engine/headers.rs
@@ -402,11 +402,29 @@ impl UlpHdr {
 }
 
 #[derive(
-    Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
+    Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
 )]
 pub enum UlpMeta {
     Tcp(TcpMeta),
     Udp(UdpMeta),
+}
+
+impl UlpMeta {
+    /// Return the destination port.
+    pub fn dst_port(&self) -> u16 {
+        match self {
+            Self::Tcp(tcp) => tcp.dst,
+            Self::Udp(udp) => udp.dst,
+        }
+    }
+
+    /// Return the source port.
+    pub fn src_port(&self) -> u16 {
+        match self {
+            Self::Tcp(tcp) => tcp.src,
+            Self::Udp(udp) => udp.src,
+        }
+    }
 }
 
 impl PushActionArg for UlpMeta {}

--- a/opte/src/engine/packet.rs
+++ b/opte/src/engine/packet.rs
@@ -2671,7 +2671,6 @@ mod test {
     use super::*;
     use crate::engine::ether::ETHER_TYPE_IPV4;
     use crate::engine::tcp::TcpFlags;
-    use crate::engine::tcp::TCP_HDR_SZ;
 
     const SRC_MAC: [u8; 6] = [0xa8, 0x40, 0x25, 0x00, 0x00, 0x63];
     const DST_MAC: [u8; 6] = [0x78, 0x23, 0xae, 0x5d, 0x4f, 0x0d];
@@ -2684,7 +2683,7 @@ mod test {
     const DST_IP6: [u8; 16] =
         [0xfd, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2];
 
-    const PKT_SZ: usize = EtherHdr::SIZE + Ipv4Hdr::SIZE + TCP_HDR_SZ;
+    const PKT_SZ: usize = EtherHdr::SIZE + Ipv4Hdr::SIZE + TcpHdr::BASE_SIZE;
 
     fn tcp_pkt(pkt: Packet<Uninitialized>) -> Packet<Initialized> {
         let body = vec![];
@@ -2700,7 +2699,10 @@ mod test {
         let _ = wtr.write(&ip4.as_bytes()).unwrap();
         assert_eq!(wtr.pos(), EtherHdr::SIZE + Ipv4Hdr::SIZE);
         let _ = wtr.write(&tcp.as_bytes()).unwrap();
-        assert_eq!(wtr.pos(), EtherHdr::SIZE + Ipv4Hdr::SIZE + TCP_HDR_SZ);
+        assert_eq!(
+            wtr.pos(),
+            EtherHdr::SIZE + Ipv4Hdr::SIZE + TcpHdr::BASE_SIZE
+        );
 
         let pkt = wtr.finish();
         assert_eq!(pkt.len(), PKT_SZ);
@@ -3008,11 +3010,17 @@ mod test {
         let tcp_bytes = &tcp.as_bytes();
         let _ = wtr.write(&tcp_bytes[0..12]).unwrap();
         let _ = wtr.write(&tcp_bytes[12..]).unwrap();
-        assert_eq!(wtr.pos(), EtherHdr::SIZE + Ipv4Hdr::SIZE + TCP_HDR_SZ);
+        assert_eq!(
+            wtr.pos(),
+            EtherHdr::SIZE + Ipv4Hdr::SIZE + TcpHdr::BASE_SIZE
+        );
 
         let pkt = wtr.finish();
 
-        assert_eq!(pkt.len(), EtherHdr::SIZE + Ipv4Hdr::SIZE + TCP_HDR_SZ);
+        assert_eq!(
+            pkt.len(),
+            EtherHdr::SIZE + Ipv4Hdr::SIZE + TcpHdr::BASE_SIZE
+        );
         assert_eq!(pkt.num_segs(), 2);
         assert!(matches!(pkt.parse(), Err(ParseError::BadHeader(_))));
     }

--- a/opte/src/engine/udp.rs
+++ b/opte/src/engine/udp.rs
@@ -39,7 +39,7 @@ cfg_if! {
 }
 
 #[derive(
-    Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
+    Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
 )]
 pub struct UdpMeta {
     pub src: u16,


### PR DESCRIPTION
Implement UFT pairing as described in VFP §6.4.1, with the exception of flow simulation, which isn't implemented yet. This pairing allows for better UFT invalidation logic and sets us up for truly handling asymmetric Unified Flow IDs (UFIDs) in the future.

I also wrote a pair of tests to make sure the UFT invalidation logic works. Though right now there exists a scenario where the outbound UFT entry will have a `pair` value of `None` even though an inbound UFT entry exists. This happens when the first packet for a flow arrives from the inbound direction, as it's only in the inbound direction that UFT entries can be paired, and we only perform this pairing when handling the first inbound packet. The reason pairing is only accomplished on inbound is because of the possibility of asymmetric UFIDs, as described in VFP §6.4.1. However, this current limitation does not technically cause any bugs in terms of traffic filtering, as the epoch mechanism will catch the stale, unpaired outbound entries and remove them. Once we have "simulation" of flows, this edge case goes away.

Other work
----------

* Added some convenience functions to UlpMeta.

* Changed TCP_HDR_SZ to TcpHdr::BASE_SIZE.

* Added some test functions for generating HTTP packets.

* Added some of the PortStats to the port_state verification macros.

* Modified incr! to take an array of strings be more consistent with update!.

* Make sure to clear action meta between process() calls (in the tests).