### PR TITLE
opteadm: use anyhow instead of unwrapping.

### DIFF
--- a/opteadm/Cargo.lock
+++ b/opteadm/Cargo.lock
@@ -375,6 +375,7 @@ dependencies = [
 name = "opteadm"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "cfg-if 0.1.10",
  "libc",
  "libnet",

--- a/opteadm/Cargo.toml
+++ b/opteadm/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Ryan Zezeski <ryan@oxide.computer>"]
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0"
 cfg-if = "0.1"
 libc = "0.2"
 libnet = { git = "https://github.com/oxidecomputer/netadm-sys" }


### PR DESCRIPTION
Ran opteadm without pfexec and noticed it just panics for for `list-ports`. Looks like that was the only command using `unwrap()` instead of `unwrap_or_die()`. Just added anyhow which lets us throw in `?` instead everywhere.