### PR TITLE
Pass ownership of ActionMeta

### DIFF
--- a/opte/src/engine/port.rs
+++ b/opte/src/engine/port.rs
@@ -964,7 +964,7 @@ impl Port {
         &self,
         dir: Direction,
         pkt: &mut Packet<Parsed>,
-        ameta: &mut ActionMeta,
+        mut ameta: ActionMeta,
     ) -> result::Result<ProcessResult, ProcessError> {
         let mut data = self.data.lock();
         check_state!(data.state, [PortState::Running])
@@ -975,13 +975,13 @@ impl Port {
         self.port_process_entry_probe(dir, epoch, &pkt);
         let res = match dir {
             Direction::Out => {
-                let res = self.process_out(&mut data, epoch, pkt, ameta);
+                let res = self.process_out(&mut data, epoch, pkt, &mut ameta);
                 Self::update_stats_out(&mut data.stats.vals, &res);
                 res
             }
 
             Direction::In => {
-                let res = self.process_in(&mut data, epoch, pkt, ameta);
+                let res = self.process_in(&mut data, epoch, pkt, &mut ameta);
                 Self::update_stats_in(&mut data.stats.vals, &res);
                 res
             }

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -1305,8 +1305,7 @@ fn guest_loopback(
             // We have found a matching Port on this host; "loop back"
             // the packet into the inbound processing path of the
             // destination Port.
-            let mut meta = ActionMeta::new();
-            match dest_dev.port.process(In, &mut pkt, &mut meta) {
+            match dest_dev.port.process(In, &mut pkt, ActionMeta::new()) {
                 Ok(ProcessResult::Modified) => {
                     guest_loopback_probe(&pkt, src_dev, dest_dev);
 
@@ -1443,8 +1442,7 @@ unsafe extern "C" fn xde_mc_tx(
     // The port processing code will fire a probe that describes what
     // action was taken -- there should be no need to add probes or
     // prints here.
-    let mut meta = ActionMeta::new();
-    let res = port.process(Direction::Out, &mut pkt, &mut meta);
+    let res = port.process(Direction::Out, &mut pkt, ActionMeta::new());
     match res {
         Ok(ProcessResult::Modified) => {
             if xde_ext_ip_hack == 1 {
@@ -2055,9 +2053,12 @@ unsafe extern "C" fn xde_rx(
                 }
 
                 let port = &(*dev).port;
-                let mut meta = ActionMeta::new();
                 let mut pkt_copy = Packet::copy(&bytes).parse().unwrap();
-                let res = port.process(Direction::In, &mut pkt_copy, &mut meta);
+                let res = port.process(
+                    Direction::In,
+                    &mut pkt_copy,
+                    ActionMeta::new(),
+                );
 
                 match res {
                     Ok(ProcessResult::Modified) => {
@@ -2102,8 +2103,7 @@ unsafe extern "C" fn xde_rx(
     }
 
     let port = &(*dev).port;
-    let mut meta = ActionMeta::new();
-    let res = port.process(Direction::In, &mut pkt, &mut meta);
+    let res = port.process(Direction::In, &mut pkt, ActionMeta::new());
     match res {
         Ok(ProcessResult::Modified) => {
             mac::mac_rx((*dev).mh, mrh, pkt.unwrap());


### PR DESCRIPTION
The fact that `ActionMeta` was passed as a mutable reference to `Port::process()` was an artifact of some misunderstandings I had between the C and Rust parts of my brain when doing early work on opte. There's no reason that ownership shouldn't pass to the process method. A big benefit of this change is making it much less likely for leaking metadata between `process()` calls in a test (by forgetting to call `ActionMeta::clear()`.

You might wonder why ActionMeta is passed as argument at all; why not just conjure it inside `process()`? Well, it might be useful at some point to seed the `ActionMeta` with some values before calling into the port instance. If that turns out not to be true, then allocating it inside `process()` makes a lot more sense.