### PR TITLE
less malloc on the hot path

### DIFF
--- a/dtrace/common.h
+++ b/dtrace/common.h
@@ -48,3 +48,10 @@
 	svar = strjoin(svar, substr(lltostr(evar[4], 16), 2));	\
 	svar = strjoin(svar, ":");				\
 	svar = strjoin(svar, substr(lltostr(evar[5], 16), 2));
+
+/* Direction
+ *
+ * 1 = Inbound
+ * 2 = Outbound
+ */
+#define DIR_STR(dir)	((dir) == 1 ? "IN" : "OUT")

--- a/dtrace/lib/common.d
+++ b/dtrace/lib/common.d
@@ -15,7 +15,7 @@ typedef struct flow_id_sdt_arg {
 typedef struct rule_match_sdt_arg {
 	char			*port;
 	char			*layer;
-	char			*dir;
+	uintptr_t		dir;
 	flow_id_sdt_arg_t	*flow;
 	char			*rule_type;
 } rule_match_sdt_arg_t;
@@ -23,14 +23,14 @@ typedef struct rule_match_sdt_arg {
 typedef struct rule_no_match_sdt_arg {
 	char			*port;
 	char			*layer;
-	char			*dir;
+	uintptr_t		dir;
 	flow_id_sdt_arg_t	*flow;
 } rule_no_match_sdt_arg_t;
 
 typedef struct ht_run_sdt_arg {
 	char			*port;
 	char			*loc;
-	char			*dir;
+	uintptr_t		dir;
 	flow_id_sdt_arg_t	*flow_before;
 	flow_id_sdt_arg_t	*flow_after;
 } ht_run_sdt_arg_t;

--- a/dtrace/opte-bad-packet.d
+++ b/dtrace/opte-bad-packet.d
@@ -15,7 +15,7 @@ BEGIN {
 
 bad-packet {
 	this->port = stringof(arg0);
-	this->dir = stringof(arg1);
+	this->dir = DIR_STR(arg1);
 	this->mblk = arg2;
 	this->msg = stringof(arg3);
 

--- a/dtrace/opte-gen-desc-fail.d
+++ b/dtrace/opte-gen-desc-fail.d
@@ -16,7 +16,7 @@ BEGIN {
 gen-desc-fail {
 	this->port = stringof(arg0);
 	this->layer = stringof(arg1);
-	this->dir = stringof(arg2);
+	this->dir = DIR_STR(arg2);
 	this->flow = (flow_id_sdt_arg_t *)arg3;
 	this->msg = stringof(arg4);
 	this->af = this->flow->af;

--- a/dtrace/opte-gen-ht-fail.d
+++ b/dtrace/opte-gen-ht-fail.d
@@ -17,7 +17,7 @@ BEGIN {
 gen-ht-fail {
 	this->port = stringof(arg0);
 	this->layer = stringof(arg1);
-	this->dir = stringof(arg2);
+	this->dir = DIR_STR(arg2);
 	this->flow = (flow_id_sdt_arg_t *)arg3;
 	this->msg = stringof(arg4);
 	this->af = this->flow->af;

--- a/dtrace/opte-ht.d
+++ b/dtrace/opte-ht.d
@@ -1,6 +1,10 @@
 /*
  * Track Header Transformations as they happen.
  *
+ * This only applies to header transformations which occur as part of
+ * layer/rule processing. If you are interested in flow modification
+ * in the hot path, see the opte-port-process script.
+ *
  * dtrace -L ./lib -I . -Cqs ./opte-ht.d
  */
 #include "common.h"
@@ -15,7 +19,7 @@ BEGIN {
 
 ht-run {
 	this->ht = (ht_run_sdt_arg_t*)arg0;
-	this->dir = stringof(this->ht->dir);
+	this->dir = DIR_STR(this->ht->dir);
 	this->port = stringof(this->ht->port);
 	this->loc = stringof(this->ht->loc);
 	this->before = this->ht->flow_before;

--- a/dtrace/opte-layer-process.d
+++ b/dtrace/opte-layer-process.d
@@ -18,7 +18,7 @@ BEGIN {
 }
 
 layer-process-return {
-	this->dir = stringof(arg0);
+	this->dir = DIR_STR(arg0);
 	this->port = stringof(arg1);
 	this->layer = stringof(arg2);
 	this->flow_before = (flow_id_sdt_arg_t *)arg3;

--- a/dtrace/opte-port-process.d
+++ b/dtrace/opte-port-process.d
@@ -16,7 +16,7 @@ BEGIN {
 }
 
 port-process-return {
-	this->dir = stringof(arg0);
+	this->dir = DIR_STR(arg0);
 	this->name = stringof(arg1);
 	this->flow_before = (flow_id_sdt_arg_t *)arg2;
 	this->flow_after = (flow_id_sdt_arg_t *)arg3;

--- a/dtrace/opte-rule-match.d
+++ b/dtrace/opte-rule-match.d
@@ -18,7 +18,7 @@ rule-match {
 	this->port = stringof(this->match->port);
 	this->layer = stringof(this->match->layer);
 	this->flow = this->match->flow;
-	this->dir = stringof(this->match->dir);
+	this->dir = DIR_STR(this->match->dir);
 	this->af = this->flow->af;
 	num++;
 
@@ -44,7 +44,7 @@ rule-match /this->af == AF_INET6/ {
 rule-no-match {
 	this->no_match = (rule_no_match_sdt_arg_t *)arg0;
 	this->flow = this->no_match->flow;
-	this->dir = stringof(this->no_match->dir);
+	this->dir = DIR_STR(this->no_match->dir);
 	this->layer = stringof(this->no_match->layer);
 	this->af = this->flow->af;
 	num++;

--- a/dtrace/opte-uft-invaildate.d
+++ b/dtrace/opte-uft-invaildate.d
@@ -19,7 +19,7 @@ BEGIN {
 }
 
 flow-entry-invalidated {
-	this->dir = stringof(arg0);
+	this->dir = DIR_STR(arg0);
 	this->port = stringof(arg1);
 	this->flow = (flow_id_sdt_arg_t *)arg2;
 	this->epoch = arg3;

--- a/illumos-sys-hdrs/src/lib.rs
+++ b/illumos-sys-hdrs/src/lib.rs
@@ -117,12 +117,14 @@ pub union KStatNamedValue {
 }
 
 impl core::ops::AddAssign<u64> for KStatNamedValue {
+    #[inline]
     fn add_assign(&mut self, other: u64) {
         unsafe { self._u64 += other };
     }
 }
 
 impl core::ops::SubAssign<u64> for KStatNamedValue {
+    #[inline]
     fn sub_assign(&mut self, other: u64) {
         unsafe { self._u64 -= other };
     }
@@ -179,8 +181,8 @@ pub struct kmutex_t {
 #[derive(Debug)]
 pub struct dblk_t {
     pub db_frtnp: *const c_void, // imprecise
-    pub db_base: *const c_uchar,
-    pub db_lim: *const c_uchar,
+    pub db_base: *mut c_uchar,
+    pub db_lim: *mut c_uchar,
     pub db_ref: c_uchar,
     pub db_type: c_uchar,
     pub db_flags: c_uchar,
@@ -202,8 +204,8 @@ impl Default for dblk_t {
     fn default() -> Self {
         dblk_t {
             db_frtnp: ptr::null(),
-            db_base: ptr::null(),
-            db_lim: ptr::null(),
+            db_base: ptr::null_mut(),
+            db_lim: ptr::null_mut(),
             db_ref: 0,
             db_type: 0,
             db_flags: 0,

--- a/opte-api/src/encap.rs
+++ b/opte-api/src/encap.rs
@@ -33,6 +33,12 @@ pub struct Vni {
     inner: [u8; 3],
 }
 
+impl Default for Vni {
+    fn default() -> Self {
+        Vni::new(0u32).unwrap()
+    }
+}
+
 impl From<Vni> for u32 {
     fn from(vni: Vni) -> u32 {
         let bytes = vni.inner;

--- a/opte-api/src/lib.rs
+++ b/opte-api/src/lib.rs
@@ -56,12 +56,12 @@ pub use ulp::*;
 ///
 /// We rely on CI and the check-api-version.sh script to verify that
 /// this number is incremented anytime the oxide-api code changes.
-pub const API_VERSION: u64 = 18;
+pub const API_VERSION: u64 = 19;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Direction {
-    In,
-    Out,
+    In = 1,
+    Out = 2,
 }
 
 impl core::str::FromStr for Direction {
@@ -84,24 +84,6 @@ impl Display for Direction {
         };
 
         write!(f, "{}", dirstr)
-    }
-}
-
-impl From<Direction> for illumos_sys_hdrs::uintptr_t {
-    fn from(dir: Direction) -> Self {
-        match dir {
-            Direction::In => 0,
-            Direction::Out => 1,
-        }
-    }
-}
-
-impl Direction {
-    pub fn cstr_raw(&self) -> *const illumos_sys_hdrs::c_char {
-        match self {
-            Self::In => b"in\0".as_ptr() as *const illumos_sys_hdrs::c_char,
-            Self::Out => b"out\0".as_ptr() as *const illumos_sys_hdrs::c_char,
-        }
     }
 }
 

--- a/opte-api/src/mac.rs
+++ b/opte-api/src/mac.rs
@@ -24,7 +24,7 @@ cfg_if! {
 
 /// A MAC address.
 #[derive(
-    Clone, Copy, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
+    Clone, Copy, Default, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
 )]
 pub struct MacAddr {
     inner: [u8; 6],
@@ -35,6 +35,7 @@ impl MacAddr {
     pub const ZERO: Self = Self { inner: [0x00; 6] };
 
     /// Return the bytes of the MAC address.
+    #[inline]
     pub fn bytes(&self) -> [u8; 6] {
         self.inner
     }

--- a/opte-ioctl/Cargo.lock
+++ b/opte-ioctl/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,9 +10,9 @@ checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.7"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d862f14e042f75b95236d4ef1bb3d5c170964082d1e1e9c3ce689a2cbee217c"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
 dependencies = [
  "critical-section",
 ]
@@ -42,33 +33,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "bare-metal"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
-name = "bare-metal"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
-
-[[package]]
-name = "bit_field"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
-
-[[package]]
-name = "bitfield"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
 name = "bitflags"
@@ -106,28 +70,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cortex-m"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ff967e867ca14eba0c34ac25cd71ea98c678e741e3915d923999bb2fe7c826"
-dependencies = [
- "bare-metal 0.2.5",
- "bitfield",
- "embedded-hal",
- "volatile-register",
-]
-
-[[package]]
 name = "critical-section"
-version = "0.2.7"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95da181745b56d4bd339530ec393508910c909c784e8962d15d722bacf0bcbcd"
-dependencies = [
- "bare-metal 1.0.0",
- "cfg-if 1.0.0",
- "cortex-m",
- "riscv",
-]
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "cstr-argument"
@@ -155,16 +101,6 @@ name = "dyn-clone"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
-
-[[package]]
-name = "embedded-hal"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
-dependencies = [
- "nb 0.1.3",
- "void",
-]
 
 [[package]]
 name = "foreign-types"
@@ -204,12 +140,13 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.10"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d076121838e03f862871315477528debffdb7462fb229216ecef91b1a3eb31eb"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
  "hash32",
+ "rustc_version",
  "serde",
  "spin",
  "stable_deref_trait",
@@ -286,21 +223,6 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
-
-[[package]]
-name = "nb"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
-dependencies = [
- "nb 1.0.0",
-]
-
-[[package]]
-name = "nb"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "num_enum"
@@ -448,48 +370,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
-
-[[package]]
-name = "riscv"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6907ccdd7a31012b70faf2af85cd9e5ba97657cc3987c4f13f8e4d2c2a088aba"
-dependencies = [
- "bare-metal 1.0.0",
- "bit_field",
- "riscv-target",
-]
-
-[[package]]
-name = "riscv-target"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88aa938cda42a0cf62a20cfe8d139ff1af20c2e681212b5b34adb5a58333f222"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "rustc_version"
-version = "0.2.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
@@ -520,18 +404,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.9.0"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
@@ -678,27 +553,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "vcell"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "volatile-register"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
-dependencies = [
- "vcell",
-]
 
 [[package]]
 name = "winapi"

--- a/opte/Cargo.lock
+++ b/opte/Cargo.lock
@@ -4,27 +4,18 @@ version = 3
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.3"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a93ba5d6053837dbb76fd0ae26fd4f0c1859a008a783b0ce072b797c07f0f27"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
 dependencies = [
- "cortex-m",
+ "critical-section",
 ]
 
 [[package]]
-name = "bare-metal"
-version = "0.2.5"
+name = "autocfg"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
-name = "bitfield"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
@@ -72,16 +63,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
-name = "cortex-m"
-version = "0.7.3"
+name = "critical-section"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac919ef424449ec8c08d515590ce15d9262c0ca5f0da5b0c901e971a3b783b3"
-dependencies = [
- "bare-metal",
- "bitfield",
- "embedded-hal",
- "volatile-register",
-]
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "digest"
@@ -126,16 +111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
-name = "embedded-hal"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36cfb62ff156596c892272f3015ef952fe1525e85261fa3a7f327bd6b384ab9"
-dependencies = [
- "nb 0.1.3",
- "void",
-]
-
-[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,12 +136,13 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.9"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e476c64197665c3725621f0ac3f9e5209aa5e889e02a08b1daf5f16dc5fd952"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
  "hash32",
+ "rustc_version",
  "spin",
  "stable_deref_trait",
 ]
@@ -206,10 +182,11 @@ checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -224,21 +201,6 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "nb"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
-dependencies = [
- "nb 1.0.0",
-]
-
-[[package]]
-name = "nb"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "opaque-debug"
@@ -363,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
@@ -384,18 +346,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.9.0"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
@@ -464,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 dependencies = [
  "lock_api",
 ]
@@ -612,31 +565,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcell"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "volatile-register"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d67cb4616d99b940db1d6bd28844ff97108b498a6ca850e5b6191a532063286"
-dependencies = [
- "vcell",
-]
 
 [[package]]
 name = "winapi"

--- a/opte/Cargo.toml
+++ b/opte/Cargo.toml
@@ -21,7 +21,7 @@ test-help = []
 [dependencies]
 cfg-if = "0.1"
 dyn-clone = "1.0.9"
-heapless = "0.7.9"
+heapless = "0.7.16"
 illumos-sys-hdrs = { path = "../illumos-sys-hdrs" }
 kstat-macro = { path = "../kstat-macro" }
 opte-api = { path = "../opte-api", default-features = false }

--- a/opte/src/ddi/kstat.rs
+++ b/opte/src/ddi/kstat.rs
@@ -227,6 +227,7 @@ impl KStatU64 {
 
 #[cfg(all(not(feature = "std"), not(test)))]
 impl core::ops::AddAssign<u64> for KStatU64 {
+    #[inline]
     fn add_assign(&mut self, other: u64) {
         self.inner.value += other;
     }
@@ -234,6 +235,7 @@ impl core::ops::AddAssign<u64> for KStatU64 {
 
 #[cfg(all(not(feature = "std"), not(test)))]
 impl core::ops::SubAssign<u64> for KStatU64 {
+    #[inline]
     fn sub_assign(&mut self, other: u64) {
         self.inner.value -= other;
     }

--- a/opte/src/engine/checksum.rs
+++ b/opte/src/engine/checksum.rs
@@ -125,7 +125,7 @@ impl Checksum {
     ///
     /// This is useful for incrementally updating an existing checksum
     /// where only a portion of the bytes are being rewritten.
-    pub fn add(&mut self, bytes: &[u8]) {
+    pub fn add_bytes(&mut self, bytes: &[u8]) {
         self.inner = csum_add(self.inner, bytes);
     }
 
@@ -139,7 +139,7 @@ impl Checksum {
     ///
     /// This is useful for incrementally updating an existing checksum
     /// where only a portion of the bytes are being rewritten.
-    pub fn sub(&mut self, bytes: &[u8]) {
+    pub fn sub_bytes(&mut self, bytes: &[u8]) {
         self.inner = csum_sub(self.inner, bytes);
     }
 
@@ -180,6 +180,13 @@ impl core::ops::Add for Checksum {
 impl core::ops::AddAssign for Checksum {
     fn add_assign(&mut self, other: Self) {
         self.inner += other.inner
+    }
+}
+
+impl core::ops::SubAssign for Checksum {
+    fn sub_assign(&mut self, other: Self) {
+        let other_bytes = other.clone().finalize().to_ne_bytes();
+        self.sub_bytes(&other_bytes);
     }
 }
 

--- a/opte/src/engine/geneve.rs
+++ b/opte/src/engine/geneve.rs
@@ -4,18 +4,12 @@
 
 // Copyright 2022 Oxide Computer Company
 
-use super::ether::EtherType;
 use super::ether::ETHER_TYPE_ETHER;
-use super::headers::Header;
-use super::headers::HeaderAction;
-use super::headers::HeaderActionModify;
-use super::headers::ModifyActionArg;
-use super::headers::PushActionArg;
+use super::headers::ModifyAction;
+use super::headers::PushAction;
 use super::headers::RawHeader;
-use super::packet::PacketRead;
+use super::packet::PacketReadMut;
 use super::packet::ReadErr;
-use super::packet::WriteError;
-use core::convert::TryFrom;
 use core::mem;
 pub use opte_api::Vni;
 use serde::Deserialize;
@@ -25,125 +19,141 @@ use zerocopy::FromBytes;
 use zerocopy::LayoutVerified;
 use zerocopy::Unaligned;
 
-cfg_if! {
-    if #[cfg(all(not(feature = "std"), not(test)))] {
-        use alloc::vec::Vec;
-    } else {
-        use std::vec::Vec;
-    }
-}
-
 pub const GENEVE_VSN: u8 = 0;
 pub const GENEVE_VER_MASK: u8 = 0xC0;
 pub const GENEVE_VER_SHIFT: u8 = 6;
 pub const GENEVE_OPT_LEN_MASK: u8 = 0x3F;
 pub const GENEVE_PORT: u16 = 6081;
 
-#[derive(
-    Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
-)]
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct GeneveMeta {
+    pub entropy: u16,
+    pub vni: Vni,
+    pub len: u16,
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Deserialize,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+)]
+pub struct GenevePush {
+    pub entropy: u16,
     pub vni: Vni,
 }
 
-impl PushActionArg for GeneveMeta {}
+impl PushAction<GeneveMeta> for GenevePush {
+    fn push(&self) -> GeneveMeta {
+        let mut geneve = GeneveMeta::default();
+        geneve.entropy = self.entropy;
+        geneve.vni = self.vni;
+        geneve
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct GeneveMetaOpt {
+pub struct GeneveMod {
     vni: Option<Vni>,
 }
 
-impl ModifyActionArg for GeneveMetaOpt {}
-
-impl GeneveMeta {
-    pub fn push(vni: Vni) -> HeaderAction<GeneveMeta, GeneveMetaOpt> {
-        HeaderAction::Push(GeneveMeta { vni })
-    }
-}
-
-impl From<&GeneveHdr> for GeneveMeta {
-    fn from(geneve: &GeneveHdr) -> Self {
-        Self { vni: geneve.vni }
-    }
-}
-
-impl From<&GeneveHdrRaw> for GeneveMeta {
-    fn from(raw: &GeneveHdrRaw) -> Self {
-        let vni = Vni::new(u32::from_be_bytes([
-            0, raw.vni[0], raw.vni[1], raw.vni[2],
-        ]))
-        .expect("need to verify this beforehand");
-
-        Self { vni }
-    }
-}
-
-impl HeaderActionModify<GeneveMetaOpt> for GeneveMeta {
-    fn run_modify(&mut self, spec: &GeneveMetaOpt) {
-        if spec.vni.is_some() {
-            self.vni = spec.vni.unwrap();
+impl ModifyAction<GeneveMeta> for GeneveMod {
+    fn modify(&self, meta: &mut GeneveMeta) {
+        if let Some(vni) = self.vni {
+            meta.vni = vni;
         }
     }
 }
 
-#[derive(Debug)]
-pub struct GeneveHdr {
-    pub opt_len_bytes: u16,
-    pub flags: u8,
-    // The Geneve spec calls names this field the "protocol", but its
-    // value is an Ether Type.
-    pub proto: EtherType,
-    pub vni: Vni,
-}
-
-impl GeneveHdr {
-    // This is for the base header size only.
-    pub const SIZE: usize = mem::size_of::<GeneveHdrRaw>();
-
-    pub fn as_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(self.hdr_len());
-        let raw = GeneveHdrRaw::from(self);
-        bytes.extend_from_slice(raw.as_bytes());
-        bytes
+impl GeneveMeta {
+    #[inline]
+    pub fn emit(&self, dst: &mut [u8]) {
+        debug_assert_eq!(dst.len(), self.hdr_len());
+        let base = &mut dst[0..GeneveHdrRaw::SIZE];
+        let mut raw = GeneveHdrRaw::new_mut(base).unwrap();
+        raw.write(GeneveHdrRaw::from(self));
     }
 
     pub fn hdr_len(&self) -> usize {
-        usize::from(self.opt_len_bytes) + Self::SIZE
-    }
-
-    pub fn new(proto: EtherType, vni: Vni) -> Self {
-        Self { opt_len_bytes: 0, flags: 0, proto, vni }
-    }
-
-    pub fn options_len_bytes(&self) -> usize {
-        usize::from(self.opt_len_bytes)
+        GeneveHdr::BASE_SIZE
     }
 }
 
-impl Header for GeneveHdr {
-    type Error = GeneveHdrError;
-
-    fn parse<'a, 'b, R>(rdr: &'b mut R) -> Result<Self, GeneveHdrError>
-    where
-        R: PacketRead<'a>,
-    {
-        GeneveHdr::try_from(&GeneveHdrRaw::raw_zc(rdr)?)
-    }
-}
-
-impl From<&GeneveMeta> for GeneveHdr {
-    fn from(meta: &GeneveMeta) -> Self {
-        GeneveHdr {
-            opt_len_bytes: 0,
-            flags: 0,
-            proto: EtherType::Ether,
-            vni: meta.vni,
+impl<'a> From<&GeneveHdr<'a>> for GeneveMeta {
+    fn from(geneve: &GeneveHdr<'a>) -> Self {
+        Self {
+            vni: geneve.vni(),
+            entropy: geneve.entropy(),
+            len: geneve.len() as u16,
         }
     }
 }
 
-#[derive(Debug)]
+pub struct GeneveHdr<'a> {
+    bytes: LayoutVerified<&'a mut [u8], GeneveHdrRaw>,
+}
+
+impl<'a> GeneveHdr<'a> {
+    pub const BASE_SIZE: usize = mem::size_of::<GeneveHdrRaw>();
+
+    /// Return the header length, in bytes.
+    pub fn hdr_len(&self) -> usize {
+        usize::from(self.bytes.options_len() * 4) + Self::BASE_SIZE
+    }
+
+    pub fn entropy(&self) -> u16 {
+        u16::from_be_bytes(self.bytes.src_port)
+    }
+
+    pub fn len(&self) -> usize {
+        usize::from(u16::from_be_bytes(self.bytes.length))
+    }
+
+    pub fn parse<'b, R>(rdr: &'b mut R) -> Result<Self, GeneveHdrError>
+    where
+        R: PacketReadMut<'a>,
+    {
+        let src = rdr.slice_mut(GeneveHdrRaw::SIZE)?;
+        Ok(Self { bytes: GeneveHdrRaw::new_mut(src)? })
+    }
+
+    /// Set the length, in bytes.
+    ///
+    /// The UDP length field includes both header and payload.
+    pub fn set_len(&mut self, len: u16) {
+        self.bytes.length = len.to_be_bytes();
+    }
+
+    pub fn unify(&mut self, meta: &GeneveMeta) {
+        self.bytes.src_port = meta.entropy.to_be_bytes();
+        self.bytes.dst_port = GENEVE_PORT.to_be_bytes();
+        self.bytes.vni = meta.vni.bytes();
+    }
+
+    /// Return the VNI.
+    pub fn vni(&self) -> Vni {
+        // Unwrap: We know it's legit because we are making sure the
+        // MSB is zero.
+        Vni::new(u32::from_be_bytes([
+            0,
+            self.bytes.vni[0],
+            self.bytes.vni[1],
+            self.bytes.vni[2],
+        ]))
+        .unwrap()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum GeneveHdrError {
+    BadDstPort { dst_port: u16 },
+    BadLength { len: u16 },
     BadVersion { vsn: u8 },
     BadVni { vni: u32 },
     ReadError { error: ReadErr },
@@ -156,52 +166,19 @@ impl From<ReadErr> for GeneveHdrError {
     }
 }
 
-impl TryFrom<&LayoutVerified<&[u8], GeneveHdrRaw>> for GeneveHdr {
-    type Error = GeneveHdrError;
-
-    fn try_from(
-        raw: &LayoutVerified<&[u8], GeneveHdrRaw>,
-    ) -> Result<Self, Self::Error> {
-        let vsn = raw.version();
-
-        if raw.version() != GENEVE_VSN {
-            return Err(GeneveHdrError::BadVersion { vsn });
-        }
-
-        if raw.options_len() > 0 {
-            todo!("implement geneve options");
-        }
-
-        let proto = EtherType::try_from(u16::from_be_bytes(raw.proto))
-            .map_err(|_s| GeneveHdrError::UnexpectedProtocol {
-                protocol: u16::from_be_bytes(raw.proto),
-            })?;
-
-        let vni = Vni::new(u32::from_be_bytes([
-            0, raw.vni[0], raw.vni[1], raw.vni[2],
-        ]))
-        .map_err(|_s| GeneveHdrError::BadVni {
-            vni: u32::from_be_bytes([0, raw.vni[0], raw.vni[1], raw.vni[2]]),
-        })?;
-
-        Ok(GeneveHdr {
-            opt_len_bytes: raw.options_len() as u16 * 4,
-            flags: raw.flags,
-            proto,
-            vni,
-        })
-    }
-}
-
 /// Note: For now we keep this unaligned to be safe.
 #[repr(C)]
 #[derive(Clone, Debug, FromBytes, AsBytes, Unaligned)]
 pub struct GeneveHdrRaw {
-    pub ver_opt_len: u8,
-    pub flags: u8,
-    pub proto: [u8; 2],
-    pub vni: [u8; 3],
-    pub reserved: u8,
+    src_port: [u8; 2],
+    dst_port: [u8; 2],
+    length: [u8; 2],
+    csum: [u8; 2],
+    ver_opt_len: u8,
+    flags: u8,
+    proto: [u8; 2],
+    vni: [u8; 3],
+    reserved: u8,
 }
 
 impl<'a> GeneveHdrRaw {
@@ -212,29 +189,20 @@ impl<'a> GeneveHdrRaw {
         self.ver_opt_len & GENEVE_OPT_LEN_MASK
     }
 
-    fn version(&self) -> u8 {
+    pub fn version(&self) -> u8 {
         (self.ver_opt_len & GENEVE_VER_MASK) >> GENEVE_VER_SHIFT
     }
 }
 
 impl<'a> RawHeader<'a> for GeneveHdrRaw {
-    fn raw_zc<'b, R: PacketRead<'a>>(
-        rdr: &'b mut R,
-    ) -> Result<LayoutVerified<&'a [u8], Self>, ReadErr> {
-        let slice = rdr.slice(mem::size_of::<Self>())?;
-        let hdr = match LayoutVerified::new(slice) {
-            Some(bytes) => bytes,
+    #[inline]
+    fn new_mut(
+        src: &mut [u8],
+    ) -> Result<LayoutVerified<&mut [u8], Self>, ReadErr> {
+        debug_assert_eq!(src.len(), mem::size_of::<Self>());
+        let hdr = match LayoutVerified::new(src) {
+            Some(hdr) => hdr,
             None => return Err(ReadErr::BadLayout),
-        };
-        Ok(hdr)
-    }
-
-    fn raw_mut_zc(
-        dst: &mut [u8],
-    ) -> Result<LayoutVerified<&mut [u8], Self>, WriteError> {
-        let hdr = match LayoutVerified::new(dst) {
-            Some(bytes) => bytes,
-            None => return Err(WriteError::BadLayout),
         };
         Ok(hdr)
     }
@@ -242,7 +210,11 @@ impl<'a> RawHeader<'a> for GeneveHdrRaw {
 
 impl Default for GeneveHdrRaw {
     fn default() -> Self {
-        GeneveHdrRaw {
+        Self {
+            src_port: [0; 2],
+            dst_port: [0; 2],
+            length: [0; 2],
+            csum: [0; 2],
             ver_opt_len: 0x0,
             flags: 0x0,
             proto: ETHER_TYPE_ETHER.to_be_bytes(),
@@ -252,16 +224,60 @@ impl Default for GeneveHdrRaw {
     }
 }
 
-impl From<&GeneveHdr> for GeneveHdrRaw {
-    fn from(geneve: &GeneveHdr) -> Self {
-        let opt_len_words = geneve.opt_len_bytes / 4;
-
-        GeneveHdrRaw {
-            ver_opt_len: opt_len_words as u8,
-            flags: geneve.flags,
-            proto: (geneve.proto as u16).to_be_bytes(),
-            vni: geneve.vni.bytes(),
+impl From<&GeneveMeta> for GeneveHdrRaw {
+    fn from(meta: &GeneveMeta) -> Self {
+        Self {
+            src_port: meta.entropy.to_be_bytes(),
+            dst_port: GENEVE_PORT.to_be_bytes(),
+            length: meta.len.to_be_bytes(),
+            csum: [0; 2],
+            ver_opt_len: 0x0,
+            flags: 0x0,
+            proto: ETHER_TYPE_ETHER.to_be_bytes(),
+            vni: meta.vni.bytes(),
             reserved: 0,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::engine::packet::Packet;
+
+    #[test]
+    fn emit() {
+        let geneve = GeneveMeta {
+            entropy: 7777,
+            vni: Vni::new(1234u32).unwrap(),
+            len: GeneveHdr::BASE_SIZE as u16,
+        };
+
+        let len = geneve.hdr_len();
+        let mut pkt = Packet::alloc_and_expand(len);
+        let mut wtr = pkt.seg0_wtr();
+        // geneve.emit(&mut wtr).unwrap();
+        geneve.emit(wtr.slice_mut(len).unwrap());
+        assert_eq!(len, pkt.len());
+        #[rustfmt::skip]
+        let expected_bytes = vec![
+            // source
+            0x1E, 0x61,
+            // dest
+            0x17, 0xC1,
+            // length
+            0x00, 0x10,
+            // csum
+            0x00, 0x00,
+            // ver + opt len
+            0x00,
+            // flags
+            0x00,
+            // proto
+            0x65, 0x58,
+            // vni + reserved
+            0x00, 0x04, 0xD2, 0x00
+        ];
+        assert_eq!(&expected_bytes, pkt.seg_bytes(0));
     }
 }

--- a/opte/src/engine/headers.rs
+++ b/opte/src/engine/headers.rs
@@ -5,36 +5,35 @@
 // Copyright 2022 Oxide Computer Company
 
 use super::checksum::Checksum;
+use super::geneve::GeneveHdr;
+use super::geneve::GeneveMeta;
+use super::geneve::GeneveMod;
+use super::geneve::GenevePush;
 use super::ip4::Ipv4Hdr;
 use super::ip4::Ipv4Meta;
-use super::ip4::Ipv4MetaOpt;
+use super::ip4::Ipv4Mod;
+use super::ip4::Ipv4Push;
 use super::ip6::Ipv6Hdr;
 use super::ip6::Ipv6Meta;
-use super::ip6::Ipv6MetaOpt;
-use super::packet::PacketRead;
+use super::ip6::Ipv6Mod;
+use super::ip6::Ipv6Push;
 use super::packet::ReadErr;
-use super::packet::WriteError;
 use super::tcp::TcpHdr;
 use super::tcp::TcpMeta;
-use super::tcp::TcpMetaOpt;
+use super::tcp::TcpMod;
+use super::tcp::TcpPush;
 use super::udp::UdpHdr;
 use super::udp::UdpMeta;
-use super::udp::UdpMetaOpt;
+use super::udp::UdpMod;
+use super::udp::UdpPush;
 use core::fmt;
 pub use opte_api::IpAddr;
 pub use opte_api::IpCidr;
 pub use opte_api::Protocol;
+pub use opte_api::Vni;
 use serde::Deserialize;
 use serde::Serialize;
 use zerocopy::LayoutVerified;
-
-cfg_if! {
-    if #[cfg(all(not(feature = "std"), not(test)))] {
-        use alloc::vec::Vec;
-    } else {
-        use std::vec::Vec;
-    }
-}
 
 pub const AF_INET: i32 = 2;
 pub const AF_INET6: i32 = 26;
@@ -46,55 +45,25 @@ pub const AF_INET6: i32 = 26;
 /// in network order. A raw header undergoes no validation of header
 /// fields. A raw header represents only the base header, eschewing
 /// any options or extensions.
-pub trait RawHeader<'a> {
-    /// Read a zerocopy version of the raw header from the `Packet`
-    /// backing `rdr`.
-    fn raw_zc<'b, R: PacketRead<'a>>(
-        rdr: &'b mut R,
-    ) -> Result<LayoutVerified<&'a [u8], Self>, ReadErr>;
+pub trait RawHeader<'a>: Sized {
+    const SIZE: usize = core::mem::size_of::<Self>();
 
-    /// Read a mutable, zerocopy version of the raw header from the
-    /// passed in mutable slice.
-    fn raw_mut_zc(
+    /// Create a mutable, zerocopy version of the raw header from the
+    /// src.
+    fn new_mut(
         src: &mut [u8],
-    ) -> Result<LayoutVerified<&mut [u8], Self>, WriteError>;
+    ) -> Result<LayoutVerified<&mut [u8], Self>, ReadErr>;
 }
 
-/// A parsed, partially validated header.
-///
-/// A value of this type represents a header type which has been
-/// parsed from a [`RawHeader`]. This parsing includes some amount of
-/// intra-header validation along with conversion from a sequence of
-/// network-order bytes to native host types. This header value may
-/// also include options or extension headers.
-///
-/// In general, this is the primary type of header value that OPTE
-/// code should be dealing with. The idea is to convert [`RawHeader`]
-/// to [`Header`] as close to the edges as possible.
-///
-/// NOTE: OPTE currently performs all header reads as copy-only. This
-/// was done as a measure of expedience for development and to cut
-/// down on initial complexity. Furthermore, while zerocopy can be
-/// important, it's less important at this moment, especially for the
-/// header data. There are larger performance wins to be had before we
-/// worry too much about header zercopy, such as the Unified Flow
-/// Table, checksum offloads, LSO, and LRO.
-pub trait Header {
-    type Error;
-
-    /// Create a value of `Self` by attempting to parse and validate a
-    /// copy of it from the provided [`PacketRead`] argument.
-    fn parse<'a, 'b, R>(rdr: &'b mut R) -> Result<Self, Self::Error>
-    where
-        Self: core::marker::Sized,
-        R: PacketRead<'a>;
+pub trait PushAction<HdrM> {
+    fn push(&self) -> HdrM;
 }
-
-pub trait PushActionArg {}
 
 /// A type that is meant to be used as an argument to a
 /// [`HeaderActionModify`] implementation.
-pub trait ModifyActionArg {}
+pub trait ModifyAction<HdrM> {
+    fn modify(&self, meta: &mut HdrM);
+}
 
 #[derive(Clone, Copy, Debug)]
 pub enum IpType {
@@ -103,51 +72,63 @@ pub enum IpType {
 }
 
 #[derive(Debug)]
-pub enum IpHdr {
-    Ip4(Ipv4Hdr),
-    Ip6(Ipv6Hdr),
+pub enum IpHdr<'a> {
+    Ip4(Ipv4Hdr<'a>),
+    Ip6(Ipv6Hdr<'a>),
 }
 
-#[macro_export]
-macro_rules! assert_ip {
-    ($left:expr, $right:expr) => {
-        match ($left, $right) {
-            (
-                Some($crate::engine::headers::IpHdr::Ip4(ip4_left)),
-                Some($crate::engine::headers::IpHdr::Ip4(ip4_right)),
-            ) => {
-                assert_ip4!(ip4_left, ip4_right);
-            }
-
-            (
-                Some($crate::engine::headers::IpHdr::Ip6(ip6_left)),
-                Some($crate::engine::headers::IpHdr::Ip6(ip6_right)),
-            ) => {
-                assert_ip6!(ip6_left, ip6_right);
-            }
-
-            (left, right) => {
-                panic!(
-                    "IP headers not same type\nleft: {:?}\nright: {:?}",
-                    left, right,
-                );
-            }
-        }
-    };
-}
-
-impl IpHdr {
-    /// Return the bytes of the header.
-    pub fn as_bytes(&self) -> Vec<u8> {
+impl<'a> IpHdr<'a> {
+    pub fn pseudo_csum(&self) -> Checksum {
         match self {
-            Self::Ip4(ip4) => ip4.as_bytes(),
-            Self::Ip6(ip6) => ip6.as_bytes(),
+            Self::Ip4(ip4) => ip4.pseudo_csum(),
+            Self::Ip6(ip6) => ip6.pseudo_csum(),
+        }
+    }
+}
+
+impl<'a> From<Ipv4Hdr<'a>> for IpHdr<'a> {
+    fn from(ip4: Ipv4Hdr<'a>) -> Self {
+        Self::Ip4(ip4)
+    }
+}
+
+impl<'a> From<Ipv6Hdr<'a>> for IpHdr<'a> {
+    fn from(ip6: Ipv6Hdr<'a>) -> Self {
+        Self::Ip6(ip6)
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Copy)]
+pub enum IpMeta {
+    Ip4(Ipv4Meta),
+    Ip6(Ipv6Meta),
+}
+
+impl IpMeta {
+    /// Return the checksum value.
+    pub fn csum(&self) -> [u8; 2] {
+        match self {
+            Self::Ip4(ip4) => ip4.csum,
+            // IPv6 has no checksum.
+            Self::Ip6(_) => [0; 2],
         }
     }
 
-    /// Return the total length of the header.
-    ///
-    /// In the case of IPv6, this includes any extension headers.
+    pub fn has_csum(&self) -> bool {
+        match self {
+            Self::Ip4(ip4) => ip4.csum != [0; 2],
+            // IPv6 has no checksum.
+            Self::Ip6(_) => false,
+        }
+    }
+
+    pub fn emit(&self, dst: &mut [u8]) {
+        match self {
+            Self::Ip4(ip4) => ip4.emit(dst),
+            Self::Ip6(ip6) => ip6.emit(dst),
+        }
+    }
+
     pub fn hdr_len(&self) -> usize {
         match self {
             Self::Ip4(ip4) => ip4.hdr_len(),
@@ -155,82 +136,6 @@ impl IpHdr {
         }
     }
 
-    /// Return `Some` if this is an IPv4 header, or `None`.
-    pub fn ip4(&self) -> Option<&Ipv4Hdr> {
-        match self {
-            Self::Ip4(ip4) => Some(ip4),
-            _ => None,
-        }
-    }
-
-    /// Return `Some` if this is an IPv6 header, or `None`.
-    pub fn ip6(&self) -> Option<&Ipv6Hdr> {
-        match self {
-            Self::Ip6(ip6) => Some(ip6),
-            _ => None,
-        }
-    }
-
-    /// Return the length of the upper-layer protocol contents.
-    pub fn ulp_len(&self) -> usize {
-        match self {
-            Self::Ip4(ip4) => ip4.ulp_len(),
-            Self::Ip6(ip6) => ip6.ulp_len(),
-        }
-    }
-
-    pub fn pseudo_bytes(&self) -> Vec<u8> {
-        match self {
-            Self::Ip4(ip4) => ip4.pseudo_bytes(),
-            Self::Ip6(ip6) => ip6.pseudo_bytes(),
-        }
-    }
-
-    pub fn pseudo_csum(&self) -> Checksum {
-        match self {
-            Self::Ip4(ip4) => ip4.pseudo_csum(),
-            Self::Ip6(ip6) => ip6.pseudo_csum(),
-        }
-    }
-
-    /// Set the total length of the packet, in octets.
-    pub fn set_total_len(&mut self, len: usize) {
-        match self {
-            Self::Ip4(ip4) => ip4.set_total_len(len as u16),
-            Self::Ip6(ip6) => ip6.set_total_len(len as u16),
-        }
-    }
-
-    /// Total length of the packet, including all headers and payload
-    pub fn total_len(&self) -> u16 {
-        match self {
-            Self::Ip4(ip4) => ip4.total_len(),
-            Self::Ip6(ip6) => ip6.total_len(),
-        }
-    }
-}
-
-impl From<Ipv4Hdr> for IpHdr {
-    fn from(ip4: Ipv4Hdr) -> Self {
-        IpHdr::Ip4(ip4)
-    }
-}
-
-impl From<Ipv6Hdr> for IpHdr {
-    fn from(ip6: Ipv6Hdr) -> Self {
-        IpHdr::Ip6(ip6)
-    }
-}
-
-#[derive(
-    Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize, Copy,
-)]
-pub enum IpMeta {
-    Ip4(Ipv4Meta),
-    Ip6(Ipv6Meta),
-}
-
-impl IpMeta {
     /// Get the [`Ipv4Meta`], if this is IPv4.
     pub fn ip4(&self) -> Option<&Ipv4Meta> {
         match self {
@@ -254,6 +159,13 @@ impl IpMeta {
             Self::Ip6(meta) => meta.proto,
         }
     }
+
+    pub fn pseudo_csum(&self) -> Checksum {
+        match self {
+            Self::Ip4(ip4) => ip4.pseudo_csum(),
+            Self::Ip6(ip6) => ip6.pseudo_csum(),
+        }
+    }
 }
 
 impl From<Ipv4Meta> for IpMeta {
@@ -268,45 +180,49 @@ impl From<Ipv6Meta> for IpMeta {
     }
 }
 
-impl From<&IpHdr> for IpMeta {
-    fn from(ip: &IpHdr) -> Self {
-        match ip {
-            IpHdr::Ip4(ip4) => IpMeta::Ip4(Ipv4Meta::from(ip4)),
-            IpHdr::Ip6(ip6) => IpMeta::Ip6(Ipv6Meta::from(ip6)),
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub enum IpPush {
+    Ip4(Ipv4Push),
+    Ip6(Ipv6Push),
+}
+
+impl PushAction<IpMeta> for IpPush {
+    fn push(&self) -> IpMeta {
+        match self {
+            Self::Ip4(spec) => IpMeta::from(spec.push()),
+
+            Self::Ip6(spec) => IpMeta::from(spec.push()),
         }
     }
 }
 
+impl From<Ipv4Push> for IpPush {
+    fn from(ip4: Ipv4Push) -> Self {
+        Self::Ip4(ip4)
+    }
+}
+
+impl From<Ipv6Push> for IpPush {
+    fn from(ip6: Ipv6Push) -> Self {
+        Self::Ip6(ip6)
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum IpMetaOpt {
-    Ip4(Ipv4MetaOpt),
-    Ip6(Ipv6MetaOpt),
+pub enum IpMod {
+    Ip4(Ipv4Mod),
+    Ip6(Ipv6Mod),
 }
 
-impl PushActionArg for IpMeta {}
-impl ModifyActionArg for IpMetaOpt {}
-
-impl From<Ipv4MetaOpt> for IpMetaOpt {
-    fn from(ip4: Ipv4MetaOpt) -> Self {
-        IpMetaOpt::Ip4(ip4)
-    }
-}
-
-impl From<Ipv6MetaOpt> for IpMetaOpt {
-    fn from(ip6: Ipv6MetaOpt) -> Self {
-        IpMetaOpt::Ip6(ip6)
-    }
-}
-
-impl HeaderActionModify<IpMetaOpt> for IpMeta {
-    fn run_modify(&mut self, spec: &IpMetaOpt) {
-        match (self, spec) {
-            (IpMeta::Ip4(ip4_meta), IpMetaOpt::Ip4(ip4_spec)) => {
-                ip4_meta.run_modify(&ip4_spec);
+impl ModifyAction<IpMeta> for IpMod {
+    fn modify(&self, meta: &mut IpMeta) {
+        match (self, meta) {
+            (IpMod::Ip4(spec), IpMeta::Ip4(meta)) => {
+                spec.modify(meta);
             }
 
-            (IpMeta::Ip6(ip6_meta), IpMetaOpt::Ip6(ip6_spec)) => {
-                ip6_meta.run_modify(&ip6_spec);
+            (IpMod::Ip6(spec), IpMeta::Ip6(meta)) => {
+                spec.modify(meta);
             }
 
             (meta, spec) => {
@@ -319,49 +235,91 @@ impl HeaderActionModify<IpMetaOpt> for IpMeta {
     }
 }
 
-#[derive(Debug)]
-pub enum UlpHdr {
-    Tcp(TcpHdr),
-    Udp(UdpHdr),
+impl From<Ipv4Mod> for IpMod {
+    fn from(ip4: Ipv4Mod) -> Self {
+        Self::Ip4(ip4)
+    }
 }
 
-#[macro_export]
-macro_rules! assert_ulp {
-    ($left:expr, $right:expr) => {
-        match ($left, $right) {
-            (
-                Some($crate::engine::headers::UlpHdr::Tcp(tcp_left)),
-                Some($crate::engine::headers::UlpHdr::Tcp(tcp_right)),
-            ) => {
-                assert_tcp!(tcp_left, tcp_right);
-            }
-
-            (
-                Some($crate::engine::headers::UlpHdr::Udp(udp_left)),
-                Some($crate::engine::headers::UlpHdr::Udp(udp_right)),
-            ) => {
-                assert_udp!(udp_left, udp_right);
-            }
-
-            (left, right) => {
-                panic!(
-                    "ULP headers not same type\nleft: {:?}\nright: {:?}",
-                    left, right,
-                );
-            }
-        }
-    };
+impl From<Ipv6Mod> for IpMod {
+    fn from(ip6: Ipv6Mod) -> Self {
+        Self::Ip6(ip6)
+    }
 }
 
-impl UlpHdr {
-    pub fn as_bytes(&self) -> Vec<u8> {
+pub enum EncapHdr<'a> {
+    Geneve(GeneveHdr<'a>),
+}
+
+impl<'a> From<GeneveHdr<'a>> for EncapHdr<'a> {
+    fn from(hdr: GeneveHdr<'a>) -> Self {
+        Self::Geneve(hdr)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum EncapMeta {
+    Geneve(GeneveMeta),
+}
+
+impl From<GeneveMeta> for EncapMeta {
+    fn from(meta: GeneveMeta) -> Self {
+        Self::Geneve(meta)
+    }
+}
+
+#[derive(
+    Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize, Copy,
+)]
+pub enum EncapPush {
+    Geneve(GenevePush),
+}
+
+impl PushAction<EncapMeta> for EncapPush {
+    fn push(&self) -> EncapMeta {
         match self {
-            Self::Tcp(tcp) => tcp.as_bytes(),
-            Self::Udp(udp) => udp.as_bytes(),
+            Self::Geneve(gp) => EncapMeta::from(gp.push()),
         }
     }
+}
 
-    pub fn csum_minus_hdr(&self) -> Checksum {
+impl From<GenevePush> for EncapPush {
+    fn from(gp: GenevePush) -> Self {
+        Self::Geneve(gp)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum EncapMod {
+    Geneve(GeneveMod),
+}
+
+impl ModifyAction<EncapMeta> for EncapMod {
+    fn modify(&self, meta: &mut EncapMeta) {
+        match (self, meta) {
+            (EncapMod::Geneve(g_spec), EncapMeta::Geneve(g_meta)) => {
+                g_spec.modify(g_meta);
+            }
+        }
+    }
+}
+
+impl EncapMeta {
+    pub fn hdr_len(&self) -> usize {
+        match self {
+            Self::Geneve(geneve) => geneve.hdr_len(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum UlpHdr<'a> {
+    Tcp(TcpHdr<'a>),
+    Udp(UdpHdr<'a>),
+}
+
+impl<'a> UlpHdr<'a> {
+    pub fn csum_minus_hdr(&self) -> Option<Checksum> {
         match self {
             Self::Tcp(tcp) => tcp.csum_minus_hdr(),
             Self::Udp(udp) => udp.csum_minus_hdr(),
@@ -389,7 +347,7 @@ impl UlpHdr {
             // Nothing to do for TCP as it determines payload len from
             // IP header.
             Self::Tcp(_tcp) => (),
-            Self::Udp(udp) => udp.set_total_len(len as u16),
+            Self::Udp(udp) => udp.set_len(len as u16),
         }
     }
 
@@ -401,20 +359,52 @@ impl UlpHdr {
     }
 }
 
-#[derive(
-    Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
-)]
+impl<'a> From<TcpHdr<'a>> for UlpHdr<'a> {
+    fn from(tcp: TcpHdr<'a>) -> Self {
+        UlpHdr::Tcp(tcp)
+    }
+}
+
+impl<'a> From<UdpHdr<'a>> for UlpHdr<'a> {
+    fn from(udp: UdpHdr<'a>) -> Self {
+        Self::Udp(udp)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum UlpMeta {
     Tcp(TcpMeta),
     Udp(UdpMeta),
 }
 
 impl UlpMeta {
+    /// Return the checksum value.
+    pub fn csum(&self) -> [u8; 2] {
+        match self {
+            Self::Tcp(tcp) => tcp.csum,
+            Self::Udp(udp) => udp.csum,
+        }
+    }
+
+    pub fn has_csum(&self) -> bool {
+        match self {
+            Self::Tcp(tcp) => tcp.csum != [0; 2],
+            Self::Udp(udp) => udp.csum != [0; 2],
+        }
+    }
+
     /// Return the destination port.
     pub fn dst_port(&self) -> u16 {
         match self {
             Self::Tcp(tcp) => tcp.dst,
             Self::Udp(udp) => udp.dst,
+        }
+    }
+
+    pub fn hdr_len(&self) -> usize {
+        match self {
+            Self::Tcp(tcp) => tcp.hdr_len(),
+            Self::Udp(udp) => udp.hdr_len(),
         }
     }
 
@@ -425,33 +415,78 @@ impl UlpMeta {
             Self::Udp(udp) => udp.src,
         }
     }
+
+    pub fn emit(&self, dst: &mut [u8]) {
+        match self {
+            Self::Tcp(tcp) => tcp.emit(dst),
+            Self::Udp(udp) => udp.emit(dst),
+        }
+    }
 }
 
-impl PushActionArg for UlpMeta {}
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
+)]
+pub enum UlpPush {
+    Tcp(TcpPush),
+    Udp(UdpPush),
+}
+
+impl PushAction<UlpMeta> for UlpPush {
+    fn push(&self) -> UlpMeta {
+        match self {
+            Self::Tcp(tcp) => UlpMeta::from(tcp.push()),
+
+            Self::Udp(udp) => UlpMeta::from(udp.push()),
+        }
+    }
+}
+
+impl From<TcpPush> for UlpPush {
+    fn from(tcp: TcpPush) -> Self {
+        UlpPush::Tcp(tcp)
+    }
+}
+
+impl From<UdpPush> for UlpPush {
+    fn from(udp: UdpPush) -> Self {
+        UlpPush::Udp(udp)
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum UlpMetaOpt {
-    Tcp(TcpMetaOpt),
-    Udp(UdpMetaOpt),
+pub enum UlpMod {
+    Tcp(TcpMod),
+    Udp(UdpMod),
 }
 
-impl ModifyActionArg for UlpMetaOpt {}
-
-impl HeaderActionModify<UlpMetaOpt> for UlpMeta {
-    fn run_modify(&mut self, spec: &UlpMetaOpt) {
-        match (self, spec) {
-            (UlpMeta::Tcp(tcp_meta), UlpMetaOpt::Tcp(tcp_spec)) => {
-                tcp_meta.run_modify(tcp_spec);
+impl ModifyAction<UlpMeta> for UlpMod {
+    fn modify(&self, meta: &mut UlpMeta) {
+        match (self, meta) {
+            (Self::Tcp(spec), UlpMeta::Tcp(meta)) => {
+                spec.modify(meta);
             }
 
-            (UlpMeta::Udp(udp_meta), UlpMetaOpt::Udp(udp_spec)) => {
-                udp_meta.run_modify(udp_spec);
+            (Self::Udp(spec), UlpMeta::Udp(meta)) => {
+                spec.modify(meta);
             }
 
-            (meta, spec) => {
-                panic!("differeing IP meta and spec: {:?} {:?}", meta, spec);
+            (spec, meta) => {
+                panic!("differeing ULP meta and spec: {:?} {:?}", meta, spec);
             }
         }
+    }
+}
+
+impl From<TcpMod> for UlpMod {
+    fn from(tcp: TcpMod) -> Self {
+        UlpMod::Tcp(tcp)
+    }
+}
+
+impl From<UdpMod> for UlpMod {
+    fn from(udp: UdpMod) -> Self {
+        UlpMod::Udp(udp)
     }
 }
 
@@ -467,7 +502,7 @@ impl From<UdpMeta> for UlpMeta {
     }
 }
 
-impl From<&UlpHdr> for UlpMeta {
+impl<'a> From<&UlpHdr<'a>> for UlpMeta {
     fn from(ulp: &UlpHdr) -> Self {
         match ulp {
             UlpHdr::Tcp(tcp) => UlpMeta::Tcp(TcpMeta::from(tcp)),
@@ -480,7 +515,6 @@ impl HeaderActionModify<UlpMetaModify> for UlpMeta {
     fn run_modify(&mut self, spec: &UlpMetaModify) {
         match self {
             UlpMeta::Tcp(tcp_meta) => tcp_meta.run_modify(spec),
-
             UlpMeta::Udp(udp_meta) => udp_meta.run_modify(spec),
         }
     }
@@ -488,53 +522,43 @@ impl HeaderActionModify<UlpMetaModify> for UlpMeta {
 
 /// The action to take for a particular header transposition.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum HeaderAction<P, M>
+pub enum HeaderAction<H, P, M>
 where
-    P: PushActionArg + fmt::Debug,
-    M: ModifyActionArg + fmt::Debug,
+    P: PushAction<H> + fmt::Debug,
+    M: ModifyAction<H> + fmt::Debug,
 {
-    Push(P),
+    Push(P, core::marker::PhantomData<H>),
     Pop,
-    Modify(M),
+    Modify(M, core::marker::PhantomData<H>),
     Ignore,
 }
 
-impl<P, M> Default for HeaderAction<P, M>
+impl<H, P, M> Default for HeaderAction<H, P, M>
 where
-    P: PushActionArg + fmt::Debug,
-    M: ModifyActionArg + fmt::Debug,
+    P: PushAction<H> + fmt::Debug,
+    M: ModifyAction<H> + fmt::Debug,
 {
-    fn default() -> HeaderAction<P, M> {
+    fn default() -> HeaderAction<H, P, M> {
         HeaderAction::Ignore
     }
 }
 
-// XXX Every time I look at this I ask myself "why must P be
-// PushActionArg?". This is just saying that the metadata passed to
-// run() must be the actual full header metadata (e.g. `TcpMeta`). But
-// because of the way I coded this up originally that's also the same
-// type as the argument for a push action. That is, I've conflated the
-// header metadata and the action arguments a bit. This is mostly fine
-// because the two overlap almost 100% (i.e., the values needed for
-// header metadata and the values needed to push a header are
-// basically always the same), but it's a bit confusing and it would
-// probably be better to place a seam between these two things.
-impl<P, M> HeaderAction<P, M>
+impl<H, P, M> HeaderAction<H, P, M>
 where
-    P: HeaderActionModify<M> + PushActionArg + Clone + fmt::Debug,
-    M: ModifyActionArg + fmt::Debug,
+    P: PushAction<H> + fmt::Debug,
+    M: ModifyAction<H> + fmt::Debug,
 {
-    pub fn run(&self, meta: &mut Option<P>) -> Result<(), HeaderActionError> {
+    pub fn run(&self, meta: &mut Option<H>) -> Result<(), HeaderActionError> {
         match self {
             Self::Ignore => (),
 
-            Self::Modify(arg) => match meta {
-                Some(meta) => meta.run_modify(arg),
+            Self::Modify(action, _) => match meta {
+                Some(meta) => action.modify(meta),
                 None => return Err(HeaderActionError::MissingHeader),
             },
 
-            Self::Push(arg) => {
-                meta.replace(arg.clone());
+            Self::Push(action, _) => {
+                meta.replace(action.push());
             }
 
             // A previous action may have already removed this meta,
@@ -552,6 +576,8 @@ where
 pub enum HeaderActionError {
     MissingHeader,
 }
+
+pub trait ModifyActionArg {}
 
 /// A header type that allows itself to be modified via a
 /// [`ModifyActionArg`] specification.

--- a/opte/src/engine/ioctl.rs
+++ b/opte/src/engine/ioctl.rs
@@ -173,14 +173,14 @@ pub struct RuleDump {
 }
 
 pub fn dump_layer(
-    port: &Port,
+    port: &Port<impl crate::engine::NetworkImpl>,
     req: &DumpLayerReq,
 ) -> Result<DumpLayerResp, OpteError> {
     port.dump_layer(&req.name)
 }
 
 pub fn dump_tcp_flows(
-    port: &Port,
+    port: &Port<impl crate::engine::NetworkImpl>,
     _req: &DumpTcpFlowsReq,
 ) -> Result<DumpTcpFlowsResp, OpteError> {
     port.dump_tcp_flows()

--- a/opte/src/engine/mod.rs
+++ b/opte/src/engine/mod.rs
@@ -156,3 +156,218 @@ cfg_if! {
         }
     }
 }
+
+use crate::engine::ether::EtherType;
+use crate::engine::flow_table::FlowTable;
+use crate::engine::ip4::Protocol;
+use crate::engine::packet::HeaderOffsets;
+use crate::engine::packet::Initialized;
+use crate::engine::packet::InnerFlowId;
+use crate::engine::packet::Packet;
+use crate::engine::packet::PacketInfo;
+use crate::engine::packet::PacketMeta;
+use crate::engine::packet::PacketReaderMut;
+use crate::engine::packet::ParseError;
+use crate::engine::packet::Parsed;
+use crate::engine::port::UftEntry;
+
+/// The action to take for a single packet, based on the processing of
+/// the [`NetworkImpl::handle_pkt()`] callback.
+pub enum HdlPktAction {
+    /// Allow the packet to pass through the port.
+    ///
+    /// The handler may have modified the packet.
+    Allow,
+
+    /// Deny the packet from passing through the port.
+    Deny,
+
+    /// Deliver a response packet in the opposite direction of the
+    /// input packet.
+    ///
+    /// The input packet is dropped.
+    Hairpin(Packet<Initialized>),
+}
+
+/// Some type of problem occurred during [`NetworkImpl::handle_pkt()`]
+/// processing.
+pub struct HdlPktError(pub &'static str);
+
+/// An implementation of a particular type of network.
+///
+/// OPTE is a generalized engine for processing and transforming
+/// packets in a flow-based manner. It does not dictate the specific
+/// details of the expected types of packets, that is left to the
+/// network implementation built atop of OPTE. The network
+/// implementation does this is two ways.
+///
+/// 1. It provides its own unique stack of [`layer::Layer`]
+/// definitions; each made up of its unique set of [`rule::Rule`] &
+/// [`rule::Action`] pairings. Furthermore, the actions themselves may
+/// be built atop generic OPTE actions or may be provided in whole by
+/// the network implementation.
+///
+/// 2. It uses this trait to provide hooks into the parsing of packets
+/// as well as single packet processing (non-flow processing).
+///
+/// OPTE itself provides a general structure for parsing; limiting the
+/// possible parse graph to that of a typical L2 + L3 + L4 packet,
+/// with optional encapsulation. The network implementation provides a
+/// specific parser to fill out this general template, as only the
+/// implementation knows the shape of the traffic it expects to see.
+///
+/// The network implementation may also provide additional
+/// single-packet processing. This allows a rule to specify the
+/// handling of the packet at an individual level, instead of
+/// treating it as a flow. This is useful for packets that do not
+/// easily map to the flow model.
+pub trait NetworkImpl {
+    /// The packet parser for this network implementation.
+    type Parser: NetworkParser;
+
+    /// Handle an individual packet on its own, separate from the flow
+    /// processing. This callback is a general mechanism for handling
+    /// packets which don't fit neatly into flow processing, and do
+    /// not require maximal performance. For this reason, it allows
+    /// deeper packet inspection and is not bound to the more limited
+    /// predicate matching system.
+    ///
+    /// This is called as part of rule processing when a matched rule
+    /// has an action of [`rule::Action::HandlePacket`]. Upon entering
+    /// this callback, there is no return to rule processing. It's the
+    /// sole discretion of this callback to determine the response to
+    /// take in regards to the input packet. That response is dictated
+    /// by the [`HdlPktAction`] value.
+    ///
+    /// This callback is given access to both the inbound and outbound
+    /// UFT tables. This can be useful for handling certain types of
+    /// traffic, such as ICMP DU, where you may want to match parts of
+    /// the packet body with flow state.
+    ///
+    /// # Errors
+    ///
+    /// As this is a general mechanism, the handler may fail for a
+    /// myriad of reasons. The error returned is for informational
+    /// purposes, rather than having any obvious direct action to take
+    /// in response.
+    fn handle_pkt(
+        &self,
+        dir: Direction,
+        pkt: &mut Packet<Parsed>,
+        uft_in: &FlowTable<UftEntry<InnerFlowId>>,
+        uft_out: &FlowTable<UftEntry<InnerFlowId>>,
+    ) -> Result<HdlPktAction, HdlPktError>;
+
+    /// Return the parser for this network implementation.
+    fn parser(&self) -> Self::Parser;
+}
+
+/// A packet parser for the network implementation.
+///
+/// This provides parsing for inbound/outbound packets for a given
+/// [`NetworkImpl`].
+pub trait NetworkParser {
+    /// Parse an outbound packet.
+    ///
+    /// An outbound packet is one traveling from the [`port::Port`]
+    /// client to the network.
+    fn parse_outbound(
+        &self,
+        rdr: &mut PacketReaderMut,
+    ) -> Result<PacketInfo, ParseError>;
+
+    /// Parse an inbound packet.
+    ///
+    /// An inbound packet is one traveling from the network to the
+    /// [`port::Port`] client.
+    fn parse_inbound(
+        &self,
+        rdr: &mut PacketReaderMut,
+    ) -> Result<PacketInfo, ParseError>;
+}
+
+/// A generic ULP parser, useful for testing inside of the opte crate
+/// itself.
+pub struct GenericUlp {}
+
+impl GenericUlp {
+    /// Parse a generic L2 + L3 + L4 packet, storing the headers in
+    /// the inner position.
+    fn parse_ulp(
+        &self,
+        rdr: &mut PacketReaderMut,
+    ) -> Result<PacketInfo, ParseError> {
+        let mut meta = PacketMeta::default();
+        let mut offsets = HeaderOffsets::default();
+
+        let (ether_hi, _ether_hdr) = Packet::parse_ether(rdr)?;
+        meta.inner.ether = ether_hi.meta;
+        offsets.inner.ether = ether_hi.offset;
+        let ether_type = EtherType::from(ether_hi.meta.ether_type);
+
+        let (ip_hi, pseudo_csum) = match ether_type {
+            EtherType::Arp => {
+                return Ok(PacketInfo { meta, offsets, body_csum: None });
+            }
+
+            EtherType::Ipv4 => {
+                let (ip_hi, hdr) = Packet::parse_ip4(rdr)?;
+                (ip_hi, hdr.pseudo_csum())
+            }
+
+            EtherType::Ipv6 => {
+                let (ip_hi, hdr) = Packet::parse_ip6(rdr)?;
+                (ip_hi, hdr.pseudo_csum())
+            }
+
+            _ => return Err(ParseError::UnexpectedEtherType(ether_type)),
+        };
+
+        meta.inner.ip = Some(ip_hi.meta);
+        offsets.inner.ip = Some(ip_hi.offset);
+
+        let (ulp_hi, ulp_hdr) = match ip_hi.meta.proto() {
+            Protocol::ICMP => {
+                return Ok(PacketInfo { meta, offsets, body_csum: None });
+
+                // todo!("need to reintrodouce ICMP as pseudo-ULP header");
+                // pkt.parse_icmp()?,
+            }
+
+            Protocol::ICMPv6 => {
+                return Ok(PacketInfo { meta, offsets, body_csum: None });
+            }
+
+            Protocol::TCP => Packet::parse_tcp(rdr)?,
+            Protocol::UDP => Packet::parse_udp(rdr)?,
+            proto => return Err(ParseError::UnexpectedProtocol(proto)),
+        };
+
+        meta.inner.ulp = Some(ulp_hi.meta);
+        offsets.inner.ulp = Some(ulp_hi.offset);
+        let body_csum = if let Some(mut csum) = ulp_hdr.csum_minus_hdr() {
+            csum -= pseudo_csum;
+            Some(csum)
+        } else {
+            None
+        };
+
+        Ok(PacketInfo { meta, offsets, body_csum })
+    }
+}
+
+impl NetworkParser for GenericUlp {
+    fn parse_inbound(
+        &self,
+        rdr: &mut PacketReaderMut,
+    ) -> Result<PacketInfo, ParseError> {
+        self.parse_ulp(rdr)
+    }
+
+    fn parse_outbound(
+        &self,
+        rdr: &mut PacketReaderMut,
+    ) -> Result<PacketInfo, ParseError> {
+        self.parse_ulp(rdr)
+    }
+}

--- a/opteadm/Cargo.lock
+++ b/opteadm/Cargo.lock
@@ -19,11 +19,11 @@ checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.3"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a93ba5d6053837dbb76fd0ae26fd4f0c1859a008a783b0ce072b797c07f0f27"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
 dependencies = [
- "cortex-m",
+ "critical-section",
 ]
 
 [[package]]
@@ -36,21 +36,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "bare-metal"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
-name = "bitfield"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
 name = "bitflags"
@@ -103,16 +88,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cortex-m"
-version = "0.7.3"
+name = "critical-section"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac919ef424449ec8c08d515590ce15d9262c0ca5f0da5b0c901e971a3b783b3"
-dependencies = [
- "bare-metal",
- "bitfield",
- "embedded-hal",
- "volatile-register",
-]
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "cstr-argument"
@@ -140,16 +119,6 @@ name = "dyn-clone"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
-
-[[package]]
-name = "embedded-hal"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36cfb62ff156596c892272f3015ef952fe1525e85261fa3a7f327bd6b384ab9"
-dependencies = [
- "nb 0.1.3",
- "void",
-]
 
 [[package]]
 name = "foreign-types"
@@ -189,12 +158,13 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.9"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e476c64197665c3725621f0ac3f9e5209aa5e889e02a08b1daf5f16dc5fd952"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
  "hash32",
+ "rustc_version",
  "serde",
  "spin",
  "stable_deref_trait",
@@ -279,21 +249,6 @@ name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
-
-[[package]]
-name = "nb"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
-dependencies = [
- "nb 1.0.0",
-]
-
-[[package]]
-name = "nb"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "num_enum"
@@ -482,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
@@ -515,18 +470,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.9.0"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
@@ -726,12 +672,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
-name = "vcell"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
-
-[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,21 +682,6 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "volatile-register"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d67cb4616d99b940db1d6bd28844ff97108b498a6ca850e5b6191a532063286"
-dependencies = [
- "vcell",
-]
 
 [[package]]
 name = "winapi"

--- a/oxide-vpc/Cargo.lock
+++ b/oxide-vpc/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,9 +10,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14bf7b4f565e5e717d7a7a65b2a05c0b8c96e4db636d6f780f03b15108cdd1b"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
 dependencies = [
  "critical-section",
 ]
@@ -31,33 +22,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "bare-metal"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
-dependencies = [
- "rustc_version 0.2.3",
-]
-
-[[package]]
-name = "bare-metal"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
-
-[[package]]
-name = "bit_field"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
-
-[[package]]
-name = "bitfield"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
 name = "bitflags"
@@ -117,18 +81,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
 
 [[package]]
-name = "cortex-m"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd20d4ac4aa86f4f75f239d59e542ef67de87cce2c282818dc6e84155d3ea126"
-dependencies = [
- "bare-metal 0.2.5",
- "bitfield",
- "embedded-hal",
- "volatile-register",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,15 +91,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "0.2.7"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95da181745b56d4bd339530ec393508910c909c784e8962d15d722bacf0bcbcd"
-dependencies = [
- "bare-metal 1.0.0",
- "cfg-if 1.0.0",
- "cortex-m",
- "riscv",
-]
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "crypto-common"
@@ -207,16 +153,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 
 [[package]]
-name = "embedded-hal"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
-dependencies = [
- "nb 0.1.3",
- "void",
-]
-
-[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,7 +185,7 @@ checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
  "hash32",
- "rustc_version 0.4.0",
+ "rustc_version",
  "spin",
  "stable_deref_trait",
 ]
@@ -273,12 +209,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "lexical-core"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,9 +229,9 @@ checksum = "64de3cc433455c14174d42e554d4027ee631c4d046d43e3ecc6efc4636cdc7a7"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -318,21 +248,6 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "nb"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
-dependencies = [
- "nb 1.0.0",
-]
-
-[[package]]
-name = "nb"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "nom"
@@ -503,59 +418,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
-
-[[package]]
-name = "riscv"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6907ccdd7a31012b70faf2af85cd9e5ba97657cc3987c4f13f8e4d2c2a088aba"
-dependencies = [
- "bare-metal 1.0.0",
- "bit_field",
- "riscv-target",
-]
-
-[[package]]
-name = "riscv-target"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88aa938cda42a0cf62a20cfe8d139ff1af20c2e681212b5b34adb5a58333f222"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.13",
+ "semver",
 ]
 
 [[package]]
@@ -581,24 +449,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.9.0"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
@@ -832,31 +685,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcell"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "volatile-register"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
-dependencies = [
- "vcell",
-]
 
 [[package]]
 name = "winapi"

--- a/oxide-vpc/src/engine/firewall.rs
+++ b/oxide-vpc/src/engine/firewall.rs
@@ -9,6 +9,7 @@
 //! This layer is responsible for implementing the VPC firewall as
 //! described in RFD 21 §2.8.
 
+use super::VpcNetwork;
 use crate::api::AddFwRuleReq;
 use crate::api::Address;
 use crate::api::FirewallAction;
@@ -53,7 +54,10 @@ pub fn setup(
     pb.add_layer(fw_layer, Pos::First)
 }
 
-pub fn add_fw_rule(port: &Port, req: &AddFwRuleReq) -> Result<(), OpteError> {
+pub fn add_fw_rule(
+    port: &Port<VpcNetwork>,
+    req: &AddFwRuleReq,
+) -> Result<(), OpteError> {
     let action = match req.rule.action {
         FirewallAction::Allow => Action::StatefulAllow,
         FirewallAction::Deny => Action::Deny,
@@ -63,11 +67,17 @@ pub fn add_fw_rule(port: &Port, req: &AddFwRuleReq) -> Result<(), OpteError> {
     port.add_rule(FW_LAYER_NAME, req.rule.direction, rule)
 }
 
-pub fn rem_fw_rule(port: &Port, req: &RemFwRuleReq) -> Result<(), OpteError> {
+pub fn rem_fw_rule(
+    port: &Port<VpcNetwork>,
+    req: &RemFwRuleReq,
+) -> Result<(), OpteError> {
     port.remove_rule(FW_LAYER_NAME, req.dir, req.id)
 }
 
-pub fn set_fw_rules(port: &Port, req: &SetFwRulesReq) -> Result<(), OpteError> {
+pub fn set_fw_rules(
+    port: &Port<VpcNetwork>,
+    req: &SetFwRulesReq,
+) -> Result<(), OpteError> {
     let mut in_rules = vec![];
     let mut out_rules = vec![];
 

--- a/oxide-vpc/src/engine/gateway/arp.rs
+++ b/oxide-vpc/src/engine/gateway/arp.rs
@@ -6,23 +6,16 @@
 
 //! The ARP implementation of the Virtual Gateway.
 
-cfg_if! {
-    if #[cfg(all(not(feature = "std"), not(test)))] {
-        use alloc::sync::Arc;
-    } else {
-        use std::sync::Arc;
-    }
-}
-
 use crate::api::Ipv4Cfg;
 use crate::api::VpcCfg;
 use core::result::Result;
 use opte::api::Direction;
 use opte::api::MacAddr;
 use opte::api::OpteError;
-use opte::engine::arp::ArpReply;
+use opte::engine::ether::ETHER_TYPE_ARP;
 use opte::engine::layer::Layer;
 use opte::engine::predicate::EtherAddrMatch;
+use opte::engine::predicate::EtherTypeMatch;
 use opte::engine::predicate::Predicate;
 use opte::engine::rule::Action;
 use opte::engine::rule::Rule;
@@ -32,56 +25,43 @@ pub fn setup(
     cfg: &VpcCfg,
     ip_cfg: &Ipv4Cfg,
 ) -> Result<(), OpteError> {
-    // We need to respond to its ARP requests to resolve the gateway
-    // (OPTE) IP address. While the external IP hack is still in
-    // place, we also need to Proxy ARP external requests for the
-    // guest's IP address.
-
     // ================================================================
     // Outbound ARP Request for Gateway, from Guest
+    //
+    // We need to respond to guest ARP requests so it may resolve the
+    // gateway (OPTE) IP address.
     // ================================================================
-    let reply = Action::Hairpin(Arc::new(ArpReply::new(
-        ip_cfg.gateway_ip,
-        cfg.gateway_mac,
-    )));
-    let mut rule = Rule::new(1, reply);
-    rule.add_predicate(Predicate::InnerEtherSrc(vec![EtherAddrMatch::Exact(
-        MacAddr::from(cfg.guest_mac),
-    )]));
+    let mut rule = Rule::new(1, Action::HandlePacket);
+    rule.add_predicates(vec![
+        Predicate::InnerEtherType(vec![EtherTypeMatch::Exact(ETHER_TYPE_ARP)]),
+        Predicate::InnerEtherDst(vec![EtherAddrMatch::Exact(
+            MacAddr::BROADCAST,
+        )]),
+        Predicate::InnerEtherSrc(vec![EtherAddrMatch::Exact(MacAddr::from(
+            cfg.guest_mac,
+        ))]),
+    ]);
     layer.add_rule(Direction::Out, rule.finalize());
 
     // ================================================================
-    // Proxy ARP for any incoming requests for guest's external IP.
+    // Proxy ARP for any incoming requests for guest's externally
+    // visible IPs.
     //
     // XXX-EXT-IP This is a hack to get guest access working until we
     // have boundary services integrated.
     // ================================================================
-    if let Some(ip) = ip_cfg.external_ips.as_ref() {
+    if ip_cfg.external_ips.as_ref().is_some() || ip_cfg.snat.is_some() {
         if cfg.proxy_arp_enable {
-            let action =
-                Action::Hairpin(Arc::new(ArpReply::new(*ip, cfg.guest_mac)));
-            let rule = Rule::new(1, action);
-            layer.add_rule(Direction::In, rule.finalize());
-        }
-    }
+            let mut rule = Rule::new(1, Action::HandlePacket);
+            rule.add_predicates(vec![
+                Predicate::InnerEtherType(vec![EtherTypeMatch::Exact(
+                    ETHER_TYPE_ARP,
+                )]),
+                Predicate::InnerEtherDst(vec![EtherAddrMatch::Exact(
+                    MacAddr::BROADCAST,
+                )]),
+            ]);
 
-    // ================================================================
-    // Proxy ARP for any incoming requests for guest's SNAT IP.
-    //
-    // This is not great because once you have more than one guest it
-    // means there is an ARP battle for the same SNAT IP. One more
-    // rason why this hack needs to go away.
-    //
-    // XXX-EXT-IP This is a hack to get guest access working until we
-    // have boundary services integrated.
-    // ================================================================
-    if let Some(snat) = ip_cfg.snat.as_ref() {
-        if cfg.proxy_arp_enable {
-            let action = Action::Hairpin(Arc::new(ArpReply::new(
-                snat.external_ip,
-                cfg.guest_mac,
-            )));
-            let rule = Rule::new(1, action);
             layer.add_rule(Direction::In, rule.finalize());
         }
     }

--- a/oxide-vpc/src/engine/gateway/mod.rs
+++ b/oxide-vpc/src/engine/gateway/mod.rs
@@ -49,9 +49,11 @@ use crate::engine::overlay::VpcMappings;
 use crate::engine::overlay::ACTION_META_VNI;
 use core::fmt;
 use core::fmt::Display;
+use core::marker::PhantomData;
 use opte::api::Direction;
 use opte::api::OpteError;
-use opte::engine::ether::EtherMeta;
+use opte::engine::ether::EtherMod;
+use opte::engine::headers::HeaderAction;
 use opte::engine::layer::DefaultAction;
 use opte::engine::layer::Layer;
 use opte::engine::layer::LayerActions;
@@ -146,7 +148,10 @@ impl StaticAction for RewriteSrcMac {
         _action_meta: &mut ActionMeta,
     ) -> GenHtResult {
         Ok(AllowOrDeny::Allow(HdrTransform {
-            inner_ether: EtherMeta::modify(Some(self.gateway_mac), None),
+            inner_ether: HeaderAction::Modify(
+                EtherMod { src: Some(self.gateway_mac), ..Default::default() },
+                PhantomData,
+            ),
             ..Default::default()
         }))
     }

--- a/oxide-vpc/src/engine/mod.rs
+++ b/oxide-vpc/src/engine/mod.rs
@@ -11,3 +11,328 @@ pub mod overlay;
 #[cfg(any(feature = "std", test))]
 pub mod print;
 pub mod router;
+
+use crate::api::VpcCfg;
+use opte::engine::ether::EtherType;
+use opte::engine::flow_table::FlowTable;
+use opte::engine::headers::EncapMeta;
+use opte::engine::ip4::Protocol;
+use opte::engine::packet::HeaderOffsets;
+use opte::engine::packet::InnerFlowId;
+use opte::engine::packet::Packet;
+use opte::engine::packet::PacketInfo;
+use opte::engine::packet::PacketMeta;
+use opte::engine::packet::PacketRead;
+use opte::engine::packet::PacketReaderMut;
+use opte::engine::packet::ParseError;
+use opte::engine::packet::Parsed;
+use opte::engine::port::UftEntry;
+use opte::engine::Direction;
+use opte::engine::HdlPktAction;
+use opte::engine::HdlPktError;
+use opte::engine::NetworkImpl;
+use opte::engine::NetworkParser;
+
+use opte::engine::arp;
+use opte::engine::arp::ArpEthIpv4;
+use opte::engine::arp::ArpOp;
+use opte::engine::ether::ETHER_TYPE_IPV4;
+use opte::engine::ip4::Ipv4Addr;
+
+#[derive(Clone, Copy, Debug)]
+pub struct VpcParser {
+    // XXX-EXT-IP hack
+    pub proxy_arp_enable: bool,
+}
+
+impl VpcParser {
+    pub fn new() -> Self {
+        Self { proxy_arp_enable: false }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct VpcNetwork {
+    pub cfg: VpcCfg,
+}
+
+// The ARP HTYPE for Ethernet.
+const HTYPE_ETHER: u16 = 1;
+
+fn is_arp_req(arp: &ArpEthIpv4) -> bool {
+    arp.htype == HTYPE_ETHER
+        && arp.ptype == ETHER_TYPE_IPV4
+        && arp.op == ArpOp::Request
+}
+
+fn is_arp_req_for_tpa(tpa: Ipv4Addr, arp: &ArpEthIpv4) -> bool {
+    if is_arp_req(&arp) {
+        if arp.tpa == tpa {
+            return true;
+        }
+    }
+
+    false
+}
+
+impl VpcNetwork {
+    fn handle_arp_out(
+        &self,
+        pkt: &mut Packet<Parsed>,
+    ) -> Result<HdlPktAction, HdlPktError> {
+        let arp_start = pkt.hdr_offsets().inner.ether.hdr_len;
+        let mut rdr = pkt.get_rdr_mut();
+        rdr.seek(arp_start).unwrap();
+        let arp = ArpEthIpv4::parse(&mut rdr)
+            .map_err(|_| HdlPktError("outbound ARP"))?;
+        let gw_ip = self.cfg.ipv4_cfg().unwrap().gateway_ip;
+
+        if is_arp_req_for_tpa(gw_ip, &arp) {
+            let gw_mac = self.cfg.gateway_mac;
+
+            let hp = arp::gen_arp_reply(gw_mac, gw_ip, arp.sha, arp.spa);
+            return Ok(HdlPktAction::Hairpin(hp));
+        }
+
+        Ok(HdlPktAction::Deny)
+    }
+
+    fn handle_arp_in(
+        &self,
+        pkt: &mut Packet<Parsed>,
+    ) -> Result<HdlPktAction, HdlPktError> {
+        let arp_start = pkt.hdr_offsets().inner.ether.hdr_len;
+        let mut rdr = pkt.get_rdr_mut();
+        rdr.seek(arp_start).unwrap();
+        let arp = ArpEthIpv4::parse(&mut rdr)
+            .map_err(|_| HdlPktError("inbound ARP"))?;
+        let proxy_arp = self.cfg.proxy_arp_enable;
+        let guest_mac = self.cfg.guest_mac;
+        let ip_cfg = self.cfg.ipv4_cfg().unwrap();
+
+        // ================================================================
+        // Proxy ARP for any incoming requests for guest's external IP.
+        //
+        // XXX-EXT-IP This is a hack to get guest access working until
+        // we have boundary services integrated.
+        // ================================================================
+        if let Some(external_ip) = ip_cfg.external_ips {
+            if proxy_arp && is_arp_req_for_tpa(external_ip, &arp) {
+                let hp = arp::gen_arp_reply(
+                    guest_mac,
+                    external_ip,
+                    arp.sha,
+                    arp.spa,
+                );
+                return Ok(HdlPktAction::Hairpin(hp));
+            }
+        }
+
+        // ================================================================
+        // Proxy ARP for any incoming requests for guest's SNAT IP.
+        //
+        // This is not great because once you have more than one guest
+        // it means there is an ARP battle for the same SNAT IP. One
+        // more rason why this hack needs to go away.
+        //
+        // XXX-EXT-IP This is a hack to get guest access working until
+        // we have boundary services integrated.
+        // ================================================================
+        if let Some(snat) = ip_cfg.snat.as_ref() {
+            if proxy_arp && is_arp_req_for_tpa(snat.external_ip, &arp) {
+                let hp = arp::gen_arp_reply(
+                    guest_mac,
+                    snat.external_ip,
+                    arp.sha,
+                    arp.spa,
+                );
+                return Ok(HdlPktAction::Hairpin(hp));
+            }
+        }
+
+        Ok(HdlPktAction::Deny)
+    }
+}
+
+impl NetworkImpl for VpcNetwork {
+    type Parser = VpcParser;
+
+    fn handle_pkt(
+        &self,
+        dir: Direction,
+        pkt: &mut Packet<Parsed>,
+        _uft_in: &FlowTable<UftEntry<InnerFlowId>>,
+        _uft_out: &FlowTable<UftEntry<InnerFlowId>>,
+    ) -> Result<HdlPktAction, HdlPktError> {
+        match (dir, pkt.meta().inner.ether.ether_type) {
+            (Direction::Out, EtherType::Arp) => self.handle_arp_out(pkt),
+
+            // XXX-EXT-IP This is only need for the hack.
+            (Direction::In, EtherType::Arp) => self.handle_arp_in(pkt),
+
+            _ => Ok(HdlPktAction::Deny),
+        }
+    }
+
+    fn parser(&self) -> Self::Parser {
+        VpcParser { proxy_arp_enable: self.cfg.proxy_arp_enable }
+    }
+}
+
+impl NetworkParser for VpcParser {
+    fn parse_outbound(
+        &self,
+        rdr: &mut PacketReaderMut,
+    ) -> Result<PacketInfo, ParseError> {
+        let mut meta = PacketMeta::default();
+        let mut offsets = HeaderOffsets::default();
+        let (ether_hi, _hdr) = Packet::parse_ether(rdr)?;
+        meta.inner.ether = ether_hi.meta;
+        offsets.inner.ether = ether_hi.offset;
+        let ether_type = ether_hi.meta.ether_type;
+
+        let (ip_hi, pseudo_csum) = match ether_type {
+            EtherType::Arp => {
+                return Ok(PacketInfo { meta, offsets, body_csum: None });
+            }
+
+            EtherType::Ipv4 => {
+                let (ip_hi, hdr) = Packet::parse_ip4(rdr)?;
+                (ip_hi, hdr.pseudo_csum())
+            }
+
+            EtherType::Ipv6 => {
+                let (ip_hi, hdr) = Packet::parse_ip6(rdr)?;
+                (ip_hi, hdr.pseudo_csum())
+            }
+
+            _ => return Err(ParseError::UnexpectedEtherType(ether_type)),
+        };
+
+        meta.inner.ip = Some(ip_hi.meta);
+        offsets.inner.ip = Some(ip_hi.offset);
+
+        let (ulp_hi, ulp_hdr) = match ip_hi.meta.proto() {
+            Protocol::ICMP => {
+                return Ok(PacketInfo { meta, offsets, body_csum: None });
+                // todo!("need to reintrodouce ICMP as pseudo-ULP header");
+                // pkt.parse_icmp()?,
+            }
+
+            Protocol::ICMPv6 => {
+                return Ok(PacketInfo { meta, offsets, body_csum: None });
+            }
+
+            Protocol::TCP => Packet::parse_tcp(rdr)?,
+            Protocol::UDP => Packet::parse_udp(rdr)?,
+            proto => return Err(ParseError::UnexpectedProtocol(proto)),
+        };
+
+        meta.inner.ulp = Some(ulp_hi.meta);
+        offsets.inner.ulp = Some(ulp_hi.offset);
+
+        let body_csum = if let Some(mut csum) = ulp_hdr.csum_minus_hdr() {
+            csum -= pseudo_csum;
+            Some(csum)
+        } else {
+            None
+        };
+
+        Ok(PacketInfo { meta, offsets, body_csum })
+    }
+
+    fn parse_inbound(
+        &self,
+        rdr: &mut PacketReaderMut,
+    ) -> Result<PacketInfo, ParseError> {
+        let mut meta = PacketMeta::default();
+        let mut offsets = HeaderOffsets::default();
+
+        // XXX-EXT-IP If proxy ARP is enabled, then we are not on the
+        // Oxide Rack Network and have no encap.
+        if !self.proxy_arp_enable {
+            let (outer_ether_hi, _hdr) = Packet::parse_ether(rdr)?;
+            meta.outer.ether = Some(outer_ether_hi.meta);
+            offsets.outer.ether = Some(outer_ether_hi.offset);
+            let outer_et = outer_ether_hi.meta.ether_type;
+
+            // VPC traffic is delivered exclusively on an IPv6 +
+            // Geneve underlay.
+            let outer_ip_hi = match outer_et {
+                EtherType::Ipv6 => Packet::parse_ip6(rdr)?.0,
+
+                _ => return Err(ParseError::UnexpectedEtherType(outer_et)),
+            };
+
+            meta.outer.ip = Some(outer_ip_hi.meta);
+            offsets.outer.ip = Some(outer_ip_hi.offset);
+
+            let (geneve_hi, _geneve_hdr) = match outer_ip_hi.meta.proto() {
+                Protocol::UDP => Packet::parse_geneve(rdr)?,
+                proto => return Err(ParseError::UnexpectedProtocol(proto)),
+            };
+
+            meta.outer.encap = Some(EncapMeta::from(geneve_hi.meta));
+            offsets.outer.encap = Some(geneve_hi.offset);
+        }
+
+        let (inner_ether_hi, _) = Packet::parse_ether(rdr)?;
+        meta.inner.ether = inner_ether_hi.meta;
+        offsets.inner.ether = inner_ether_hi.offset;
+        let inner_et = inner_ether_hi.meta.ether_type;
+
+        let (inner_ip_hi, pseudo_csum) = match inner_et {
+            EtherType::Ipv4 => {
+                let (ip_hi, hdr) = Packet::parse_ip4(rdr)?;
+                (ip_hi, hdr.pseudo_csum())
+            }
+
+            EtherType::Ipv6 => {
+                let (ip_hi, hdr) = Packet::parse_ip6(rdr)?;
+                (ip_hi, hdr.pseudo_csum())
+            }
+
+            EtherType::Arp => {
+                // XXX-EXT-IP Need to allow inbound ARP for proxy ARP
+                // to work.
+                if self.proxy_arp_enable {
+                    return Ok(PacketInfo { meta, offsets, body_csum: None });
+                } else {
+                    return Err(ParseError::UnexpectedEtherType(inner_et));
+                }
+            }
+
+            _ => return Err(ParseError::UnexpectedEtherType(inner_et)),
+        };
+
+        meta.inner.ip = Some(inner_ip_hi.meta);
+        offsets.inner.ip = Some(inner_ip_hi.offset);
+
+        let (inner_ulp_hi, inner_ulp_hdr) = match inner_ip_hi.meta.proto() {
+            Protocol::ICMP => {
+                return Ok(PacketInfo { meta, offsets, body_csum: None });
+                // todo!("need to reintrodouce ICMP as pseudo-ULP header");
+                // pkt.parse_icmp()?,
+            }
+
+            Protocol::ICMPv6 => {
+                return Ok(PacketInfo { meta, offsets, body_csum: None });
+            }
+
+            Protocol::TCP => Packet::parse_tcp(rdr)?,
+            Protocol::UDP => Packet::parse_udp(rdr)?,
+            proto => return Err(ParseError::UnexpectedProtocol(proto)),
+        };
+
+        meta.inner.ulp = Some(inner_ulp_hi.meta);
+        offsets.inner.ulp = Some(inner_ulp_hi.offset);
+        let body_csum = if let Some(mut csum) = inner_ulp_hdr.csum_minus_hdr() {
+            csum -= pseudo_csum;
+            Some(csum)
+        } else {
+            None
+        };
+
+        Ok(PacketInfo { meta, offsets, body_csum })
+    }
+}

--- a/oxide-vpc/src/engine/router.rs
+++ b/oxide-vpc/src/engine/router.rs
@@ -23,6 +23,7 @@ cfg_if! {
 }
 
 use super::firewall as fw;
+use super::VpcNetwork;
 use crate::api::DelRouterEntryResp;
 use crate::api::RouterTarget;
 use crate::api::VpcCfg;
@@ -299,7 +300,7 @@ fn make_rule(
 /// For the entry to be deleted it must match exactly for the
 /// destination [`IpCidr`] as well as its paired [`RouterTarget`].
 pub fn del_entry(
-    port: &Port,
+    port: &Port<VpcNetwork>,
     dest: IpCidr,
     target: RouterTarget,
 ) -> Result<DelRouterEntryResp, OpteError> {
@@ -319,7 +320,7 @@ pub fn del_entry(
 ///
 /// Route the [`IpCidr`] to the specified [`RouterTarget`].
 pub fn add_entry(
-    port: &Port,
+    port: &Port<VpcNetwork>,
     dest: IpCidr,
     target: RouterTarget,
 ) -> Result<NoResp, OpteError> {
@@ -330,7 +331,7 @@ pub fn add_entry(
 
 /// Replace the current set of router entries with the set passed in.
 pub fn replace(
-    port: &Port,
+    port: &Port<VpcNetwork>,
     entries: Vec<(IpCidr, RouterTarget)>,
 ) -> Result<NoResp, OpteError> {
     let mut out_rules = Vec::with_capacity(entries.len());

--- a/oxide-vpc/tests/common/icmp.rs
+++ b/oxide-vpc/tests/common/icmp.rs
@@ -11,10 +11,13 @@ use opte::engine::ether::*;
 use opte::engine::ip4::*;
 use opte::engine::ip6::*;
 use opte::engine::packet::*;
+use opte::engine::Direction::*;
+use oxide_vpc::engine::VpcParser;
 use smoltcp::wire::Icmpv4Packet;
 use smoltcp::wire::Icmpv4Repr;
 use smoltcp::wire::Icmpv6Packet;
 use smoltcp::wire::Icmpv6Repr;
+use smoltcp::wire::IpProtocol;
 use smoltcp::wire::Ipv6Address;
 
 pub enum IcmpEchoType {
@@ -86,25 +89,24 @@ pub fn gen_icmp_echo(
     let mut icmp_pkt = Icmpv4Packet::new_unchecked(&mut icmp_bytes);
     let _ = icmp.emit(&mut icmp_pkt, &Default::default());
 
-    let mut ip4 = Ipv4Hdr::from(&Ipv4Meta {
+    let mut ip4 = Ipv4Meta {
         src: ip_src,
         dst: ip_dst,
         proto: Protocol::ICMP,
-    });
-    ip4.set_total_len(ip4.hdr_len() as u16 + icmp.buffer_len() as u16);
+        total_len: (Ipv4Hdr::BASE_SIZE + icmp.buffer_len()) as u16,
+        ..Default::default()
+    };
     ip4.compute_hdr_csum();
-    let eth = EtherHdr::from(&EtherMeta {
-        dst: eth_dst,
-        src: eth_src,
-        ether_type: ETHER_TYPE_IPV4,
-    });
+    let eth =
+        &EtherMeta { dst: eth_dst, src: eth_src, ether_type: EtherType::Ipv4 };
 
-    let mut pkt_bytes =
-        Vec::with_capacity(EtherHdr::SIZE + ip4.hdr_len() + icmp.buffer_len());
-    pkt_bytes.extend_from_slice(&eth.as_bytes());
-    pkt_bytes.extend_from_slice(&ip4.as_bytes());
-    pkt_bytes.extend_from_slice(&icmp_bytes);
-    Packet::copy(&pkt_bytes).parse().unwrap()
+    let total_len = EtherHdr::SIZE + ip4.hdr_len() + icmp.buffer_len();
+    let mut pkt = Packet::alloc_and_expand(total_len);
+    let mut wtr = pkt.seg0_wtr();
+    eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
+    ip4.emit(wtr.slice_mut(ip4.hdr_len()).unwrap());
+    wtr.write(&icmp_bytes).unwrap();
+    pkt.parse(Out, VpcParser::new()).unwrap()
 }
 
 pub fn gen_icmpv6_echo_req(
@@ -125,22 +127,23 @@ pub fn gen_icmpv6_echo_req(
         &mut req_pkt,
         &Default::default(),
     );
-    let mut ip6 = Ipv6Hdr::from(&Ipv6Meta {
+    let ip6 = Ipv6Meta {
         src: ip_src,
         dst: ip_dst,
         proto: Protocol::ICMPv6,
-    });
-    ip6.set_total_len(ip6.hdr_len() as u16 + req.buffer_len() as u16);
-    let eth = EtherHdr::from(&EtherMeta {
-        dst: eth_dst,
-        src: eth_src,
-        ether_type: ETHER_TYPE_IPV6,
-    });
+        next_hdr: IpProtocol::Icmpv6,
+        hop_limit: 64,
+        pay_len: (Ipv6Hdr::BASE_SIZE + req.buffer_len()) as u16,
+        ..Default::default()
+    };
+    let eth =
+        &EtherMeta { dst: eth_dst, src: eth_src, ether_type: EtherType::Ipv6 };
 
-    let mut pkt_bytes =
-        Vec::with_capacity(EtherHdr::SIZE + ip6.hdr_len() + req.buffer_len());
-    pkt_bytes.extend_from_slice(&eth.as_bytes());
-    pkt_bytes.extend_from_slice(&ip6.as_bytes());
-    pkt_bytes.extend_from_slice(&body_bytes);
-    Packet::copy(&pkt_bytes).parse().unwrap()
+    let total_len = EtherHdr::SIZE + ip6.hdr_len() + req.buffer_len();
+    let mut pkt = Packet::alloc_and_expand(total_len);
+    let mut wtr = pkt.seg0_wtr();
+    eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
+    ip6.emit(wtr.slice_mut(ip6.hdr_len()).unwrap());
+    wtr.write(&body_bytes).unwrap();
+    pkt.parse(Out, VpcParser::new()).unwrap()
 }

--- a/oxide-vpc/tests/common/pcap.rs
+++ b/oxide-vpc/tests/common/pcap.rs
@@ -63,7 +63,7 @@ impl PcapBuilder {
 
     /// Add a packet to the capture.
     pub fn add_pkt(&mut self, pkt: &Packet<Parsed>) {
-        let pkt_bytes = PacketReader::new(&pkt, ()).copy_remaining();
+        let pkt_bytes = pkt.get_rdr().copy_remaining();
         let mut block = LegacyPcapBlock {
             ts_sec: 7777,
             ts_usec: 7777,

--- a/oxide-vpc/tests/common/port_state.rs
+++ b/oxide-vpc/tests/common/port_state.rs
@@ -11,11 +11,12 @@ use opte::engine::port::*;
 use opte::engine::print::*;
 use oxide_vpc::engine::overlay::VpcMappings;
 use oxide_vpc::engine::print::*;
+use oxide_vpc::engine::VpcNetwork;
 use std::collections::BTreeMap;
 
 /// Print various port state in a human-friendly manner when a test
 /// assertion fails.
-pub fn print_port(port: &Port, vpc_map: &VpcMappings) {
+pub fn print_port(port: &Port<VpcNetwork>, vpc_map: &VpcMappings) {
     // ================================================================
     // Print VPC mappings.
     // ================================================================

--- a/oxide-vpc/tests/firewall_tests.rs
+++ b/oxide-vpc/tests/firewall_tests.rs
@@ -87,8 +87,11 @@ fn firewall_replace_rules() {
     // outgoing packet and then reparse it.
     // ================================================================
     let mblk = pkt2.unwrap_mblk();
-    let mut pkt3 = unsafe { Packet::wrap_mblk_and_parse(mblk).unwrap() };
-    let mut pkt3_copy = Packet::copy(&pkt3.all_bytes()).parse().unwrap();
+    let mut pkt3 = unsafe {
+        Packet::wrap_mblk_and_parse(mblk, In, VpcParser::new()).unwrap()
+    };
+    let mut pkt3_copy =
+        Packet::copy(&pkt3.all_bytes()).parse(In, VpcParser::new()).unwrap();
     let res = g2.port.process(In, &mut pkt3, ActionMeta::new());
     assert!(matches!(res, Ok(Modified)));
     incr!(
@@ -128,10 +131,7 @@ fn firewall_replace_rules() {
     let res = g2.port.process(In, &mut pkt3_copy, ActionMeta::new());
     assert_drop!(
         res,
-        DropReason::Layer {
-            name: "firewall".to_string(),
-            reason: DenyReason::Rule
-        }
+        DropReason::Layer { name: "firewall", reason: DenyReason::Rule }
     );
     update!(
         g2,
@@ -194,10 +194,7 @@ fn firewall_vni_inbound() {
     let res = g1.port.process(In, &mut pkt1, ActionMeta::new());
     assert_drop!(
         res,
-        DropReason::Layer {
-            name: "firewall".to_string(),
-            reason: DenyReason::Default,
-        }
+        DropReason::Layer { name: "firewall", reason: DenyReason::Default }
     );
     incr!(
         g1,
@@ -307,10 +304,7 @@ fn firewall_vni_outbound() {
     let res = g1.port.process(Out, &mut pkt1, ActionMeta::new());
     assert_drop!(
         res,
-        DropReason::Layer {
-            name: "firewall".to_string(),
-            reason: DenyReason::Rule,
-        }
+        DropReason::Layer { name: "firewall", reason: DenyReason::Rule }
     );
     incr!(
         g1,

--- a/xde/Cargo.lock
+++ b/xde/Cargo.lock
@@ -4,27 +4,18 @@ version = 3
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.3"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a93ba5d6053837dbb76fd0ae26fd4f0c1859a008a783b0ce072b797c07f0f27"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
 dependencies = [
- "cortex-m",
+ "critical-section",
 ]
 
 [[package]]
-name = "bare-metal"
-version = "0.2.5"
+name = "autocfg"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
-name = "bitfield"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
@@ -45,32 +36,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
-name = "cortex-m"
-version = "0.7.3"
+name = "critical-section"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac919ef424449ec8c08d515590ce15d9262c0ca5f0da5b0c901e971a3b783b3"
-dependencies = [
- "bare-metal",
- "bitfield",
- "embedded-hal",
- "volatile-register",
-]
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
 name = "dyn-clone"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
-
-[[package]]
-name = "embedded-hal"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36cfb62ff156596c892272f3015ef952fe1525e85261fa3a7f327bd6b384ab9"
-dependencies = [
- "nb 0.1.3",
- "void",
-]
 
 [[package]]
 name = "hash32"
@@ -83,12 +58,13 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.9"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e476c64197665c3725621f0ac3f9e5209aa5e889e02a08b1daf5f16dc5fd952"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
  "hash32",
+ "rustc_version",
  "spin",
  "stable_deref_trait",
 ]
@@ -107,10 +83,11 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -119,21 +96,6 @@ name = "managed"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
-
-[[package]]
-name = "nb"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
-dependencies = [
- "nb 1.0.0",
-]
-
-[[package]]
-name = "nb"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "opte"
@@ -210,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
@@ -225,18 +187,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.9.0"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
@@ -271,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 dependencies = [
  "lock_api",
 ]
@@ -312,27 +265,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "vcell"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "volatile-register"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d67cb4616d99b940db1d6bd28844ff97108b498a6ca850e5b6191a532063286"
-dependencies = [
- "vcell",
-]
 
 [[package]]
 name = "xde"


### PR DESCRIPTION
The main goal of this commit is to reduce the amount of allocation happening per-packet on the hot path (aka when we have a UFT hit). However, achieving that goal led to refactoring several bits of OPTE. I'm still not 100% happy with this code, but it does reduce allocation, and I do think it's simpler and more robust in some regards.

new parsing strategy
--------------------

One major refactor was to packet parsing. Up to this point OPTE used a generic parser which allowed either a single frame or a Geneve encapsulated frame. However, as it was part of the generic bits of OPTE, this parser had no way to know the shape of the traffic expected by the network implementation. For example, in the case of oxide-vpc, all outbound traffic is coming from an HVM guest. For such traffic, we only care about parsing one level of headers. The guest may be sending encapsulated packets for all we know, but that's not our concern. Our only concern is that the outermost headers map to a destination in the guest's VPC (or some other reachable network), and so only one level of headers should be parsed. In the old parser we would attempt to parse two levels, which could easily lead to connection issues, confusion, and maybe even some shenanigans.

The generic parser also allowed nonsensical combinations. For example, one could pair TCP + Geneve in the outer header. The new parser/packet type limits those combinations a bit further to reduce the possibility of invalid combos.

The new parser is inspired (but not equal to) the approach taken in P4: provide a custom parser tailored to your expected network traffic. The new parser provides a generic two-level packet structure: either you have a single frame with typical ARP/ICMP/ULP traffic, or you have said frame encapsulated. That generic structure is filled out by a network-implementation-specific parser. This is achieved by the `NetworkImpl` and `NetworkParser` traits.

The `NetworkImpl` trait is meant as a callback mechanism in which the generic bits of OPTE can pass control flow to the network implementation to make decisions that are specific to it. The new parser uses the associated `Parser` type which maps to a `NetworkParser` implementation. This trait provides hooks for inbound/outbound packet parsing. The network implementation uses generic parsing routines provided by `Packet` and provides a `PacketInfo` value describing how it decided to parse the packet.

out-of-band packet handling
---------------------------

OPTE is highly inspired by Microsoft's VFP. You could even say it's basically a copy of VFP; and I wouldn't argue with you. That said, the entire point of VFP is really two tings:

1. To deal in flows, not packets.

2. To establish a hot path for active flows by caching the header transformations that take place in either direction of an active flow.

At the end of the day, this really boils down to optimizing TCP/UDP flows as much as possible, and doing it in a manner that is amenable to pushing down into a more traditional MAT (match-action table). That's the point of the UFT, and the point of phrasing traffic in terms of flows.

However, not all traffic needs the absolute best latency, or has high throughput demands. Attempting to shoehorn _all_ traffic into this flow-based model can be quite quirky; along with making the hot-path more complicated and brittle. For those reasons, I introduced a new out-of-band processing action intended for traffic that should be treated on a per-packet basis. This is the purpose of the `NetworkImpl::handle_pkt()` callback. To use it, you set the `Rule` action value to `Action::HandlePacket`. This immediately kicks control flow to the `handle_pkt()` implementation, upon which it can either allow (and modify) the packet, drop the packet, or produce a packet to be hairpinned back in the source's direction.

Any rule that specifies this action does not create a flow, does not create a UFT entry, and is handled on a packet-by-packet basis. This has several benefits, including not using hot-path resources (limited UFT entries) for traffic that doesn't need it, and allows more flexible, deep inspection of the packet.

The `handle_pkt()` callback _does_ have read access to the UFT tables. While the oxide-vpc implementation is not currently using those arguments, they will become necessary when implementation solutions for dealing with ICMP DU and TE messages, where one has to map a ICMP body to an existing flow.

I migrated the ARP handling to this new method. I think this should be taken a step further, and `DataPredicate` should be fully removed and replaced by adding logic to `handle_pkt()`. That is, I think data predicates were probably a mistake, as they break the flow model that OPTE is based on.

new header/meta types
---------------------

A main alloc culprit revolved around my previous (read poor) decision around header parsing and emitting. In the old code we would use "raw" headers to essentially cast a sequence of bytes into a raw definition of the base header. We would then use this raw header to create a logical `Header` value. These logical values would live with the packet inside `HeaderGroup`. Along with these logical headers, we created header metadata types (e.g. Ipv4Meta), that provided a limited view into the header values. It's this data that is used to express header transformations throughout the Layer pipeline. At the end of processing the logical header values would be "unified" with the metadata values, and then emit new header bytes based on them. This final step was done via the `as_bytes()` method, which did it's job by creating a `Vec<u8>`. These bytes would then be copied into the new header segment. That's a lot of waste.

The main fix here is to modify the emit stage to provide a slice of mutable bytes for the logical header type to write its raw bytes to. This eliminates any need to create a `Vec<u8>`. However, I went a bit beyond this and made a large refactor around how headers are dealt with. I'm not sure I'm 100% happy with how it turned out, and in some sense I just kind of shifted things around, but I did also managed to eliminate the unnecessary allocs. That said, it felt more important to land this commit than continue to noodle with this stuff. Here's what I did.

First, I replaced the notion of the logical `Header` type with the metadata type. For example, `TcpHdr` is now subsumed by `TcpMeta`. The metadata type is derived from a raw version of the base header: `TcpHdrRaw`. Any options are stored as an array in the `TcpMeta` type. Port/Layer processing was modified to no longer act directly on this metadata, and instead now acts via `PushAction`/`ModifyAction` traits. E.g., TCP defines the `TcpPush` and `TcpMod` types, which allow the processing pipeline to create/modify the source/destination ports, but all other parts of the header are off limits.

So during processing, the metadata types are modified based on the limited view of the `HeaderAction` type. At the end of processing, we now have metadata types that represent the logical values of the headers and we need to emit these to raw bytes. That is now done with `PacketSegWriter` and the `emit()` method on each metadata type. For each defined metadata type in the `PacketMeta` type, we attempt to get a mutable slice of the required length from the `PacketSegWriter`, and then call emit passing it that slice.

Now, one might wonder: what's the point of creating all these logical values in the metadata type, which represent the various fields in the header type: e.g., why have things like IPv4 TTL or TCP window_size in their respective metadata types? Why not just reuse the bytes that are already in the mblk? We could, but it requires more complicated code. Technically, the network implementation could decide to drop/push/modify headers, and those changes can change the offsets of the headers in the packet. If the offsets don't change, then we can effectively just do a zero-copy form of modification on them, but we need a way to know they haven't shifted. If they have shifted, then we essentially have to copy anyways, and so perhaps doing it up front isn't the worst cost.

reuse header mblk when possible
-------------------------------

The other culprit of superfluous allocation was the invariable creation of a new mblk for the purpose of emitting the new headers. This commit adds the `hdr_seg()` function, which creates a new header segment only as needed. For oxide-vpc specifically, this avoids the additional allocation on ingress, as we are decaping and modifying, thus there is plenty of room to write the new headers in the existing segment. For the outbound case we still need to allocate, as we need to encapsulate.

I think the best way to solve this issue is to have some way for a client of OPTE/xde to negotiate a prefix length. That is, a given network implementation could specify that it would like a certain amount of prefix margin for each outbound packet. The client, if it agrees, would then make sure that each header mblk contains said margin. With this contract negotiated, there would always be enough space in the first segment for writing the new headers. This type of capability would require both mac and viona changes.

remove useless dbg calls
------------------------

Another source of wasteful allocation were various `opte::engine::dbg()` calls. These calls were useful when first developing the "external IP hack", but are effectively useless today (especially since the hack is going away). This situation was especially bad because even when `opte_debug` was set to zero, we still payed the allocation cost of `format!`.

reduced cost of some SDT probes
--------------------------------

Another issue we currently have is around SDT probes: we still do the work even if the probe is not enabled (AFAIK there is no "is enabled" parlance for SDT probes). This is especially painful for any probe site that creates a new CString on the fly (even more so because often it first allocates a String, and then allocates a new CString based on that). This issue is documented more in opte#259.

I made the following changes to reduce the cost of SDT probes in the hot path.

* Use an integer instead of string to pass `Direction` value, saving an alloc for each probe site.

* Changed `Layer` names to `&'static str` to avoid unnecessary alloc when returning error.

* Add `Layer.ft_cstr` and `Layer.rt_cstr` to avoid unnecessary alloc.

* Removed the `ht_probe()` call from the processing hot-path (UFT hit). It was a bit redundant as you get the same info via the port-process probes; and it means less work in the hot path.

replace Vec seg list with heapless Vec
--------------------------------------

I replaced the `PacketSeg` vec with a heapless vec, eliminating an allocation per packet. At the moment this list is limited to 4 segments and there is some `unwrap()` that could cause crashes if this turns out not to be enough.

misc. changes
-------------

* Sprinkle various `#[inline]` attributes on hot functions based on some DTrace investigation. Some of these took, some didn't.

* Drop the `state` field from `PacketReader`, it no longer serves any purpose.

* Update `Protocol` and `EtherType` to not use `TryFrom`. Instead, they now represent either a protocol or ether type OPTE is interested in, or it's deemed "unknown" and the raw value is stored instead.

* Rework the guest-loopback code in regards to the ext-ip-hack in order to save some redundant work.

* Modified `RawHeader` trait to just have `new_mut()`: aka a zero-copy, mutable type over the underlying header bytes.

* Replaced use of `EtherAddr` with `MacAddr` in some places. The goal is to eventually get rid of `EtherAddr`.

* Modified `GeneveHdrRaw` to include it's associated UDP header as well.

* Eliminated a bunch of unused macros.