### PR TITLE
Supply DNS domain search list option via `VpcCfg`

### DIFF
--- a/opte-api/src/dhcpv6.rs
+++ b/opte-api/src/dhcpv6.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2023 Oxide Computer Company
 
 //! Types for working with the DHCPv6
 
@@ -40,8 +40,8 @@ pub struct Dhcpv6Action {
     /// SNTP servers the client should use.
     pub sntp_servers: Vec<Ipv6Addr>,
 
-    /// An optional list of domain names used during DNS resolution.
-    pub domain_list: Option<Vec<DomainName>>,
+    /// A list of domain names used during DNS resolution.
+    pub domain_list: Vec<DomainName>,
 }
 
 impl Dhcpv6Action {

--- a/opte-api/src/dhcpv6.rs
+++ b/opte-api/src/dhcpv6.rs
@@ -6,6 +6,7 @@
 
 //! Types for working with the DHCPv6
 
+use crate::DomainName;
 use crate::Ipv6Addr;
 use crate::MacAddr;
 use core::fmt;
@@ -38,6 +39,9 @@ pub struct Dhcpv6Action {
 
     /// SNTP servers the client should use.
     pub sntp_servers: Vec<Ipv6Addr>,
+
+    /// An optional list of domain names used during DNS resolution.
+    pub domain_list: Option<Vec<DomainName>>,
 }
 
 impl Dhcpv6Action {

--- a/opte-api/src/dns.rs
+++ b/opte-api/src/dns.rs
@@ -1,0 +1,223 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2023 Oxide Computer Company
+
+//! Types related to DNS and advertisement of DNS options to clients.
+
+use core::convert::TryFrom;
+use core::fmt;
+use core::str::FromStr;
+use serde::Deserialize;
+use serde::Serialize;
+
+cfg_if! {
+    if #[cfg(all(not(feature = "std"), not(test)))] {
+        use alloc::string::String;
+        use alloc::vec::Vec;
+        use alloc::str;
+    } else {
+        use std::string::String;
+        use std::vec::Vec;
+        use std::str;
+    }
+}
+
+/// A DNS domain name, which can be encoded in the label-sequence format of RFC
+/// 1035 section 3.1.
+///
+/// # Requirements
+///
+/// It's recommended that domain names follow the LDH rule: only ASCII letters,
+/// digits, and hyphens, and not starting with a hyphen. However, this is not
+/// currently enforced, and the domain name is just a UTF-8 string. No other
+/// encoding is enforced.
+///
+/// The only other enforcements are currently around length:
+///
+/// - The string form of the name may not exceed 253 octets
+/// - Each label (except for possibly the last, root label) must be between 1
+/// and 63 octets.
+///
+/// # Details
+///
+/// A DNS domain name is a sequence of labels. Colloquially, this is a string
+/// like `foo.bar.com.`. When specified as in a domain search list on a system,
+/// this allows tools like `ping` to use items from the list when they are
+/// provided just a hostname.
+///
+/// For example, given:
+///
+/// ```console
+/// $ ping baz
+/// ```
+///
+/// and the above domain name in its search list, `ping` will try to resolve the
+/// host `baz.foo.bar.com` before sending IP packets.
+///
+/// Each of the strings separated by `.` is a "label". In the standard format of
+/// RFC 1035 section 3.1 each label is prefixed by a single octet describing its
+/// length. All label sequences technically end with the "root label", a bare
+/// ".", which is encoded as a length octet of zero. Thus all DNS domains are
+/// null terminated.
+///
+/// There are also length requirements: Each label cannot be more than 63 octets
+/// long; and the total length cannot be more than 255 octets.
+///
+/// # Notes
+///
+/// Technically, labels can contain any octets. However, DNS servers are
+/// required to compare labels without considering case, assuming ASCII with
+/// zero parity. (See RFC 1035 section 3.1, final paragraph.) We enforce this
+/// restriction here.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DomainName {
+    // The original, parsed string.
+    name: String,
+    // The name encoded according to RFC 1035 sec 3.1.
+    encoded: Vec<u8>,
+}
+
+impl DomainName {
+    const MAX_STR_LEN: usize = 253;
+    const MAX_ENCODED_LEN: usize = 255;
+    const MAX_LABEL_LEN: usize = 63;
+
+    /// Encode the full domain name in the format prescribed by RFC 1035 section
+    /// 3.1.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use opte_api::DomainName;
+    /// let n: DomainName = "quuz.bar.com".parse().unwrap();
+    /// assert_eq!(n.encode(), b"\x04quuz\x03bar\x03com\x00");
+    /// ```
+    pub fn encode(&self) -> &[u8] {
+        self.encoded.as_slice()
+    }
+
+    /// Return the validated domain name string.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl TryFrom<&[u8]> for DomainName {
+    type Error = &'static str;
+
+    fn try_from(buf: &[u8]) -> Result<Self, Self::Error> {
+        // Sanity check the size of the buffer.
+        //
+        // From RFC 1035, section 3.1, this is limited to 255 octets.
+        if buf.len() > Self::MAX_ENCODED_LEN || buf.is_empty() {
+            return Err("Encoded domain name too long or empty");
+        }
+
+        // Pull out each label length, then the label itself.
+        let mut start: u8 = 0;
+        let mut name = String::new();
+        loop {
+            let len = buf[usize::from(start)];
+
+            // Root label has zero length.
+            if len == 0 {
+                break;
+            }
+
+            // The name starts on the next octet. Check that the end is within a
+            // u8 and the length of the string!
+            start += 1;
+            let Some(end) = start.checked_add(len) else {
+                return Err("Invalid label length");
+            };
+            let Some(chunk) = buf.get(usize::from(start)..usize::from(end)) else {
+                return Err("Invalid label length");
+            };
+
+            // Push the label and _then_ the label-separator.
+            let Ok(label) = str::from_utf8(chunk) else {
+                return Err("Non-UTF8 label");
+            };
+            name.push_str(label);
+            name.push('.');
+
+            // Off to the next label.
+            start += len;
+        }
+
+        // We've already pushed the root label separator, since we push `'.'`
+        // after each label, including the last, before breaking.
+        Ok(Self { encoded: buf.to_vec(), name })
+    }
+}
+
+impl FromStr for DomainName {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() > Self::MAX_STR_LEN || s.is_empty() {
+            return Err("Domain name too long or empty");
+        }
+        if s.starts_with('.') {
+            return Err("Domain name cannot start with '.'");
+        }
+
+        // Pull out a possible `.` at the very end, and handle that separately.
+        let is_fqdn = s.ends_with('.');
+        let relative_name = if is_fqdn { &s[..s.len() - 1] } else { s };
+
+        // Split out each label, and create the encoded form.
+        let mut encoded = Vec::with_capacity(s.len());
+        for label in relative_name.split('.') {
+            if label.is_empty() || label.len() > Self::MAX_LABEL_LEN {
+                return Err("Label empty or too long");
+            }
+            encoded.push(label.len() as u8);
+            encoded.extend_from_slice(label.as_bytes());
+        }
+
+        // Push final "length" for the root label.
+        encoded.push(0);
+        Ok(Self { name: String::from(s), encoded })
+    }
+}
+
+impl fmt::Display for DomainName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DomainName;
+
+    #[test]
+    fn test_domain_name() {
+        // String and expected encoding.
+        let orig = "foo.bar.com";
+        let encoded = b"\x03foo\x03bar\x03com\x00";
+
+        // Check parsing and API
+        let name: DomainName = orig.parse().unwrap();
+        assert_eq!(format!("{name}"), orig);
+        assert_eq!(name.name(), orig);
+        assert_eq!(name.encode(), encoded);
+
+        // Check we can reconstruct the same thing out of encoded bytes.
+        let from_encoded = DomainName::try_from(encoded.as_slice()).unwrap();
+        assert_eq!(from_encoded.name(), format!("{orig}."));
+        assert_eq!(from_encoded.encode(), encoded);
+
+        // Should support FQDNs
+        assert!("foo.bar.com.".parse::<DomainName>().is_ok());
+
+        // Malformed
+        assert!("a".repeat(256).parse::<DomainName>().is_err());
+        assert!(".foo.bar".parse::<DomainName>().is_err());
+        assert!("foo..bar".parse::<DomainName>().is_err());
+        assert!(DomainName::try_from(b"\xffnonono".as_slice()).is_err());
+    }
+}

