### PR TITLE
Update for stable toolchain

### DIFF
--- a/.github/buildomat/jobs/opte-api.sh
+++ b/.github/buildomat/jobs/opte-api.sh
@@ -24,7 +24,7 @@ header "check API_VERSION"
 ./check-api-version.sh
 
 header "check style"
-ptime -m cargo fmt -- --check
+ptime -m cargo +nightly fmt -- --check
 
 header "analyze std"
 ptime -m cargo check

--- a/.github/buildomat/jobs/opte-ioctl.sh
+++ b/.github/buildomat/jobs/opte-ioctl.sh
@@ -21,7 +21,7 @@ rustc --version
 cd opte-ioctl
 
 header "check style"
-ptime -m cargo fmt -- --check
+ptime -m cargo +nightly fmt -- --check
 
 header "analyze"
 ptime -m cargo check

--- a/.github/buildomat/jobs/opte.sh
+++ b/.github/buildomat/jobs/opte.sh
@@ -30,7 +30,7 @@ header "check docs"
 #
 # Use nightly which is needed for the `kernel` feature.
 RUSTDOCFLAGS="-D warnings" ptime -m \
-	    cargo +nightly doc --no-default-features --features=api,engine,kernel
+	    cargo +nightly doc --no-default-features --features=api,std,engine,kernel
 
 header "analyze std + api"
 ptime -m cargo check

--- a/.github/buildomat/jobs/opte.sh
+++ b/.github/buildomat/jobs/opte.sh
@@ -28,14 +28,15 @@ header "check docs"
 # I believe this means any doc warnings in deps will cause this to
 # fail. Using a more targeted approach in the future might be nice.
 #
+# Use nightly which is needed for the `kernel` feature.
 RUSTDOCFLAGS="-D warnings" ptime -m \
-	    cargo doc --no-default-features --features=api,engine,kernel
+	    cargo +nightly doc --no-default-features --features=api,engine,kernel
 
 header "analyze std + api"
 ptime -m cargo check
 
 header "analyze no_std + engine + kernel"
-ptime -m cargo check --no-default-features --features engine,kernel
+ptime -m cargo +nightly check --no-default-features --features engine,kernel
 
 header "test"
 ptime -m cargo test

--- a/.github/buildomat/jobs/opte.sh
+++ b/.github/buildomat/jobs/opte.sh
@@ -21,7 +21,7 @@ rustc --version
 cd opte
 
 header "check style"
-ptime -m cargo fmt -- --check
+ptime -m cargo +nightly fmt -- --check
 
 header "check docs"
 #

--- a/.github/buildomat/jobs/opteadm.sh
+++ b/.github/buildomat/jobs/opteadm.sh
@@ -26,7 +26,7 @@ rustc --version
 cd opteadm
 
 header "check style"
-ptime -m cargo fmt -- --check
+ptime -m cargo +nightly fmt -- --check
 
 header "debug build"
 ptime -m cargo build

--- a/.github/buildomat/jobs/oxide-vpc.sh
+++ b/.github/buildomat/jobs/oxide-vpc.sh
@@ -21,7 +21,7 @@ rustc --version
 cd oxide-vpc
 
 header "check style"
-ptime -m cargo fmt -- --check
+ptime -m cargo +nightly fmt -- --check
 
 header "check docs"
 #

--- a/.github/buildomat/jobs/oxide-vpc.sh
+++ b/.github/buildomat/jobs/oxide-vpc.sh
@@ -28,14 +28,15 @@ header "check docs"
 # I believe this means any doc warnings in deps will cause this to
 # fail. Using a more targeted approach in the future might be nice.
 #
+# Use nightly which is needed for the `kernel` feature.
 RUSTDOCFLAGS="-D warnings" ptime -m \
-	    cargo doc --no-default-features --features=api,std,engine,kernel
+	    cargo +nightly doc --no-default-features --features=api,std,engine,kernel
 
 header "analyze std + api + usdt"
 ptime -m cargo check --features usdt
 
 header "analyze no_std + engine + kernel"
