### PR TITLE
Add assert_drop macro

### DIFF
--- a/oxide-vpc/tests/common/mod.rs
+++ b/oxide-vpc/tests/common/mod.rs
@@ -679,3 +679,31 @@ macro_rules! chk {
         }
     };
 }
+
+#[macro_export]
+macro_rules! assert_drop {
+    ($res:expr, $expected:expr) => {
+        match &$res {
+            Ok(ProcessResult::Drop { reason }) => match (reason, &$expected) {
+                (
+                    DropReason::Layer { name: res_name, reason: res_reason },
+                    DropReason::Layer { name: exp_name, reason: exp_reason },
+                ) => {
+                    assert_eq!(res_name, exp_name);
+                    assert_eq!(res_reason, exp_reason);
+                }
+
+                (DropReason::TcpErr, DropReason::TcpErr) => (),
+
+                (_, _) => {
+                    panic!(
+                        "expected drop type: {:?}, but got: {:?}",
+                        $expected, $res,
+                    );
+                }
+            },
+
+            _ => panic!("execpted drop, but got: {:?}", $res),
+        }
+    };
+}


### PR DESCRIPTION
This makes it easier to assert drop results.

The other change I made was to change the `guest_to_guest_no_route()` test to verify the default outbound router rule, rather than using an explicit rule to drop all packets.