--- a/opte-api/src/ip.rs
+++ b/opte-api/src/ip.rs
@@ -5,6 +5,7 @@
 // Copyright 2022 Oxide Computer Company
 
 use super::mac::MacAddr;
+use crate::DomainName;
 use core::convert::AsRef;
 use core::fmt;
 use core::fmt::Debug;
@@ -144,6 +145,10 @@ pub struct DhcpAction {
 
     /// An optional list of 1-3 DNS servers.
     pub dns_servers: Option<[Option<Ipv4Addr>; 3]>,
+
+    /// An optional list of domain names used when resolving relative names via
+    /// DNS.
+    pub domain_list: Option<Vec<DomainName>>,
 }
 
 impl Display for DhcpAction {

--- a/opte-api/src/ip.rs
+++ b/opte-api/src/ip.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2023 Oxide Computer Company
 
 use super::mac::MacAddr;
 use crate::DomainName;
@@ -146,9 +146,9 @@ pub struct DhcpAction {
     /// An optional list of 1-3 DNS servers.
     pub dns_servers: Option<[Option<Ipv4Addr>; 3]>,
 
-    /// An optional list of domain names used when resolving relative names via
+    /// A list of domain names used when resolving relative names via
     /// DNS.
-    pub domain_list: Option<Vec<DomainName>>,
+    pub domain_list: Vec<DomainName>,
 }
 
 impl Display for DhcpAction {

--- a/opte-api/src/lib.rs
+++ b/opte-api/src/lib.rs
@@ -34,6 +34,7 @@ cfg_if! {
 
 pub mod cmd;
 pub mod dhcpv6;
+pub mod dns;
 pub mod encap;
 pub mod ip;
 pub mod mac;
@@ -42,6 +43,7 @@ pub mod ulp;
 
 pub use cmd::*;
 pub use dhcpv6::*;
+pub use dns::*;
 pub use encap::*;
 pub use ip::*;
 pub use mac::*;
@@ -56,7 +58,7 @@ pub use ulp::*;
 ///
 /// We rely on CI and the check-api-version.sh script to verify that
 /// this number is incremented anytime the oxide-api code changes.
-pub const API_VERSION: u64 = 19;
+pub const API_VERSION: u64 = 20;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Direction {

--- a/opte-api/src/lib.rs
+++ b/opte-api/src/lib.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2023 Oxide Computer Company
 
 #![no_std]
 #![deny(unreachable_patterns)]

--- a/opte/src/engine/dhcp.rs
+++ b/opte/src/engine/dhcp.rs
@@ -34,6 +34,7 @@ use core::fmt;
 use core::fmt::Display;
 use opte_api::DhcpAction;
 use opte_api::DhcpReplyType;
+use opte_api::DomainName;
 use opte_api::MacAddr;
 use opte_api::SubnetRouterPair;
 use serde::de;
@@ -243,6 +244,35 @@ impl ClasslessStaticRouteOpt {
     }
 }
 
+const DOMAIN_SEARCH_OPTION_OPTION_CODE: u8 = 119;
+const MAX_OPTION_LEN: usize = 255;
+
+// Encoded a list of Domain Names into a Domain Search Option, in accordance
+// with RFC 3397.
+//
+// Note that this may return more than one actual DHCP option. Those are
+// limited to 255 octets. However, domain names can be long, and we don't
+// want to artificially constrain the number of names that can be sent in a
+// DHCP Lease. Thus we allow any number, and encode them into as many
+// underlying options as required.
+fn encode_domain_search_option(names: &[DomainName]) -> Vec<u8> {
+    let mut all_names = Vec::new();
+    for name in names {
+        all_names.extend_from_slice(name.encode());
+    }
+
+    let mut out = Vec::with_capacity(all_names.len());
+    for chunk in all_names.chunks(MAX_OPTION_LEN) {
+        out.push(DOMAIN_SEARCH_OPTION_OPTION_CODE);
+        out.push(
+            u8::try_from(chunk.len()).expect("Chunk length checked above"),
+        );
+        out.extend_from_slice(chunk);
+    }
+
+    out
+}
+
 // XXX I read up just enough on DHCP to get initial lease working.
 // However, I imagine there could be post-lease messages between
 // client/server and those might be unicast, at which point these
@@ -344,11 +374,21 @@ impl HairpinAction for DhcpAction {
         let _ = reply.emit(&mut dhcp).unwrap();
 
         // Need to overwrite the End Option with Classless Static
-        // Route Option and then write new End Option marker.
+        // Route Option, and possibly the Domain Search Option, and then write
+        // the new End Option marker.
         assert_eq!(tmp.pop(), Some(255));
         tmp.extend_from_slice(&csr_opt.encode());
+        let dso_encode_len = if let Some(domain_list) = &self.domain_list {
+            let encoded = encode_domain_search_option(domain_list);
+            tmp.extend_from_slice(&encoded);
+            encoded.len()
+        } else {
+            0
+        };
         tmp.push(255);
-        assert_eq!(tmp.len(), reply_len + csr_opt.encode_len() as usize);
+        let expected_len =
+            reply_len + csr_opt.encode_len() as usize + dso_encode_len;
+        assert_eq!(tmp.len(), expected_len);
 
         let mut udp = UdpMeta {
             src: 67,
@@ -556,5 +596,49 @@ mod test {
                 47, 10, 0, 0, 1, 15, 10, 16, 10, 0, 0, 1
             ]
         );
+    }
+
+    #[test]
+    fn domain_search_option_encode() {
+        let names = vec![
+            "foo.bar.com".parse::<DomainName>().unwrap(),
+            "something.that.is.very.long.so.we.need.to.split.the.option"
+                .parse::<DomainName>()
+                .unwrap(),
+            "something.that.is.very.long.so.we.need.to.split.the.option"
+                .parse::<DomainName>()
+                .unwrap(),
+            "something.that.is.very.long.so.we.need.to.split.the.option"
+                .parse::<DomainName>()
+                .unwrap(),
+            "something.that.is.very.long.so.we.need.to.split.the.option"
+                .parse::<DomainName>()
+                .unwrap(),
+            "something.that.is.very.long.so.we.need.to.split.the.option"
+                .parse::<DomainName>()
+                .unwrap(),
+            "oxide.computer".parse::<DomainName>().unwrap(),
+        ];
+        let buf = encode_domain_search_option(&names);
+        let mut option_bytes = Vec::new();
+        for name in &names {
+            option_bytes.extend_from_slice(name.encode());
+        }
+        // There should be two actual options in the output, check the option
+        // code and option lengths are inserted correctly.
+        assert_eq!(buf[0], DOMAIN_SEARCH_OPTION_OPTION_CODE);
+        assert_eq!(buf[1], u8::try_from(MAX_OPTION_LEN).unwrap());
+        assert_eq!(buf[MAX_OPTION_LEN + 2], DOMAIN_SEARCH_OPTION_OPTION_CODE);
+        assert_eq!(
+            buf[MAX_OPTION_LEN + 3],
+            u8::try_from(option_bytes.len() - MAX_OPTION_LEN).unwrap()
+        );
+
+        // Check the actual bytes.
+        assert_eq!(
+            &buf[2..MAX_OPTION_LEN + 2],
+            &option_bytes[..MAX_OPTION_LEN]
+        );
+        assert_eq!(&buf[MAX_OPTION_LEN + 4..], &option_bytes[MAX_OPTION_LEN..]);
     }
 }

--- a/opte/src/engine/dhcp.rs
+++ b/opte/src/engine/dhcp.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2023 Oxide Computer Company
 
 //! DHCP headers, data, and actions.
 
@@ -273,7 +273,7 @@ fn encode_domain_search_option(names: &[DomainName]) -> Vec<u8> {
     let len =
         n_full * (MAX_OPTION_LEN + 1) + if n_left > 0 { n_left + 1 } else { 0 };
 
-    // Join all cunks, prefixed by the option code.
+    // Join all chunks, prefixed by the option code.
     let mut out = Vec::with_capacity(len);
     for chunk in all_names.chunks(MAX_OPTION_LEN) {
         out.push(DOMAIN_SEARCH_OPTION_OPTION_CODE);
@@ -391,8 +391,8 @@ impl HairpinAction for DhcpAction {
         // the new End Option marker.
         assert_eq!(tmp.pop(), Some(255));
         tmp.extend_from_slice(&csr_opt.encode());
-        let dso_encode_len = if let Some(domain_list) = &self.domain_list {
-            let encoded = encode_domain_search_option(domain_list);
+        let dso_encode_len = if !self.domain_list.is_empty() {
+            let encoded = encode_domain_search_option(&self.domain_list);
             tmp.extend_from_slice(&encoded);
             encoded.len()
         } else {

--- a/opte/src/engine/dhcpv6/options.rs
+++ b/opte/src/engine/dhcpv6/options.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2023 Oxide Computer Company
 
 //! Support for DHCPv6 Options
 //!

--- a/opte/src/engine/dhcpv6/protocol.rs
+++ b/opte/src/engine/dhcpv6/protocol.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2023 Oxide Computer Company
 
 //! Implementation of the main message types for DHCPv6.
 
@@ -358,8 +358,8 @@ fn generate_reply_options<'a>(
     if msg.has_option(OptionCode::DomainList)
         || msg.has_option_request_with(OptionCode::DomainList)
     {
-        if let Some(list) = &action.domain_list {
-            let opt = Dhcpv6Option::from(list.as_slice());
+        if !action.domain_list.is_empty() {
+            let opt = Dhcpv6Option::from(action.domain_list.as_slice());
             options.push(opt);
         }
     }

--- a/opte/src/engine/dhcpv6/protocol.rs
+++ b/opte/src/engine/dhcpv6/protocol.rs
@@ -195,6 +195,18 @@ impl<'a> Message<'a> {
         self.find_option(code).is_some()
     }
 
+    /// Return `true` if the message has an Option Request option, which
+    /// contains the provided type.
+    pub fn has_option_request_with(&self, code: OptionCode) -> bool {
+        if let Some(Dhcpv6Option::OptionRequest(opts)) =
+            self.find_option(OptionCode::OptionRequest)
+        {
+            opts.contains(code)
+        } else {
+            false
+        }
+    }
+
     /// Return the _first_ contained option of the provided type, or `None` if
     /// the message does not contain such an option.
     ///
@@ -222,13 +234,7 @@ impl<'a> Message<'a> {
 
         // Look for the Rapid Commit option contained in the Option Request
         // option.
-        if let Some(Dhcpv6Option::OptionRequest(opts)) =
-            self.find_option(OptionCode::OptionRequest)
-        {
-            opts.contains(OptionCode::RapidCommit)
-        } else {
-            false
-        }
+        self.has_option_request_with(OptionCode::RapidCommit)
     }
 
     fn option_len(&self) -> usize {
@@ -308,15 +314,11 @@ fn generate_reply_options<'a>(
     ];
 
     // If requested, provide the list of DNS servers.
-    if let Some(Dhcpv6Option::OptionRequest(oro)) =
-        msg.find_option(OptionCode::OptionRequest)
-    {
-        if oro.contains(OptionCode::DnsServers) {
-            let opt = Dhcpv6Option::DnsServers(IpList::from(
-                action.dns_servers.as_slice(),
-            ));
-            options.push(opt);
-        }
+    if msg.has_option_request_with(OptionCode::DnsServers) {
+        let opt = Dhcpv6Option::DnsServers(IpList::from(
+            action.dns_servers.as_slice(),
+        ));
+        options.push(opt);
     }
 
     // Add the leased address(es), if they were requested, along with the IAID
@@ -349,6 +351,18 @@ fn generate_reply_options<'a>(
         options.push(Dhcpv6Option::IaNa(iana));
     }
 
+    // If requested, provide the Domain Search List option.
+    //
+    // This is a list of domain names appended to hostnames before trying to
+    // resolve them.
+    if msg.has_option(OptionCode::DomainList)
+        || msg.has_option_request_with(OptionCode::DomainList)
+    {
+        if let Some(list) = &action.domain_list {
+            let opt = Dhcpv6Option::from(list.as_slice());
+            options.push(opt);
+        }
+    }
     options
 }
 

--- a/opteadm/src/main.rs
+++ b/opteadm/src/main.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2023 Oxide Computer Company
 
 use std::io;
 use std::str::FromStr;
@@ -183,7 +183,7 @@ enum Command {
         /// A list of domain names provided to the guest, used when resolving
         /// hostnames.
         #[structopt(long, parse(try_from_str))]
-        domain_list: Option<Vec<DomainName>>,
+        domain_list: Vec<DomainName>,
 
         #[structopt(long)]
         phys_gw_mac: Option<MacAddr>,

--- a/opteadm/src/main.rs
+++ b/opteadm/src/main.rs
@@ -146,7 +146,7 @@ enum Command {
         #[structopt(long)]
         gateway_ip: std::net::Ipv4Addr,
 
-        /// The IP addreess for Boundary Services, where packets destined to
+        /// The IP address for Boundary Services, where packets destined to
         /// off-rack networks are sent.
         #[structopt(long)]
         bsvc_addr: std::net::Ipv6Addr,

--- a/oxide-vpc/src/api.rs
+++ b/oxide-vpc/src/api.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2023 Oxide Computer Company
 
 use core::fmt;
 use core::fmt::Display;
@@ -193,11 +193,11 @@ pub struct VpcCfg {
     /// for external networks.
     pub boundary_services: BoundaryServices,
 
-    /// An optional list of domain names used during DNS resolution.
+    /// A list of domain names used during DNS resolution.
     ///
     /// Resolvers will use the provided list when resolving relative domain
     /// names.
-    pub domain_list: Option<Vec<DomainName>>,
+    pub domain_list: Vec<DomainName>,
 
     // XXX-EXT-IP the following two fields are for the external IP hack.
     pub proxy_arp_enable: bool,

--- a/oxide-vpc/src/api.rs
+++ b/oxide-vpc/src/api.rs
@@ -193,6 +193,12 @@ pub struct VpcCfg {
     /// for external networks.
     pub boundary_services: BoundaryServices,
 
+    /// An optional list of domain names used during DNS resolution.
+    ///
+    /// Resolvers will use the provided list when resolving relative domain
+    /// names.
+    pub domain_list: Option<Vec<DomainName>>,
+
     // XXX-EXT-IP the following two fields are for the external IP hack.
     pub proxy_arp_enable: bool,
     pub phys_gw_mac: Option<MacAddr>,

--- a/oxide-vpc/src/engine/gateway/dhcp.rs
+++ b/oxide-vpc/src/engine/gateway/dhcp.rs
@@ -86,6 +86,7 @@ pub fn setup(
             None,
             None,
         ]),
+        domain_list: cfg.domain_list.clone(),
     }));
 
     let ack = Action::Hairpin(Arc::new(DhcpAction {
@@ -104,6 +105,7 @@ pub fn setup(
             None,
             None,
         ]),
+        domain_list: cfg.domain_list.clone(),
     }));
 
     let discover_rule = Rule::new(1, offer);

--- a/oxide-vpc/src/engine/gateway/dhcp.rs
+++ b/oxide-vpc/src/engine/gateway/dhcp.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2023 Oxide Computer Company
 
 //! The DHCP implementation of the Virtual Gateway.
 

--- a/oxide-vpc/src/engine/gateway/dhcpv6.rs
+++ b/oxide-vpc/src/engine/gateway/dhcpv6.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2023 Oxide Computer Company
 
 //! The DHCPv6 implementation of the Virtual Gateway.
 

--- a/oxide-vpc/src/engine/gateway/dhcpv6.rs
+++ b/oxide-vpc/src/engine/gateway/dhcpv6.rs
@@ -50,6 +50,7 @@ pub fn setup(layer: &mut Layer, cfg: &VpcCfg) -> Result<(), OpteError> {
             Ipv6Addr::from_const([0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8844]),
         ],
         sntp_servers: vec![],
+        domain_list: cfg.domain_list.clone(),
     };
 
     let server = Action::Hairpin(Arc::new(action));

--- a/oxide-vpc/tests/common/mod.rs
+++ b/oxide-vpc/tests/common/mod.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2023 Oxide Computer Company
 
 //! Common routines for integration tests.
 
@@ -146,7 +146,7 @@ pub fn g1_cfg2(ip_cfg: IpCfg) -> VpcCfg {
             ]),
             vni: Vni::new(99u32).unwrap(),
         },
-        domain_list: Some(vec!["oxide.computer".parse().unwrap()]),
+        domain_list: vec!["oxide.computer".parse().unwrap()],
         proxy_arp_enable: false,
         phys_gw_mac: Some(MacAddr::from([0x78, 0x23, 0xae, 0x5d, 0x4f, 0x0d])),
     }
@@ -192,7 +192,7 @@ pub fn g2_cfg() -> VpcCfg {
             ]),
             vni: Vni::new(99u32).unwrap(),
         },
