### PR TITLE
Update ICMPv6 checksum, set correct IPv6 payload len and misc

### DIFF
--- a/opte/src/engine/icmpv6.rs
+++ b/opte/src/engine/icmpv6.rs
@@ -470,7 +470,7 @@ impl HairpinAction for RouterAdvertisement {
             dst: meta.inner_ip6().unwrap().src,
             proto: Protocol::ICMPv6,
             next_hdr: IpProtocol::Icmpv6,
-            // RFC 4861 7.1.2 requires that the hop limit be 255 in an RA.
+            // RFC 4861 6.1.2 requires that the hop limit be 255 in an RA.
             hop_limit: 255,
             // There are no extension headers; the ULP is the only
             // content.
@@ -721,6 +721,8 @@ impl HairpinAction for NeighborAdvertisement {
             dst: dst_ip,
             proto: Protocol::ICMPv6,
             next_hdr: IpProtocol::Icmpv6,
+            // RFC 4861 7.1.2 requires that the hop limit be 255 in an NA.
+            hop_limit: 255,
             // There are no extension headers; the ULP is the only
             // content.
             pay_len: reply_len as u16,

--- a/opte/src/engine/icmpv6.rs
+++ b/opte/src/engine/icmpv6.rs
@@ -349,6 +349,8 @@ impl HairpinAction for RouterAdvertisement {
             dst: meta.inner_ip6().unwrap().src,
             proto: Protocol::ICMPv6,
             next_hdr: IpProtocol::Icmpv6,
+            // RFC 4861 7.1.2 requires that the hop limit be 255 in an RA.
+            hop_limit: 255,
             // There are no extension headers; the ULP is the only
             // content.
             pay_len: reply_len as u16,

--- a/opte/src/engine/mod.rs
+++ b/opte/src/engine/mod.rs
@@ -327,10 +327,7 @@ impl GenericUlp {
                 // pkt.parse_icmp()?,
             }
 
-            Protocol::ICMPv6 => {
-                return Ok(PacketInfo { meta, offsets, body_csum: None });
-            }
-
+            Protocol::ICMPv6 => Packet::parse_icmp6(rdr)?,
             Protocol::TCP => Packet::parse_tcp(rdr)?,
             Protocol::UDP => Packet::parse_udp(rdr)?,
             proto => return Err(ParseError::UnexpectedProtocol(proto)),

--- a/opte/src/engine/packet.rs
+++ b/opte/src/engine/packet.rs
@@ -30,6 +30,9 @@ use super::headers::IpAddr;
 use super::headers::IpMeta;
 use super::headers::UlpHdr;
 use super::headers::UlpMeta;
+use super::icmpv6::Icmpv6Hdr;
+use super::icmpv6::Icmpv6HdrError;
+use super::icmpv6::Icmpv6Meta;
 use super::ip4::Ipv4Addr;
 use super::ip4::Ipv4Hdr;
 use super::ip4::Ipv4HdrError;
@@ -155,11 +158,13 @@ impl From<&PacketMeta> for InnerFlowId {
             ),
         };
 
-        let (src_port, dst_port) = match &meta.inner.ulp {
-            Some(UlpMeta::Tcp(tcp)) => (tcp.src, tcp.dst),
-            Some(UlpMeta::Udp(udp)) => (udp.src, udp.dst),
-            None => (0, 0),
-        };
+        let (src_port, dst_port) = meta
+            .inner
+            .ulp
+            .map(|ulp| {
+                (ulp.src_port().unwrap_or(0), ulp.dst_port().unwrap_or(0))
+            })
+            .unwrap_or((0, 0));
 
         InnerFlowId { proto, src_ip, src_port, dst_ip, dst_port }
     }
@@ -679,6 +684,15 @@ impl Packet<Initialized> {
         Ok((HdrInfo { meta, offset }, ip))
     }
 
+    pub fn parse_icmp6<'a, 'b>(
+        rdr: &'b mut PacketReaderMut<'a>,
+    ) -> Result<(HdrInfo<UlpMeta>, UlpHdr<'a>), ParseError> {
+        let icmp6 = Icmpv6Hdr::parse(rdr)?;
+        let offset = HdrOffset::new(rdr.offset(), icmp6.hdr_len());
+        let meta = UlpMeta::from(Icmpv6Meta::from(&icmp6));
+        Ok((HdrInfo { meta, offset }, UlpHdr::from(icmp6)))
+    }
+
     pub fn parse_tcp<'a, 'b>(
         rdr: &'b mut PacketReaderMut<'a>,
     ) -> Result<(HdrInfo<UlpMeta>, UlpHdr<'a>), ParseError> {
@@ -1019,6 +1033,10 @@ impl Packet<Parsed> {
                 let ulp = &mut seg0_bytes[ulp_start..ulp_end];
 
                 match self.state.meta.inner.ulp.as_mut().unwrap() {
+                    UlpMeta::Icmpv6(icmp6) => {
+                        Self::update_icmpv6_csum(icmp6, csum, ulp);
+                    }
+
                     UlpMeta::Tcp(tcp) => {
                         Self::update_tcp_csum(tcp, csum, ulp);
                     }
@@ -1051,6 +1069,26 @@ impl Packet<Parsed> {
             let csum_end = ip_start + Ipv4Hdr::CSUM_END;
             all_hdr_bytes[csum_begin..csum_end].copy_from_slice(&csum[..]);
         }
+    }
+
+    fn update_icmpv6_csum(
+        icmp6: &mut Icmpv6Meta,
+        mut csum: Checksum,
+        ulp: &mut [u8],
+    ) {
+        let csum_start = Icmpv6Hdr::CSUM_BEGIN_OFFSET;
+        let csum_end = Icmpv6Hdr::CSUM_END_OFFSET;
+
+        // First we must zero the existing checksum.
+        ulp[csum_start..csum_end].copy_from_slice(&[0; 2]);
+        // Then we can add the ULP header bytes to the checksum.
+        csum.add_bytes(ulp);
+        // Convert the checksum to its final form.
+        let ulp_csum = HeaderChecksum::from(csum).bytes();
+        // Update the ICMPv6 metadata.
+        icmp6.csum = ulp_csum;
+        // Update the ICMPv6 header bytes.
+        ulp[csum_start..csum_end].copy_from_slice(&ulp_csum);
     }
 
     fn update_tcp_csum(tcp: &mut TcpMeta, mut csum: Checksum, ulp: &mut [u8]) {
@@ -1110,6 +1148,10 @@ impl Packet<Parsed> {
                 let ulp = &mut all_hdr_bytes[ulp_start..ulp_end];
 
                 match self.state.meta.inner.ulp.as_mut().unwrap() {
+                    UlpMeta::Icmpv6(icmp6) => {
+                        Self::update_icmpv6_csum(icmp6, csum, ulp);
+                    }
+
                     UlpMeta::Tcp(tcp) => {
                         Self::update_tcp_csum(tcp, csum, ulp);
                     }
@@ -1528,6 +1570,16 @@ impl Packet<Parsed> {
         // ULP
         // ================================================================
         match meta.ulp.as_mut() {
+            Some(UlpMeta::Icmpv6(icmp6)) => {
+                icmp6.emit(wtr.slice_mut(icmp6.hdr_len())?);
+                offsets.ulp = Some(HdrOffset {
+                    pkt_pos: pkt_offset,
+                    seg_idx: 0,
+                    seg_pos: pkt_offset,
+                    hdr_len: usize::from(icmp6.hdr_len()),
+                });
+            }
+
             Some(UlpMeta::Udp(udp)) => {
                 udp.len = (new_pkt_len - pkt_offset) as u16;
                 udp.emit(wtr.slice_mut(udp.hdr_len())?);
@@ -2037,6 +2089,12 @@ impl From<Ipv4HdrError> for ParseError {
 impl From<Ipv6HdrError> for ParseError {
     fn from(err: Ipv6HdrError) -> Self {
         Self::BadHeader(format!("IPv6: {:?}", err))
+    }
+}
+
+impl From<Icmpv6HdrError> for ParseError {
+    fn from(err: Icmpv6HdrError) -> Self {
+        Self::BadHeader(format!("ICMPv6: {:?}", err))
     }
 }
 

--- a/opte/src/engine/packet.rs
+++ b/opte/src/engine/packet.rs
@@ -1498,7 +1498,19 @@ impl Packet<Parsed> {
             }
 
             Some(IpMeta::Ip6(ip6)) => {
-                ip6.pay_len = (new_pkt_len - pkt_offset) as u16;
+                // IPv6 Payload Length field is defined in RFC 2640 section 3
+                // as:
+                //
+                // > Length of the IPv6 payload, i.e., the rest of the packet
+                // > following this IPv6 header, in octets. (Note that any
+                // > extension headers [section 4] present are considered part
+                // > of the payload, i.e., included in the length count.)
+                //
+                // So we need to remove the size of the fixed header (40
+                // octets), which is included in the total new packet length,
+                // when setting the payload length.
+                ip6.pay_len =
+                    (new_pkt_len - pkt_offset - Ipv6Hdr::BASE_SIZE) as u16;
                 ip6.emit(wtr.slice_mut(ip6.hdr_len())?);
                 offsets.ip = Some(HdrOffset {
                     pkt_pos: pkt_offset,

--- a/opte/src/engine/packet.rs
+++ b/opte/src/engine/packet.rs
@@ -286,6 +286,14 @@ impl PacketMeta {
         }
     }
 
+    /// Return the inner ICMPv6 metadata, if the inner ULP is ICMPv6.
+    pub fn inner_icmp6(&self) -> Option<&Icmpv6Meta> {
+        match &self.inner.ulp {
+            Some(UlpMeta::Icmpv6(icmp6)) => Some(icmp6),
+            _ => None,
+        }
+    }
+
     /// Return the inner TCP metadata, if the inner ULP is TCP.
     /// Otherwise, return `None`.
     pub fn inner_tcp(&self) -> Option<&TcpMeta> {

--- a/opte/src/engine/predicate.rs
+++ b/opte/src/engine/predicate.rs
@@ -28,13 +28,10 @@ use opte_api::MacAddr;
 use serde::Deserialize;
 use serde::Serialize;
 use smoltcp::phy::ChecksumCapabilities as Csum;
-use smoltcp::wire;
 use smoltcp::wire::DhcpPacket;
 use smoltcp::wire::DhcpRepr;
 use smoltcp::wire::Icmpv4Packet;
 use smoltcp::wire::Icmpv4Repr;
-use smoltcp::wire::Icmpv6Packet;
-use smoltcp::wire::Icmpv6Repr;
 
 cfg_if! {
     if #[cfg(all(not(feature = "std"), not(test)))] {
@@ -617,41 +614,12 @@ impl DataPredicate {
             }
 
             Self::Icmpv6MsgType(mt) => {
-                // Pull out the IPv6 source / destination addresses. This checks
-                // that this is actually an IPv6 packet, and these are needed
-                // for the `smoltcp` packet parsing / validation.
-                let (src, dst) = if let Some(metadata) = meta.inner_ip6() {
-                    (
-                        wire::IpAddress::Ipv6(wire::Ipv6Address(
-                            metadata.src.bytes(),
-                        )),
-                        wire::IpAddress::Ipv6(wire::Ipv6Address(
-                            metadata.dst.bytes(),
-                        )),
-                    )
-                } else {
-                    // This isn't an IPv6 packet at all
+                let Some(icmp6) = meta.inner_icmp6() else {
+                    // This isn't an ICMPv6 packet at all
                     return false;
                 };
 
-                let bytes = rdr.copy_remaining();
-                let pkt = match Icmpv6Packet::new_checked(&bytes) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        super::err(format!(
-                            "Icmpv6Packet::new_checked() failed: {:?}",
-                            e
-                        ));
-                        return false;
-                    }
-                };
-                if let Err(e) =
-                    Icmpv6Repr::parse(&src, &dst, &pkt, &Csum::ignored())
-                {
-                    super::err(format!("Icmpv6Repr::parse() failed: {:?}", e,));
-                    return false;
-                }
-                return Icmpv6MessageType::from(pkt.msg_type()) == *mt;
+                return icmp6.msg_type == *mt;
             }
 
             Self::Dhcpv6MsgType(mt) => {

--- a/oxide-vpc/.gitignore
+++ b/oxide-vpc/.gitignore
@@ -5,4 +5,4 @@ overlay_guest_to_guest-guest-2.pcap
 overlay_guest_to_guest-phys-1.pcap
 overlay_guest_to_guest-phys-2.pcap
 dhcpv6_solicit_reply.pcap
-guest_to_internet.pcap
+guest_to_internet_ipv[46].pcap

--- a/oxide-vpc/src/api.rs
+++ b/oxide-vpc/src/api.rs
@@ -272,6 +272,17 @@ impl VpcCfg {
             _ => panic!("expected an IPv4 SNAT configuration"),
         }
     }
+
+    #[cfg(any(feature = "test-help", test))]
+    pub fn snat6(&self) -> &SNat6Cfg {
+        match &self.ip_cfg {
+            IpCfg::Ipv6(ipv6) | IpCfg::DualStack { ipv6, .. } => {
+                ipv6.snat.as_ref().unwrap()
+            }
+
+            _ => panic!("expected an IPv6 SNAT configuration"),
+        }
+    }
 }
 
 /// A network destination on the Oxide Rack's physical network.

--- a/oxide-vpc/src/api.rs
+++ b/oxide-vpc/src/api.rs
@@ -718,6 +718,7 @@ impl FromStr for ProtoFilter {
             "any" => Ok(ProtoFilter::Any),
             "arp" => Ok(ProtoFilter::Arp),
             "icmp" => Ok(ProtoFilter::Proto(Protocol::ICMP)),
+            "icmp6" => Ok(ProtoFilter::Proto(Protocol::ICMPv6)),
             "tcp" => Ok(ProtoFilter::Proto(Protocol::TCP)),
             "udp" => Ok(ProtoFilter::Proto(Protocol::UDP)),
             _ => Err(format!("unknown protocol: {}", s)),

--- a/oxide-vpc/src/engine/mod.rs
+++ b/oxide-vpc/src/engine/mod.rs
@@ -315,10 +315,7 @@ impl NetworkParser for VpcParser {
                 // pkt.parse_icmp()?,
             }
 
-            Protocol::ICMPv6 => {
-                return Ok(PacketInfo { meta, offsets, body_csum: None });
-            }
-
+            Protocol::ICMPv6 => Packet::parse_icmp6(rdr)?,
             Protocol::TCP => Packet::parse_tcp(rdr)?,
             Protocol::UDP => Packet::parse_udp(rdr)?,
             proto => return Err(ParseError::UnexpectedProtocol(proto)),

--- a/oxide-vpc/src/engine/mod.rs
+++ b/oxide-vpc/src/engine/mod.rs
@@ -219,10 +219,7 @@ impl NetworkParser for VpcParser {
                 // pkt.parse_icmp()?,
             }
 
-            Protocol::ICMPv6 => {
-                return Ok(PacketInfo { meta, offsets, body_csum: None });
-            }
-
+            Protocol::ICMPv6 => Packet::parse_icmp6(rdr)?,
             Protocol::TCP => Packet::parse_tcp(rdr)?,
             Protocol::UDP => Packet::parse_udp(rdr)?,
             proto => return Err(ParseError::UnexpectedProtocol(proto)),

--- a/oxide-vpc/tests/integration_tests.rs
+++ b/oxide-vpc/tests/integration_tests.rs
@@ -2125,7 +2125,7 @@ fn establish_http_conn(
             "stats.port.out_modified, stats.port.out_uft_miss",
         ]
     );
-    let snat_port = pkt1.meta().inner.ulp.unwrap().src_port();
+    let snat_port = pkt1.meta().inner.ulp.unwrap().src_port().unwrap();
 
     // ================================================================
     // Step 2
@@ -2430,7 +2430,7 @@ fn tcp_outbound() {
             "stats.port.out_modified, stats.port.out_uft_miss",
         ]
     );
-    let snat_port = pkt1.meta().inner.ulp.unwrap().src_port();
+    let snat_port = pkt1.meta().inner.ulp.unwrap().src_port().unwrap();
     assert_eq!(TcpState::SynSent, g1.port.tcp_state(&flow).unwrap());
 
     // ================================================================
@@ -2669,7 +2669,7 @@ fn tcp_inbound() {
             "stats.port.in_modified, stats.port.in_uft_miss",
         ]
     );
-    let sport = pkt1.meta().inner.ulp.unwrap().src_port();
+    let sport = pkt1.meta().inner.ulp.unwrap().src_port().unwrap();
     assert_eq!(TcpState::Listen, g1.port.tcp_state(&flow).unwrap());
 
     // ================================================================


### PR DESCRIPTION
Fixes:
1. We weren't setting the right hop limit (255) for the Neighbour Advertisement & Router Advertisement packets sent to the guest. 
2. Filled in some missing validity checks for Neighbour Solicitation & Router Solicitation packets received from the guest.
3. We were erroneously including the IPv6 base header size in the payload length when updating modified inner headers.
4. ICMPv6 checksums are calculated including an IP psuedo-header which meant the SNAT transformations would render them invalid. We now treat ICMPv6 as a psuedo ULP and handle checksum updates like TCP/UDP.

Misc:
1. Allow `opteadm` to create a port using IPv6.
2. Accept `icmp6` as a protocol filter when adding a firewall rule via `opteadm`.

Future:
It would be nice to be able to filter specific ICMP message types in the firewall (i.e. allow incoming echo request/reply but drop upstream NS)