### PR TITLE
Do not panic on zero-byte packet (#197)

### DIFF
--- a/opte/src/engine/dhcpv6/protocol.rs
+++ b/opte/src/engine/dhcpv6/protocol.rs
@@ -627,7 +627,6 @@ fn generate_packet<'a>(
     start = end;
     end += UdpHdr::SIZE;
     buf[start..end].copy_from_slice(&udp.as_bytes());
-
     Ok(AllowOrDeny::Allow(Packet::copy(&buf)))
 }
 

--- a/opte/src/engine/ether.rs
+++ b/opte/src/engine/ether.rs
@@ -364,8 +364,8 @@ impl Display for EtherHdrError {
                 write!(f, "Unsupported Ether Type: 0x{:04X}", ether_type)
             }
 
-            err => {
-                write!(f, "{:?}", err)
+            Self::ReadError { error } => {
+                write!(f, "read error: {:?}", error)
             }
         }
     }

--- a/opte/src/engine/ip6.rs
+++ b/opte/src/engine/ip6.rs
@@ -476,7 +476,6 @@ impl From<&Ipv6Meta> for Ipv6Hdr {
 pub(crate) mod test {
     use super::*;
     use crate::engine::headers::Header;
-    use crate::engine::packet::Initialized;
     use crate::engine::packet::Packet;
     use crate::engine::packet::PacketReader;
     use itertools::Itertools;
@@ -673,7 +672,7 @@ pub(crate) mod test {
                 SUPPORTED_EXTENSIONS.into_iter().permutations(n_extensions)
             {
                 let (buf, pos) = generate_test_packet(extensions.as_slice());
-                let bytes = Packet::<Initialized>::copy(&buf);
+                let bytes = Packet::copy(&buf);
                 let mut reader = PacketReader::new(&bytes, ());
                 let header = Ipv6Hdr::parse(&mut reader).unwrap();
                 assert_all_lengths_ok(&header, pos);

--- a/oxide-vpc/tests/firewall_tests.rs
+++ b/oxide-vpc/tests/firewall_tests.rs
@@ -86,11 +86,9 @@ fn firewall_replace_rules() {
     // of the real process we first dump the raw bytes of g1's
     // outgoing packet and then reparse it.
     // ================================================================
-    let mblk = pkt2.unwrap();
-    let mut pkt3 =
-        unsafe { Packet::<Initialized>::wrap(mblk).parse().unwrap() };
-    let mut pkt3_copy =
-        Packet::<Initialized>::copy(&pkt3.all_bytes()).parse().unwrap();
+    let mblk = pkt2.unwrap_mblk();
+    let mut pkt3 = unsafe { Packet::wrap_mblk_and_parse(mblk).unwrap() };
+    let mut pkt3_copy = Packet::copy(&pkt3.all_bytes()).parse().unwrap();
     let res = g2.port.process(In, &mut pkt3, ActionMeta::new());
     assert!(matches!(res, Ok(Modified)));
     incr!(

--- a/xde/src/mac.rs
+++ b/xde/src/mac.rs
@@ -153,19 +153,18 @@ impl MacClient {
         // function along with `pkt`.
         let mut ret_mp = ptr::null_mut();
         unsafe {
-            mac_tx(self.mch, pkt.unwrap(), hint, flags.bits(), &mut ret_mp)
+            mac_tx(self.mch, pkt.unwrap_mblk(), hint, flags.bits(), &mut ret_mp)
         };
         if ret_mp != ptr::null_mut() {
-            // Safety: We know the ret_mp is valid because we gave
-            // mac_tx() a valid mp_chain (pkt.unwrap()); and mac_tx()
-            // will give us either that exact pointer back (via
-            // ret_mp) or the portion of the packet chain it could not
-            // queue.
+            // Unwrap: We know the ret_mp is valid because we gave
+            // mac_tx() a valid mp_chain; and mac_tx() will give us
+            // either that exact pointer back (via ret_mp) or the
+            // portion of the packet chain it could not queue.
             //
             // XXX Technically we are still only passing single
             // packets, but eventually we will pass packet chains and
             // the sentence above will hold.
-            Some(unsafe { Packet::<Initialized>::wrap(ret_mp) })
+            Some(unsafe { Packet::wrap_mblk(ret_mp).unwrap() })
         } else {
             None
         }
@@ -190,7 +189,9 @@ impl MacClient {
         let mut raw_flags = flags.bits();
         raw_flags |= MAC_DROP_ON_NO_DESC;
         let mut ret_mp = ptr::null_mut();
-        unsafe { mac_tx(self.mch, pkt.unwrap(), hint, raw_flags, &mut ret_mp) };
+        unsafe {
+            mac_tx(self.mch, pkt.unwrap_mblk(), hint, raw_flags, &mut ret_mp)
+        };
         debug_assert_eq!(ret_mp, ptr::null_mut());
     }
 }


### PR DESCRIPTION
My initial thought back in August was to change the `Packet::wrap()` functions to return a `Result`; and if the length of the packet is zero bytes, to return an error. However, after spending more time with this, there's no real issue with wrapping a zero-byte packet. In fact, it simplifies the code to allow it. Instead, you deal with this scenario when attempting to parse the packet; returning an error indicating that the end of the packet has been reached unexpectedly.

While working on this I found that `Packet<Uninitialized>` and `PacketWriter` weren't really providing much use. Their original intent was to allocate a new mblk and write the packet from start to finish, converting it to `Packet<Initialized>` in which state you could no longer open a `PacketWriter` on it. But the primary use of such an API is only for testing and packet generation. The typical hot path doesn't generate packets, but instead wraps and modifies packets traveling to or from the client. Currently the `Packet::copy()` function is fine for generating hairpin packets.

Other Work
----------

* Fixed infinite recursion in `EtherHdr` display/debug impl.

* Unified the `Packet::copy()` functions.

* Renamed the `wrap()`/`unwrap()` functions to `wrap_mblk()`/`unwrap_mblk()` so that they wouldn't be confused with `Result::unwrap()`.

* Removed the mblk pointer chasing logic. This is more consistent with the rest of illumos/mac which performs no such checks.

* Modified `mock_allocb()` to allocate a 16 byte mblk if the requested size is 0. This is more in line with how `allocb(9F)` works.

* Added a zero-byte packet test to make sure they are handled correctly.