-        domain_list: Some(vec!["oxide.computer".parse().unwrap()]),
+        domain_list: vec!["oxide.computer".parse().unwrap()],
         proxy_arp_enable: false,
         phys_gw_mac: Some(MacAddr::from([0x78, 0x23, 0xae, 0x5d, 0x4f, 0x0d])),
     }

--- a/oxide-vpc/tests/common/mod.rs
+++ b/oxide-vpc/tests/common/mod.rs
@@ -146,6 +146,7 @@ pub fn g1_cfg2(ip_cfg: IpCfg) -> VpcCfg {
             ]),
             vni: Vni::new(99u32).unwrap(),
         },
+        domain_list: Some(vec!["oxide.computer".parse().unwrap()]),
         proxy_arp_enable: false,
         phys_gw_mac: Some(MacAddr::from([0x78, 0x23, 0xae, 0x5d, 0x4f, 0x0d])),
     }
@@ -191,6 +192,7 @@ pub fn g2_cfg() -> VpcCfg {
             ]),
             vni: Vni::new(99u32).unwrap(),
         },
+        domain_list: Some(vec!["oxide.computer".parse().unwrap()]),
         proxy_arp_enable: false,
         phys_gw_mac: Some(MacAddr::from([0x78, 0x23, 0xae, 0x5d, 0x4f, 0x0d])),
     }

