### PR TITLE
Do not unwrap on flow table limits

### DIFF
--- a/oxide-vpc/tests/common/mod.rs
+++ b/oxide-vpc/tests/common/mod.rs
@@ -233,14 +233,16 @@ pub fn oxide_net_setup(
     name: &str,
     cfg: &VpcCfg,
     vpc_map: Option<Arc<VpcMappings>>,
+    flow_table_limits: Option<NonZeroU32>,
 ) -> PortAndVps {
-    oxide_net_setup2(name, cfg, vpc_map, None)
+    oxide_net_setup2(name, cfg, vpc_map, flow_table_limits, None)
 }
 
 pub fn oxide_net_setup2(
     name: &str,
     cfg: &VpcCfg,
     vpc_map: Option<Arc<VpcMappings>>,
+    flow_table_limits: Option<NonZeroU32>,
     custom_updates: Option<&[&str]>,
 ) -> PortAndVps {
     // We have to setup the global VPC mapping state just like xde
@@ -290,8 +292,10 @@ pub fn oxide_net_setup2(
     };
 
     let vpc_net = VpcNetwork { cfg: cfg.clone() };
+    let uft_limit = flow_table_limits.unwrap_or(UFT_LIMIT.unwrap());
+    let tcp_limit = flow_table_limits.unwrap_or(TCP_LIMIT.unwrap());
     let port = oxide_net_builder(name, cfg, vpc_map.clone(), port_v2p)
-        .create(vpc_net, UFT_LIMIT.unwrap(), TCP_LIMIT.unwrap())
+        .create(vpc_net, uft_limit, tcp_limit)
         .unwrap();
 
     // Add router entry that allows the guest to send to other guests

--- a/oxide-vpc/tests/firewall_tests.rs
+++ b/oxide-vpc/tests/firewall_tests.rs
@@ -6,11 +6,12 @@ use common::*;
 fn firewall_replace_rules() {
     let g1_cfg = g1_cfg();
     let g2_cfg = g2_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.port.start();
     set!(g1, "port_state=running");
 
-    let mut g2 = oxide_net_setup("g2_port", &g2_cfg, Some(g1.vpc_map.clone()));
+    let mut g2 =
+        oxide_net_setup("g2_port", &g2_cfg, Some(g1.vpc_map.clone()), None);
     g2.port.start();
     set!(g2, "port_state=running");
 
@@ -155,7 +156,8 @@ fn firewall_vni_inbound() {
     let g1_ext_ip = "10.77.78.9".parse().unwrap();
     g1_cfg.set_ext_ipv4(g1_ext_ip);
     let custom = ["set:nat.rules.in=1", "set:nat.rules.out=3"];
-    let mut g1 = oxide_net_setup2("g1_port", &g1_cfg, None, Some(&custom));
+    let mut g1 =
+        oxide_net_setup2("g1_port", &g1_cfg, None, None, Some(&custom));
     g1.port.start();
     set!(g1, "port_state=running");
 
@@ -245,7 +247,7 @@ fn firewall_vni_outbound() {
     // Setup g1 as usual.
     // ================================================================
     let g1_cfg = g1_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.port.start();
     set!(g1, "port_state=running");
 

--- a/oxide-vpc/tests/integration_tests.rs
+++ b/oxide-vpc/tests/integration_tests.rs
@@ -119,7 +119,7 @@ fn lab_cfg() -> VpcCfg {
 #[test]
 fn check_layers() {
     let g1_cfg = g1_cfg();
-    let g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     let port_layers = g1.port.layers();
     assert_eq!(&VPC_LAYERS[..], &port_layers);
 }
@@ -129,7 +129,7 @@ fn check_layers() {
 fn port_transition_running() {
     let g1_cfg = g1_cfg();
     let g2_cfg = g2_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.vpc_map.add(g2_cfg.ipv4().private_ip.into(), g2_cfg.phys_addr());
 
     // ================================================================
@@ -160,7 +160,7 @@ fn port_transition_running() {
 fn port_transition_reset() {
     let g1_cfg = g1_cfg();
     let g2_cfg = g2_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.vpc_map.add(g2_cfg.ipv4().private_ip.into(), g2_cfg.phys_addr());
 
     // ================================================================
@@ -197,8 +197,9 @@ fn port_transition_reset() {
 fn port_transition_pause() {
     let g1_cfg = g1_cfg();
     let g2_cfg = g2_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
-    let mut g2 = oxide_net_setup("g2_port", &g2_cfg, Some(g1.vpc_map.clone()));
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
+    let mut g2 =
+        oxide_net_setup("g2_port", &g2_cfg, Some(g1.vpc_map.clone()), None);
 
     // Allow incoming connections to port 80 on g1.
     let fw_rule: FirewallRule =
@@ -315,7 +316,7 @@ fn port_transition_pause() {
 #[test]
 fn add_remove_fw_rule() {
     let g1_cfg = g1_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.port.start();
     set!(g1, "port_state=running");
 
@@ -348,7 +349,7 @@ fn add_remove_fw_rule() {
 #[test]
 fn gateway_icmp4_ping() {
     let g1_cfg = g1_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.port.start();
     set!(g1, "port_state=running");
     let mut pcap = PcapBuilder::new("gateway_icmpv4_ping.pcap");
@@ -436,7 +437,7 @@ fn gateway_icmp4_ping() {
 fn guest_to_guest_no_route() {
     let g1_cfg = g1_cfg();
     let g2_cfg = g2_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.vpc_map.add(g2_cfg.ipv4().private_ip.into(), g2_cfg.phys_addr());
     g1.port.start();
     set!(g1, "port_state=running");
@@ -479,11 +480,12 @@ fn guest_to_guest_no_route() {
 fn guest_to_guest() {
     let g1_cfg = g1_cfg();
     let g2_cfg = g2_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.vpc_map.add(g2_cfg.ipv4().private_ip.into(), g2_cfg.phys_addr());
     g1.port.start();
     set!(g1, "port_state=running");
-    let mut g2 = oxide_net_setup("g2_port", &g2_cfg, Some(g1.vpc_map.clone()));
+    let mut g2 =
+        oxide_net_setup("g2_port", &g2_cfg, Some(g1.vpc_map.clone()), None);
     g2.port.start();
     set!(g2, "port_state=running");
 
@@ -654,10 +656,11 @@ fn guest_to_guest_diff_vpc_no_peer() {
     let g1_cfg = g1_cfg();
     let mut g2_cfg = g2_cfg();
     g2_cfg.vni = Vni::new(100u32).unwrap();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.port.start();
     set!(g1, "port_state=running");
-    let mut g2 = oxide_net_setup("g2_port", &g2_cfg, Some(g1.vpc_map.clone()));
+    let mut g2 =
+        oxide_net_setup("g2_port", &g2_cfg, Some(g1.vpc_map.clone()), None);
     g2.port.start();
     set!(g2, "port_state=running");
 
@@ -697,7 +700,7 @@ fn guest_to_guest_diff_vpc_no_peer() {
 #[test]
 fn guest_to_internet() {
     let g1_cfg = g1_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.port.start();
     set!(g1, "port_state=running");
 
@@ -811,7 +814,7 @@ fn guest_to_internet() {
 #[test]
 fn snat_icmp4_echo_rewrite() {
     let g1_cfg = g1_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.port.start();
     set!(g1, "port_state=running");
     let dst_ip: Ipv4Addr = "45.55.45.205".parse().unwrap();
@@ -1068,7 +1071,7 @@ fn arp_gateway() {
     use opte::engine::arp::ArpOp;
 
     let cfg = g1_cfg();
-    let mut g1 = oxide_net_setup("arp_hairpin", &cfg, None);
+    let mut g1 = oxide_net_setup("arp_hairpin", &cfg, None, None);
     g1.port.start();
     set!(g1, "port_state=running");
 
@@ -1130,7 +1133,7 @@ fn arp_gateway() {
 fn flow_expiration() {
     let g1_cfg = g1_cfg();
     let g2_cfg = g2_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.vpc_map.add(g2_cfg.ipv4().private_ip.into(), g2_cfg.phys_addr());
     g1.port.start();
     set!(g1, "port_state=running");
@@ -1172,7 +1175,7 @@ fn flow_expiration() {
 #[test]
 fn gateway_icmpv6_ping() {
     let g1_cfg = g1_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.port.start();
     set!(g1, "port_state=running");
     let mut pcap = PcapBuilder::new("gateway_icmpv6_ping.pcap");
@@ -1336,7 +1339,7 @@ fn gateway_router_advert_reply() {
     use smoltcp::time::Duration;
 
     let g1_cfg = g1_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.port.start();
     set!(g1, "port_state=running");
     let mut pcap = PcapBuilder::new("gateway_router_advert_reply.pcap");
@@ -1775,7 +1778,7 @@ fn validate_hairpin_advert(
 #[test]
 fn test_gateway_neighbor_advert_reply() {
     let g1_cfg = g1_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.port.start();
     set!(g1, "port_state=running");
     let mut pcap = PcapBuilder::new("gateway_neighbor_advert_reply.pcap");
@@ -1934,7 +1937,7 @@ fn verify_dhcpv6_essentials<'a>(
 #[test]
 fn test_reply_to_dhcpv6_solicit_or_request() {
     let g1_cfg = g1_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.port.start();
     set!(g1, "port_state=running");
     let mut pcap = PcapBuilder::new("dhcpv6_solicit_reply.pcap");
@@ -2192,7 +2195,7 @@ fn uft_lft_invalidation_out() {
     // Step 1
     // ================================================================
     let g1_cfg = g1_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.port.start();
     set!(g1, "port_state=running");
 
@@ -2278,7 +2281,7 @@ fn uft_lft_invalidation_in() {
     // Step 1
     // ================================================================
     let g1_cfg = g1_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.port.start();
     set!(g1, "port_state=running");
 
@@ -2383,7 +2386,7 @@ fn uft_lft_invalidation_in() {
 #[test]
 fn tcp_outbound() {
     let g1_cfg = g1_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.port.start();
     set!(g1, "port_state=running");
     // let now = Moment::now();
@@ -2624,7 +2627,7 @@ fn tcp_inbound() {
     };
 
     let g1_cfg = g1_cfg2(ip_cfg);
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.port.start();
     set!(g1, "port_state=running");
 
@@ -2815,7 +2818,7 @@ fn tcp_inbound() {
 fn anti_spoof() {
     let g1_cfg = g1_cfg();
     let g2_cfg = g2_cfg();
-    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None);
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
     g1.port.start();
     set!(g1, "port_state=running");
 
@@ -2884,4 +2887,54 @@ fn anti_spoof() {
             "stats.port.out_uft_miss",
         ]
     );
+}
+
+// Ensure that we do _not_ panic when trying to create more TCP flows the limit
+// applied to the flow table.
+#[test]
+fn no_panic_on_flow_table_full() {
+    let g1_cfg = g1_cfg();
+    // Let's limit to one connection, and try to establish two.
+    let flow_table_limit = NonZeroU32::new(1).unwrap();
+    let mut g1 =
+        oxide_net_setup("g1_port", &g1_cfg, None, Some(flow_table_limit));
+    g1.port.start();
+    set!(g1, "port_state=running");
+
+    // Add router entry that allows g1 to route to internet.
+    router::add_entry(
+        &g1.port,
+        IpCidr::Ip4("0.0.0.0/0".parse().unwrap()),
+        RouterTarget::InternetGateway,
+    )
+    .unwrap();
+    incr!(g1, ["epoch", "router.rules.out"]);
+
+    // Send one TCP packet to `zinascii.com`.
+    let dst_ip = "52.10.128.69".parse().unwrap();
+    let mut pkt1 = http_syn2(
+        g1_cfg.guest_mac,
+        g1_cfg.ipv4_cfg().unwrap().private_ip,
+        GW_MAC_ADDR,
+        dst_ip,
+    );
+
+    // Process the packet through our port. We don't actually care about the
+    // contents here, we just want to make sure that the packet can be _sent at
+    // all_.
+    let res = g1.port.process(Out, &mut pkt1, ActionMeta::new());
+    assert!(res.is_ok());
+
+    // Send another one, which should exhaust the TCP flow table limit we
+    // severely truncated above. Note we need to send to a different IP address.
+    // Let's use google.com.
+    let dst_ip = "142.251.46.238".parse().unwrap();
+    let mut pkt2 = http_syn2(
+        g1_cfg.guest_mac,
+        g1_cfg.ipv4_cfg().unwrap().private_ip,
+        GW_MAC_ADDR,
+        dst_ip,
+    );
+    let res2 = g1.port.process(Out, &mut pkt2, ActionMeta::new());
+    assert_drop!(res2, DropReason::TcpErr);
 }


### PR DESCRIPTION
- Add error type for handling TCP flow errors
- Return new error variants rather than `String` from methods processing TCP flows.
- Handle TCP flow errors, now just unexpected segments, in the port processing code. This is done by returning a new `ProcessError` variant.
- Add `ProcessError::FlowTableFull`, which wraps attempts to add a new flow entry which fail because the table is full. This includes the table "kind", which for now is just a static string, and the current limit.
- Add an integration test verifying that TCP packets are dropped when the flow table is full.