-ptime -m cargo check --no-default-features --features engine,kernel
+ptime -m cargo +nightly check --no-default-features --features engine,kernel
 
 header "test"
 ptime -m cargo test

--- a/.github/buildomat/jobs/xde.sh
+++ b/.github/buildomat/jobs/xde.sh
@@ -42,7 +42,7 @@ rustc --version
 pushd xde
 
 header "check style"
-ptime -m cargo fmt -- --check
+ptime -m cargo +nightly fmt -- --check
 
 header "build xde (debug)"
 ptime -m ./build-debug.sh

--- a/illumos-sys-hdrs/src/lib.rs
+++ b/illumos-sys-hdrs/src/lib.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 // Copyright 2022 Oxide Computer Company
-#![feature(extern_types)]
+#![cfg_attr(feature = "kernel", feature(extern_types))]
 #![allow(non_camel_case_types)]
 #![no_std]
 

--- a/opte-ioctl/Cargo.lock
+++ b/opte-ioctl/Cargo.lock
@@ -273,6 +273,7 @@ dependencies = [
  "postcard",
  "serde",
  "smoltcp",
+ "version_check",
  "zerocopy",
 ]
 
@@ -553,6 +554,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "winapi"

--- a/opte-ioctl/Cargo.toml
+++ b/opte-ioctl/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-opte = { path = "../opte", features = ["api"]}
-oxide-vpc = { path = "../oxide-vpc", features = ["api"] }
+opte = { path = "../opte", default-features = false, features = ["api"]}
+oxide-vpc = { path = "../oxide-vpc", default-features = false, features = ["api"] }
 postcard = "0.7.0"
 serde = "1.0"
 thiserror = "1.0.28"

--- a/opte-ioctl/Cargo.toml
+++ b/opte-ioctl/Cargo.toml
@@ -6,9 +6,11 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-libnet = { git = "https://github.com/oxidecomputer/netadm-sys" }
 opte = { path = "../opte", features = ["api"]}
 oxide-vpc = { path = "../oxide-vpc", features = ["api"] }
 postcard = "0.7.0"
 serde = "1.0"
 thiserror = "1.0.28"
+
+[target.'cfg(target_os = "illumos")'.dependencies]
+libnet = { git = "https://github.com/oxidecomputer/netadm-sys" }

--- a/opte/Cargo.lock
+++ b/opte/Cargo.lock
@@ -25,30 +25,12 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
  "generic-array",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
-]
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -63,18 +45,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
 
 [[package]]
-name = "digest"
-version = "0.8.1"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -89,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "dtrace-parser"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bbb93fb1a0c517bf20f37caaf5d1f7d20f144c6c35a7d751ecad077b6c042e8"
+checksum = "bed110893a7f9f4ceb072e166354a09f6cb4cc416eec5b5e5e8ee367442d434b"
 dependencies = [
  "pest",
  "pest_derive",
@@ -111,18 +119,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-
-[[package]]
 name = "generic-array"
-version = "0.12.4"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -162,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "kstat-macro"
@@ -176,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.99"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "lock_api"
@@ -197,32 +200,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
-name = "maplit"
-version = "1.0.2"
+name = "once_cell"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "opte"
 version = "0.1.0"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "dyn-clone",
  "heapless",
  "illumos-sys-hdrs",
  "itertools",
  "kstat-macro",
+ "opte",
  "opte-api",
  "postcard",
  "serde",
  "smoltcp",
  "usdt",
+ "version_check",
  "zerocopy 0.6.1",
 ]
 