--- a/oxide-vpc/tests/integration_tests.rs
+++ b/oxide-vpc/tests/integration_tests.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2023 Oxide Computer Company
 
 //! Integration tests.
 //!
@@ -109,7 +109,7 @@ fn lab_cfg() -> VpcCfg {
             ]),
             vni: Vni::new(99u32).unwrap(),
         },
-        domain_list: Some(vec!["oxide.computer".parse().unwrap()]),
+        domain_list: vec!["oxide.computer".parse().unwrap()],
         proxy_arp_enable: false,
         phys_gw_mac: Some(MacAddr::from([0x78, 0x23, 0xae, 0x5d, 0x4f, 0x0d])),
     }
@@ -2071,7 +2071,7 @@ fn test_reply_to_dhcpv6_solicit_or_request() {
                     panic!("Expected an Option::DomainList");
                 };
                 let mut expected_bytes = Vec::new();
-                for name in g1_cfg.domain_list.as_ref().unwrap().iter() {
+                for name in g1_cfg.domain_list.iter() {
                     expected_bytes.extend_from_slice(name.encode());
                 }
                 assert_eq!(


### PR DESCRIPTION
- Adds a basic DNS `DomainName` type, with minimal validation.
- Adds method to convert a list of `DomainName` to DHCPv6 option, and test for it.
- Add a `DomainSearchOpt` option to DHCP for encoding a list of domain names, and a test.
- Fixes bug in encoding of DHCPv6 `Option::DomainList`, trying to copy to wrong destination slice.
- Adds optional list of domain names to `VpcCfg`.
- Adds optional list of domain names to both DHCP and DHCPv6 actions, populated from the `VpcCfg`.
- Adds integration test for DHCPv6 Domain Search List, ensuring we get back in our reply the actual list the configuration describes.