### PR TITLE
Add per-tcp-flow stats

### DIFF
--- a/opte/src/engine/ioctl.rs
+++ b/opte/src/engine/ioctl.rs
@@ -130,6 +130,10 @@ pub struct TcpFlowEntryDump {
     pub hits: u64,
     pub inbound_ufid: Option<InnerFlowId>,
     pub tcp_state: TcpFlowStateDump,
+    pub segs_in: u64,
+    pub segs_out: u64,
+    pub bytes_in: u64,
+    pub bytes_out: u64,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/opte/src/engine/print.rs
+++ b/opte/src/engine/print.rs
@@ -186,7 +186,10 @@ pub fn print_uft_flow(flow_id: &InnerFlowId, flow_entry: &UftEntryDump) {
 
 /// Print a [`DumpTcpFlowsResp`].
 pub fn print_tcp_flows(flows: &DumpTcpFlowsResp) {
-    println!("{:<48} {:<12} {:<8}", "FLOW", "STATE", "HITS");
+    println!(
+        "{:<48} {:<12} {:<8} {:<8} {:<8} {:<10} {:<10}",
+        "FLOW", "STATE", "HITS", "SEGS IN", "SEGS OUT", "BYTES IN", "BYTES OUT"
+    );
     for (flow_id, entry) in &flows.flows {
         print_tcp_flow(flow_id, entry);
     }
@@ -194,10 +197,14 @@ pub fn print_tcp_flows(flows: &DumpTcpFlowsResp) {
 
 fn print_tcp_flow(id: &InnerFlowId, entry: &TcpFlowEntryDump) {
     println!(
-        "{:<48} {:<12} {:<8}",
+        "{:<48} {:<12} {:<8} {:<8} {:<8} {:<10} {:<10}",
         format!("{id}"),
         entry.tcp_state.tcp_state.to_string(),
-        entry.hits
+        entry.hits,
+        entry.segs_in,
+        entry.segs_out,
+        entry.bytes_in,
+        entry.bytes_out,
     );
 }
 


### PR DESCRIPTION
Let there be light.

```
rpz@kalm:~/oxidecomputer/opte/xde$ pfexec opteadm dump-tcp-flows -p opte2
FLOW                                             STATE        HITS     SEGS IN  SEGS OUT BYTES IN   BYTES OUT 
TCP:172.30.0.5:22:10.0.0.10:52303                ESTABLISHED  214      124      91       12293      19055     
TCP:172.30.0.5:41334:34.69.170.43:80             TIME_WAIT    10       5        6        689        484       

rpz@kalm:~/oxidecomputer/opte/xde$ pfexec opteadm dump-tcp-flows -p opte2
FLOW                                             STATE        HITS     SEGS IN  SEGS OUT BYTES IN   BYTES OUT 
TCP:172.30.0.5:22:10.0.0.10:52303                ESTABLISHED  343      172      172      15981      109325    
TCP:172.30.0.5:41334:34.69.170.43:80             TIME_WAIT    10       5        6        689        484       
```