@@ -230,7 +229,7 @@ dependencies = [
 name = "opte-api"
 version = "0.1.0"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "illumos-sys-hdrs",
  "postcard",
  "serde",
@@ -239,18 +238,19 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.1.3"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+checksum = "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
 dependencies = [
+ "thiserror",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.1.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+checksum = "cdc078600d06ff90d4ed238f0119d84ab5d43dbaad278b0e33a8820293b32344"
 dependencies = [
  "pest",
  "pest_generator",
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.1.3"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+checksum = "28a1af60b1c4148bb269006a750cff8e2ea36aff34d2d96cf7be0b14d1bed23c"
 dependencies = [
  "pest",
  "pest_meta",
@@ -271,13 +271,13 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.1.3"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+checksum = "fec8605d59fc2ae0c6c1aefc0c7c7a9769732017c0ce07f7a9cfffa7b4404f20"
 dependencies = [
- "maplit",
+ "once_cell",
  "pest",
- "sha-1",
+ "sha1",
 ]
 
 [[package]]
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "scopeguard"
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -383,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "serde_tokenstream"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6deb15c3a535e81438110111d90168d91721652f502abb147f31cde129f683d"
+checksum = "2794f0ba0179a8ca422c30d9975d86faf8306be0164bfc3b0b1ca4f060ac639d"
 dependencies = [
  "proc-macro2",
  "serde",
@@ -393,15 +393,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.8.2"
+name = "sha1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
- "block-buffer",
+ "cfg-if 1.0.0",
+ "cpufeatures",
  "digest",
- "fake-simd",
- "opaque-debug",
 ]
 
 [[package]]
@@ -455,18 +454,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -486,15 +485,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-xid"
@@ -504,11 +503,10 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "usdt"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5409e16f35fdba646ff4290e6f96f0bb958b43e0bd09d790c3714456a76c11ac"
+checksum = "2b4c48f9e522b977bbe938a0d7c4d36633d267ba0155aaa253fb57d0531be0fb"
 dependencies = [
- "dof",
  "dtrace-parser",
  "serde",
  "usdt-attr-macro",
@@ -518,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "usdt-attr-macro"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d203cad87b8424e1fbd0fef29b6df2113e68be5dd75f4043427eb0ce6601041f"
+checksum = "80e6ae4f982ae74dcbaa8eb17baf36ca0d464a3abc8a7172b3bd74c73e9505d6"
 dependencies = [
  "dtrace-parser",
  "proc-macro2",
@@ -532,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "usdt-impl"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c146394183fcea90d93e2d4602e1a7eb6cab8e807b58f99d4f343720d4e9d69"
+checksum = "f53b4ca0b33aae466dc47b30b98adc4f88454928837af8010b6ed02d18474cb1"
 dependencies = [
  "byteorder",
  "dof",
@@ -552,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "usdt-macro"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dddab3586eaf539e2daddc425261daef6a6d2f85131bac7345caa8e6a423b27"
+checksum = "7cb093f9653dc91632621c754f9ed4ee25d14e46e0239b6ccaf74a6c0c2788bd"
 dependencies = [
  "dtrace-parser",
  "proc-macro2",

--- a/opte/Cargo.toml
+++ b/opte/Cargo.toml
@@ -27,8 +27,8 @@ illumos-sys-hdrs = { path = "../illumos-sys-hdrs" }
 kstat-macro = { path = "../kstat-macro" }
 opte-api = { path = "../opte-api", default-features = false }
 postcard = { version = "0.7.0", features = ["alloc"], default-features = false }
-zerocopy = "0.6.1"
 usdt = { version = "0.3.5", optional = true }
+zerocopy = "0.6.1"
 
 [dependencies.serde]
 version = "1.0"

--- a/opte/Cargo.toml
+++ b/opte/Cargo.toml
@@ -17,6 +17,7 @@ std = ["opte-api/std"]
 # Used for declaring methods which are useful for integration testing.
 #
 test-help = []
+usdt = ["std", "dep:usdt"]
 
 [dependencies]
 cfg-if = "0.1"
@@ -26,17 +27,8 @@ illumos-sys-hdrs = { path = "../illumos-sys-hdrs" }
 kstat-macro = { path = "../kstat-macro" }
 opte-api = { path = "../opte-api", default-features = false }
 postcard = { version = "0.7.0", features = ["alloc"], default-features = false }
-#
-# XXX usdt is really a dev dependency, but when I move it there weird
-# stuff happens (TM). Maybe to do with feature flags?
-#
-# At the moment the only purpose of the usdt feature is to enable the
-# USDT probes when running the tests.
-#
-# cargo test --features=usdt
-#
-usdt = { version = "0.3.2", optional = true }
 zerocopy = "0.6.1"
+usdt = { version = "0.3.5", optional = true }
 
 [dependencies.serde]
 version = "1.0"
@@ -51,5 +43,10 @@ default-features = false
 #
 features = ["alloc", "medium-ethernet", "proto-ipv4", "proto-ipv6", "proto-dhcpv4", "socket", "socket-raw"]
 
+[build-dependencies]
+version_check = "0.9.4"
+
 [dev-dependencies]
+# Enable usdt probes for testing.
+opte = { path = ".", features = ["usdt"] }
 itertools = "0.10"

--- a/opte/build.rs
+++ b/opte/build.rs
@@ -1,0 +1,27 @@
+// Copyright 2022 Oxide Computer Company
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    if version_check::is_min_version("1.59").unwrap_or(false) {
+        println!("cargo:rustc-cfg=usdt_stable_asm");
+    }
+
+    #[cfg(target_os = "macos")]
+    if version_check::is_min_version("1.66").unwrap_or(false) {
+        println!("cargo:rustc-cfg=usdt_stable_asm_sym");
+    }
+}

--- a/opte/build.rs
+++ b/opte/build.rs
@@ -1,18 +1,3 @@
-// Copyright 2022 Oxide Computer Company
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 

--- a/opte/src/engine/flow_table.rs
+++ b/opte/src/engine/flow_table.rs
@@ -208,6 +208,7 @@ fn flow_expired_probe(port: &CString, name: &CString, flowid: &InnerFlowId) {
                 );
             }
         } else if #[cfg(feature = "usdt")] {
+            use std::string::ToString;
             let port_s = port.to_str().unwrap();
             let name_s = name.to_str().unwrap();
             crate::opte_provider::flow__expired!(

--- a/opte/src/engine/layer.rs
+++ b/opte/src/engine/layer.rs
@@ -639,7 +639,7 @@ impl Layer {
                     Err(e) => format!("ERROR: {:?}", e),
                 };
                 crate::opte_provider::layer__process__return!(
-                    || ((dir, port_s), &self.name, ifid_b_s, ifid_a_s, &res_s)
+                    || ((dir, port_s), &self.name, &flow_b_s, &flow_a_s, &res_s)
                 );
             } else {
                 let (_, _, _, _) = (dir, flow_before, flow_after, res);
@@ -1669,7 +1669,7 @@ impl<'a> RuleTable {
                 let action_s = rule.action().to_string();
 
                 crate::opte_provider::rule__match!(
-                    || (port_s, layer_s, self.dir, flow_id.to_string(),
+                    || (port_s, layer_s, dir, flow_id.to_string(),
                         action_s)
                 );
             } else {

--- a/opte/src/engine/mod.rs
+++ b/opte/src/engine/mod.rs
@@ -113,46 +113,39 @@ pub static mut opte_panic_debug: i32 = 0;
 cfg_if! {
     if #[cfg(feature = "kernel")] {
         use alloc::ffi::CString;
-        use alloc::vec::Vec;
         use illumos_sys_hdrs as ddi;
 
         /// When set to 1 enables debug messages.
         #[no_mangle]
         pub static mut opte_debug: i32 = 0;
 
-        pub fn dbg<S: AsRef<str>>(msg: S)
-        where
-            Vec<u8>: From<S>,
-        {
+        pub fn dbg<S: AsRef<str>>(msg: S) {
             use ddi::CE_NOTE;
 
             unsafe {
                 if opte_debug != 0 {
-                    let cstr = CString::new(msg).unwrap();
+                    let cstr = CString::new(msg.as_ref()).unwrap();
                     ddi::cmn_err(CE_NOTE, cstr.as_ptr());
                 }
             }
         }
 
-        pub fn err<S: AsRef<str>>(msg: S)
-        where
-            Vec<u8>: From<S>,
-        {
+        pub fn err<S: AsRef<str>>(msg: S) {
             use ddi::CE_WARN;
 
             unsafe {
-                let cstr = CString::new(msg).unwrap();
+                let cstr = CString::new(msg.as_ref()).unwrap();
                 ddi::cmn_err(CE_WARN, cstr.as_ptr());
             }
         }
 
     } else if #[cfg(feature = "std")] {
-        pub fn dbg<S: AsRef<str> + fmt::Display>(msg: S) {
-            println!("{}", msg);
+        pub fn dbg<S: AsRef<str>>(msg: S) {
+            println!("{}", msg.as_ref());
         }
 
-        pub fn err<S: AsRef<str> + fmt::Display>(msg: S) {
-            println!("ERROR: {}", msg);
+        pub fn err<S: AsRef<str>>(msg: S) {
+            println!("ERROR: {}", msg.as_ref());
         }
     }
 }

--- a/opte/src/engine/mod.rs
+++ b/opte/src/engine/mod.rs
@@ -111,7 +111,7 @@ impl From<String> for ParseErr {
 pub static mut opte_panic_debug: i32 = 0;
 
 cfg_if! {
-    if #[cfg(not(feature = "std"))] {
+    if #[cfg(feature = "kernel")] {
         use alloc::ffi::CString;
         use alloc::vec::Vec;
         use illumos_sys_hdrs as ddi;
@@ -146,8 +146,8 @@ cfg_if! {
             }
         }
 
-    } else {
-        fn dbg<S: AsRef<str> + fmt::Display>(msg: S) {
+    } else if #[cfg(feature = "std")] {
+        pub fn dbg<S: AsRef<str> + fmt::Display>(msg: S) {
             println!("{}", msg);
         }
 

--- a/opte/src/engine/mod.rs
+++ b/opte/src/engine/mod.rs
@@ -111,7 +111,15 @@ impl From<String> for ParseErr {
 pub static mut opte_panic_debug: i32 = 0;
 
 cfg_if! {
-    if #[cfg(feature = "kernel")] {
+    if #[cfg(feature = "std")] {
+        pub fn dbg<S: AsRef<str>>(msg: S) {
+            println!("{}", msg.as_ref());
+        }
+
+        pub fn err<S: AsRef<str>>(msg: S) {
+            println!("ERROR: {}", msg.as_ref());
+        }
+    } else if #[cfg(feature = "kernel")] {
         use alloc::ffi::CString;
         use illumos_sys_hdrs as ddi;
 
@@ -139,14 +147,6 @@ cfg_if! {
             }
         }
 
-    } else if #[cfg(feature = "std")] {
-        pub fn dbg<S: AsRef<str>>(msg: S) {
-            println!("{}", msg.as_ref());
-        }
-
-        pub fn err<S: AsRef<str>>(msg: S) {
-            println!("ERROR: {}", msg.as_ref());
-        }
     }
 }
 

--- a/opte/src/engine/packet.rs
+++ b/opte/src/engine/packet.rs
@@ -2488,7 +2488,10 @@ pub fn mock_allocb(size: usize) -> *mut mblk_t {
 
 #[cfg(any(feature = "std", test))]
 pub fn mock_desballoc(buf: Vec<u8>) -> *mut mblk_t {
-    let (ptr, len, avail) = buf.into_raw_parts();
+    let mut buf = std::mem::ManuallyDrop::new(buf);
+    let ptr = buf.as_mut_ptr();
+    let len = buf.len();
+    let avail = buf.capacity();
 
     // For the purposes of mocking in std the only fields that
     // matter here are the ones relating to the data buffer:

--- a/opte/src/engine/rule.rs
+++ b/opte/src/engine/rule.rs
@@ -336,7 +336,7 @@ pub fn ht_probe(
             let after_s = after.to_string();
 
             crate::opte_provider::ht__run!(
-                || (port_s, loc, dir, before_s, after_s)
+                || (port_s, loc_c, dir, before_s, after_s)
             );
         } else {
             let (..) = (port, loc, dir, before, after);

--- a/opte/src/lib.rs
+++ b/opte/src/lib.rs
@@ -16,9 +16,6 @@
     feature(asm_sym)
 )]
 
-#[cfg(all(feature = "std", feature = "kernel"))]
-compile_error!("Cannot enable both `std` and `kernel` features");
-
 use core::fmt;
 use core::fmt::Display;
 
@@ -223,10 +220,10 @@ impl LogProvider for PrintlnLog {
     }
 }
 
-#[cfg(all(feature = "kernel", not(test)))]
+#[cfg(all(feature = "kernel", not(feature = "std"), not(test)))]
 pub struct KernelLog {}
 
-#[cfg(all(feature = "kernel", not(test)))]
+#[cfg(all(feature = "kernel", not(feature = "std"), not(test)))]
 impl LogProvider for KernelLog {
     fn log(&self, level: LogLevel, msg: &str) {
         use illumos_sys_hdrs as ddi;

--- a/opte/src/lib.rs
+++ b/opte/src/lib.rs
@@ -10,9 +10,9 @@
 #![deny(unreachable_patterns)]
 #![deny(unused_must_use)]
 // Enable features needed for USDT, if needed.
-#![cfg_attr(all(usdt, not(usdt_stable_asm)), feature(asm))]
+#![cfg_attr(all(feature = "usdt", not(usdt_stable_asm)), feature(asm))]
 #![cfg_attr(
-    all(usdt, target_os = "macos", not(usdt_stable_asm_sym)),
+    all(feature = "usdt", target_os = "macos", not(usdt_stable_asm_sym)),
     feature(asm_sym)
 )]
 

--- a/opte/src/lib.rs
+++ b/opte/src/lib.rs
@@ -5,15 +5,16 @@
 // Copyright 2022 Oxide Computer Company
 
 #![cfg_attr(not(feature = "std"), no_std)]
-
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![deny(unreachable_patterns)]
 #![deny(unused_must_use)]
-
 // Enable features needed for USDT, if needed.
 #![cfg_attr(all(usdt, not(usdt_stable_asm)), feature(asm))]
-#![cfg_attr(all(usdt, target_os = "macos", not(usdt_stable_asm_sym)), feature(asm_sym))]
+#![cfg_attr(
+    all(usdt, target_os = "macos", not(usdt_stable_asm_sym)),
+    feature(asm_sym)
+)]
 
 #[cfg(all(feature = "std", feature = "kernel"))]
 compile_error!("Cannot enable both `std` and `kernel` features");

--- a/opte/src/lib.rs
+++ b/opte/src/lib.rs
@@ -4,7 +4,8 @@
 
 // Copyright 2022 Oxide Computer Company
 
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
+
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![deny(unreachable_patterns)]
@@ -14,16 +15,14 @@
 #![cfg_attr(all(usdt, not(usdt_stable_asm)), feature(asm))]
 #![cfg_attr(all(usdt, target_os = "macos", not(usdt_stable_asm_sym)), feature(asm_sym))]
 
+#[cfg(all(feature = "std", feature = "kernel"))]
+compile_error!("Cannot enable both `std` and `kernel` features");
+
 use core::fmt;
 use core::fmt::Display;
 
-// NOTE: Things get weird if you move the extern crate into cfg_if!.
-#[cfg(any(feature = "std", test))]
-#[macro_use]
-extern crate std;
-
 #[cfg(all(not(feature = "std"), not(test)))]
-#[macro_use]
+#[cfg_attr(feature = "engine", macro_use)]
 extern crate alloc;
 
 #[macro_use]
@@ -223,10 +222,10 @@ impl LogProvider for PrintlnLog {
     }
 }
 
-#[cfg(all(not(feature = "std"), not(test)))]
+#[cfg(all(feature = "kernel", not(test)))]
 pub struct KernelLog {}
 
-#[cfg(all(not(feature = "std"), not(test)))]
+#[cfg(all(feature = "kernel", not(test)))]
 impl LogProvider for KernelLog {
     fn log(&self, level: LogLevel, msg: &str) {
         use illumos_sys_hdrs as ddi;

--- a/opte/src/lib.rs
+++ b/opte/src/lib.rs
@@ -5,17 +5,14 @@
 // Copyright 2022 Oxide Computer Company
 
 #![no_std]
-// This allows one to run the tests on macOS with the usdt probes
-// enabled.
-//
-// ```
-// cargo test --features=usdt
-// ```
-#![cfg_attr(target_os = "macos", feature(asm_sym))]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![deny(unreachable_patterns)]
 #![deny(unused_must_use)]
+
+// Enable features needed for USDT, if needed.
+#![cfg_attr(all(usdt, not(usdt_stable_asm)), feature(asm))]
+#![cfg_attr(all(usdt, target_os = "macos", not(usdt_stable_asm_sym)), feature(asm_sym))]
 
 use core::fmt;
 use core::fmt::Display;

--- a/opte/src/lib.rs
+++ b/opte/src/lib.rs
@@ -12,8 +12,6 @@
 // cargo test --features=usdt
 // ```
 #![cfg_attr(target_os = "macos", feature(asm_sym))]
-#![feature(extern_types)]
-#![feature(vec_into_raw_parts)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![deny(unreachable_patterns)]

--- a/opteadm/Cargo.lock
+++ b/opteadm/Cargo.lock
@@ -299,6 +299,7 @@ dependencies = [
  "postcard",
  "serde",
  "smoltcp",
+ "version_check",
  "zerocopy",
 ]
 
@@ -680,9 +681,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "winapi"

--- a/opteadm/src/main.rs
+++ b/opteadm/src/main.rs
@@ -4,8 +4,6 @@
 
 // Copyright 2022 Oxide Computer Company
 
-#![feature(extern_types)]
-
 use std::io;
 use std::str::FromStr;
 

--- a/oxide-vpc/Cargo.lock
+++ b/oxide-vpc/Cargo.lock
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "dtrace-parser"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bbb93fb1a0c517bf20f37caaf5d1f7d20f144c6c35a7d751ecad077b6c042e8"
+checksum = "bed110893a7f9f4ceb072e166354a09f6cb4cc416eec5b5e5e8ee367442d434b"
 dependencies = [
  "pest",
  "pest_derive",
@@ -282,6 +282,7 @@ dependencies = [
  "serde",
  "smoltcp",
  "usdt",
+ "version_check",
  "zerocopy 0.6.1",
 ]
 
@@ -624,11 +625,10 @@ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "usdt"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5409e16f35fdba646ff4290e6f96f0bb958b43e0bd09d790c3714456a76c11ac"
+checksum = "2b4c48f9e522b977bbe938a0d7c4d36633d267ba0155aaa253fb57d0531be0fb"
 dependencies = [
- "dof",
  "dtrace-parser",
  "serde",
  "usdt-attr-macro",
@@ -638,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "usdt-attr-macro"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d203cad87b8424e1fbd0fef29b6df2113e68be5dd75f4043427eb0ce6601041f"
+checksum = "80e6ae4f982ae74dcbaa8eb17baf36ca0d464a3abc8a7172b3bd74c73e9505d6"
 dependencies = [
  "dtrace-parser",
  "proc-macro2",
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "usdt-impl"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c146394183fcea90d93e2d4602e1a7eb6cab8e807b58f99d4f343720d4e9d69"
+checksum = "f53b4ca0b33aae466dc47b30b98adc4f88454928837af8010b6ed02d18474cb1"
 dependencies = [
  "byteorder",
  "dof",
@@ -672,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "usdt-macro"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dddab3586eaf539e2daddc425261daef6a6d2f85131bac7345caa8e6a423b27"
+checksum = "7cb093f9653dc91632621c754f9ed4ee25d14e46e0239b6ccaf74a6c0c2788bd"
 dependencies = [
  "dtrace-parser",
  "proc-macro2",

--- a/oxide-vpc/Cargo.toml
+++ b/oxide-vpc/Cargo.toml
@@ -24,22 +24,12 @@ std = ["opte/std"]
 # #[cfg(any(feature = "test-help", test))]
 #
 test-help = ["opte/test-help"]
-usdt = ["opte/usdt", "dep:usdt"]
+usdt = ["opte/usdt"]
 
 [dependencies]
 cfg-if = "0.1"
 illumos-sys-hdrs = { path = "../illumos-sys-hdrs" }
 opte = { path = "../opte", default-features = false }
-#
-# XXX usdt is really a dev dependency, but when I move it there weird
-# stuff happens (TM). Maybe to do with feature flags?
-#
-# At the moment the only purpose of the usdt feature is to enable the
-# USDT probes when running the tests.
-#
-# cargo test --features=usdt
-#
-usdt = { version = "0.3.2", optional = true }
 zerocopy = "0.6.1"
 
 [dependencies.serde]
@@ -65,5 +55,6 @@ ctor = "0.1.22"
 #
 # https://github.com/rust-lang/cargo/issues/2911
 #
-oxide-vpc = { path = ".", features = ["engine", "test-help"] }
+oxide-vpc = { path = ".", features = ["engine", "test-help", "usdt"] }
 pcap-parser = { version = "0.11.1", features = ["serialize"] }
+usdt = "0.3.5"

--- a/oxide-vpc/tests/integration_tests.rs
+++ b/oxide-vpc/tests/integration_tests.rs
@@ -67,9 +67,9 @@ const VPC_ENCAP_SZ: usize =
 const IP_SZ: usize = EtherHdr::SIZE + Ipv4Hdr::BASE_SIZE;
 const TCP_SZ: usize = EtherHdr::SIZE + Ipv4Hdr::BASE_SIZE + TcpHdr::BASE_SIZE;
 
-// If we are running `cargo test --feature=usdt`, then make sure to
+// If we are running `cargo test`, then make sure to
 // register the USDT probes before running any tests.
-#[cfg(all(test, feature = "usdt"))]
+#[cfg(test)]
 #[ctor::ctor]
 fn register_usdt() {
     usdt::register_probes().unwrap();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,3 @@
 [toolchain]
-channel = "nightly-2022-09-23"
-target = "x86_64-unknown-illumos"
-components = [ "rustfmt", "rust-src" ]
-profile = "minimal"
+channel = "1.66"
+profile = "default"

--- a/xde/Cargo.lock
+++ b/xde/Cargo.lock
@@ -110,6 +110,7 @@ dependencies = [
  "postcard",
  "serde",
  "smoltcp",
+ "version_check",
  "zerocopy",
 ]
 
@@ -265,6 +266,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "xde"

--- a/xde/rust-toolchain.toml
+++ b/xde/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly-2022-09-23"
+target = "x86_64-unknown-illumos"
+components = [ "rustfmt", "rust-src" ]
+profile = "minimal"


### PR DESCRIPTION
With `asm_sym` stabilized, everything but xde can be built with stable.