### PR TITLE
Allow filtering ARP packets in fw rule.

### DIFF
--- a/opte/src/engine/predicate.rs
+++ b/opte/src/engine/predicate.rs
@@ -92,9 +92,16 @@ impl EtherTypeMatch {
 
 impl Display for EtherTypeMatch {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use crate::engine::ether::*;
         use EtherTypeMatch::*;
 
         match self {
+            // Print known EtherTypes by name
+            Exact(et) if *et == ETHER_TYPE_ARP => write!(f, "ARP"),
+            Exact(et) if *et == ETHER_TYPE_ETHER => write!(f, "ETHER"),
+            Exact(et) if *et == ETHER_TYPE_IPV4 => write!(f, "IPv4"),
+            Exact(et) if *et == ETHER_TYPE_IPV6 => write!(f, "IPv6"),
+
             Exact(et) => write!(f, "0x{:X}", et),
         }
     }

--- a/oxide-vpc/src/api.rs
+++ b/oxide-vpc/src/api.rs
@@ -721,6 +721,7 @@ impl Display for Address {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum ProtoFilter {
     Any,
+    Arp,
     Proto(Protocol),
 }
 
@@ -730,6 +731,7 @@ impl FromStr for ProtoFilter {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_ascii_lowercase().as_str() {
             "any" => Ok(ProtoFilter::Any),
+            "arp" => Ok(ProtoFilter::Arp),
             "icmp" => Ok(ProtoFilter::Proto(Protocol::ICMP)),
             "tcp" => Ok(ProtoFilter::Proto(Protocol::TCP)),
             "udp" => Ok(ProtoFilter::Proto(Protocol::UDP)),
@@ -758,6 +760,7 @@ impl Display for ProtoFilter {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ProtoFilter::Any => write!(f, "ANY"),
+            ProtoFilter::Arp => write!(f, "ARP"),
             ProtoFilter::Proto(proto) => write!(f, "{},", proto),
         }
     }

--- a/oxide-vpc/src/engine/firewall.rs
+++ b/oxide-vpc/src/engine/firewall.rs
@@ -22,12 +22,14 @@ use crate::engine::overlay::ACTION_META_VNI;
 use core::num::NonZeroU32;
 use opte::api::Direction;
 use opte::api::OpteError;
+use opte::engine::ether::ETHER_TYPE_ARP;
 use opte::engine::layer::DefaultAction;
 use opte::engine::layer::Layer;
 use opte::engine::layer::LayerActions;
 use opte::engine::port::Port;
 use opte::engine::port::PortBuilder;
 use opte::engine::port::Pos;
+use opte::engine::predicate::EtherTypeMatch;
 use opte::engine::predicate::IpProtoMatch;
 use opte::engine::predicate::Ipv4AddrMatch;
 use opte::engine::predicate::PortMatch;
@@ -152,6 +154,12 @@ impl ProtoFilter {
     pub fn into_predicate(self) -> Option<Predicate> {
         match self {
             ProtoFilter::Any => None,
+
+            ProtoFilter::Arp => {
+                Some(Predicate::InnerEtherType(vec![EtherTypeMatch::Exact(
+                    ETHER_TYPE_ARP,
+                )]))
+            }
 
             ProtoFilter::Proto(p) => {
                 Some(Predicate::InnerIpProto(vec![IpProtoMatch::Exact(p)]))


### PR DESCRIPTION
I know the external IP hack is on the way out but in the meantime you need to add a firewall rule to allow incoming ARP packets past the firewall layer.

It's currently possible to do this via adding an overly permissive rule:

```console
$ opteadm add-fw-rule -p vm_test0 --action allow --dir in --hosts any --ports any --priority 65534 --protocol any
$ opteadm dump-layer -p vm_test0 firewall
[...snip...]
Inbound Rules
----------------------------------------------------------------------
ID     PRI    HITS   PREDICATES                             ACTION            
0      65534  0      *                                      "Stateful Allow"
```

With this PR you can make that a bit more fine grained:

```console
$ opteadm add-fw-rule -p vm_test0 --action allow --dir in --hosts any --ports any --priority 65534 --protocol arp
$ opteadm dump-layer -p vm_test0 firewall
[...snip...]
Inbound Rules
----------------------------------------------------------------------
ID     PRI    HITS   PREDICATES                             ACTION            
0      65534  0      inner.ether.ether_type=ARP             "Stateful Allow"
```