### PR TITLE
squash headers into single segment during parsing

### DIFF
--- a/opte/src/engine/mod.rs
+++ b/opte/src/engine/mod.rs
@@ -300,7 +300,12 @@ impl GenericUlp {
 
         let (ip_hi, pseudo_csum) = match ether_type {
             EtherType::Arp => {
-                return Ok(PacketInfo { meta, offsets, body_csum: None });
+                return Ok(PacketInfo {
+                    meta,
+                    offsets,
+                    body_csum: None,
+                    extra_hdr_space: None,
+                });
             }
 
             EtherType::Ipv4 => {
@@ -321,7 +326,12 @@ impl GenericUlp {
 
         let (ulp_hi, ulp_hdr) = match ip_hi.meta.proto() {
             Protocol::ICMP => {
-                return Ok(PacketInfo { meta, offsets, body_csum: None });
+                return Ok(PacketInfo {
+                    meta,
+                    offsets,
+                    body_csum: None,
+                    extra_hdr_space: None,
+                });
 
                 // todo!("need to reintrodouce ICMP as pseudo-ULP header");
                 // pkt.parse_icmp()?,
@@ -342,7 +352,7 @@ impl GenericUlp {
             None
         };
 
-        Ok(PacketInfo { meta, offsets, body_csum })
+        Ok(PacketInfo { meta, offsets, body_csum, extra_hdr_space: None })
     }
 }
 

--- a/opte/src/engine/packet.rs
+++ b/opte/src/engine/packet.rs
@@ -471,7 +471,7 @@ pub struct PacketInfo {
     // This value may also be none if the packet has no notion of a
     // ULP checksum; e.g., ARP.
     pub body_csum: Option<Checksum>,
-    // Extra header space to avoid multiple alloctions during encapsulation.
+    // Extra header space to avoid multiple allocations during encapsulation.
     pub extra_hdr_space: Option<usize>,
 }
 

--- a/opte/src/engine/packet.rs
+++ b/opte/src/engine/packet.rs
@@ -771,7 +771,7 @@ impl Packet<Initialized> {
 
         // If the squash bound is zero, there is nothing left to do here, just
         // return.
-        if squash_to == 0 {
+        if squash_to == 0 || dir == Direction::In {
             return Ok(Packet {
                 avail: self.avail,
                 // The new packet is taking ownership of the segments.

--- a/opte/src/engine/packet.rs
+++ b/opte/src/engine/packet.rs
@@ -780,7 +780,7 @@ impl Packet<Initialized> {
             (n, 0) => n - 1,
 
             // The body starts at a non-zero offset in segment n. This means we
-            // need to squasy all segments up to and including n.
+            // need to squash all segments up to and including n.
             (n, _) => n,
         };
 
@@ -863,9 +863,9 @@ impl Packet<Initialized> {
         self.segs[i].get_writer()
     }
 
-    pub fn add_seg(&mut self, size: usize) -> usize {
+    pub fn add_seg(&mut self, size: usize) -> Result<usize, SegAdjustError> {
         let mut seg = PacketSeg::alloc(size);
-        seg.expand_end(size).unwrap();
+        seg.expand_end(size)?;
         let len = self.segs.len();
         if len > 0 {
             let last_seg = &mut self.segs[len - 1];
@@ -873,7 +873,7 @@ impl Packet<Initialized> {
         }
         self.segs.push(seg);
         self.state.len += size;
-        len
+        Ok(len)
     }
 
     /// Wrap the `mblk_t` packet in a [`Packet`], taking ownership of

--- a/opte/src/engine/packet.rs
+++ b/opte/src/engine/packet.rs
@@ -846,7 +846,7 @@ impl Packet<Initialized> {
         }
         #[cfg(any(feature = "std", test))]
         for s in &orig_segs[..squash_to + 1] {
-            mock_freemsg(s.mp);
+            mock_freeb(s.mp);
         }
 
         // Recompute info after squash.

--- a/opte/src/engine/packet.rs
+++ b/opte/src/engine/packet.rs
@@ -377,15 +377,8 @@ impl PacketMeta {
 #[derive(Debug)]
 pub struct Packet<S: PacketState> {
     avail: usize,
-    source: PacketSource,
     segs: Vec<PacketSeg>,
     state: S,
-}
-
-#[derive(Clone, Copy, Debug)]
-enum PacketSource {
-    Allocated,
-    Wrapped,
 }
 
 /// The type state of a packet that has been initialized and allocated, but
@@ -645,12 +638,7 @@ impl Packet<Initialized> {
         let len: usize = segs.iter().map(|s| s.len).sum();
         let avail: usize = segs.iter().map(|s| s.avail).sum();
 
-        Packet {
-            avail,
-            source: PacketSource::Allocated,
-            segs,
-            state: Initialized { len },
-        }
+        Packet { avail, segs, state: Initialized { len } }
     }
 
     #[cfg(test)]
@@ -659,12 +647,7 @@ impl Packet<Initialized> {
         let len: usize = segs.iter().map(|s| s.len).sum();
         let avail: usize = segs.iter().map(|s| s.avail).sum();
 
-        Packet {
-            avail,
-            source: PacketSource::Allocated,
-            segs,
-            state: Initialized { len },
-        }
+        Packet { avail, segs, state: Initialized { len } }
     }
 
     pub fn parse_ether<'a, 'b>(
@@ -791,7 +774,6 @@ impl Packet<Initialized> {
         if squash_to == 0 {
             return Ok(Packet {
                 avail: self.avail,
-                source: self.source,
                 // The new packet is taking ownership of the segments.
                 segs: core::mem::take(&mut self.segs),
                 state: Parsed {
@@ -871,7 +853,6 @@ impl Packet<Initialized> {
 
         Ok(Packet {
             avail: self.avail,
-            source: self.source,
             segs,
             state: Parsed {
                 len: self.state.len,
@@ -970,7 +951,6 @@ impl Packet<Initialized> {
 
         Ok(Packet {
             avail: avail.try_into().unwrap(),
-            source: PacketSource::Wrapped,
             segs,
             state: Initialized { len },
         })

--- a/opte/src/engine/packet.rs
+++ b/opte/src/engine/packet.rs
@@ -751,19 +751,98 @@ impl Packet<Initialized> {
             seg_offset = 0;
         }
 
-        let body = BodyInfo {
+        assert!(
+            self.state.len >= pkt_offset,
+            "{} > {}",
+            self.state.len,
+            pkt_offset,
+        );
+
+        let mut body = BodyInfo {
             pkt_offset,
             seg_index,
             seg_offset,
             len: self.state.len - pkt_offset,
         };
-
         let flow = InnerFlowId::from(&info.meta);
+
+        // Packet processing logic requires all headers to be in the leading
+        // segment. Detect if this is not the case and squash segments
+        // containing headers into one segment. This value represents the
+        // inclusive upper bound of the squash.
+        let squash_to = match (body.seg_index, body.seg_offset) {
+            // The body is in the first segment meaning all headers are also in
+            // the first segment. No squashing needed.
+            (0, _) => 0,
+
+            // The body starts at a zero offset in segment n. This means we need
+            // to squash all segments prior to n.
+            (n, 0) => n - 1,
+
+            // The body starts at a non-zero offset in segment n. This means we
+            // need to squasy all segments up to and including n.
+            (n, _) => n,
+        };
+
+        // If the squash bound is zero, there is notthing left to do here, just
+        // return.
+        if squash_to == 0 {
+            return Ok(Packet {
+                avail: self.avail,
+                source: self.source,
+                // The new packet is taking ownership of the segments.
+                segs: core::mem::take(&mut self.segs),
+                state: Parsed {
+                    len: self.state.len,
+                    hdr_offsets: info.offsets,
+                    meta: info.meta,
+                    flow,
+                    body_csum: info.body_csum,
+                    body,
+                    body_modified: false,
+                },
+            });
+        }
+
+        // Calculate the body offset within the new squashed segment
+        for s in &self.segs[..squash_to] {
+            body.seg_offset += s.len;
+        }
+        body.seg_index -= squash_to;
+
+        // Determine how big the message block for the squashed segment needs to
+        // be.
+        let mut new_seg_size = 0;
+        for s in &self.segs[..squash_to + 1] {
+            new_seg_size += s.len;
+        }
+
+        // Allocate a message block and copy in the squashed data.
+        let mut mp = allocb(new_seg_size);
+        unsafe {
+            for s in &self.segs[..squash_to + 1] {
+                core::ptr::copy_nonoverlapping(
+                    (*s.mp).b_rptr,
+                    (*mp).b_wptr,
+                    s.len,
+                );
+                (*mp).b_wptr = (*mp).b_wptr.add(s.len);
+            }
+        }
+
+        // Construct a new segment vector, tacking on any remaining segments
+        // after the header segments.
+        let orig_segs = core::mem::take(&mut self.segs);
+        let mut segs = vec![unsafe { PacketSeg::wrap_mblk(mp) }];
+        if squash_to + 1 < orig_segs.len() {
+            segs[0].link(&orig_segs[squash_to + 1]);
+            segs.extend_from_slice(&orig_segs[squash_to + 1..]);
+        }
+
         Ok(Packet {
             avail: self.avail,
             source: self.source,
-            // The new packet is taking ownership of the segments.
-            segs: core::mem::take(&mut self.segs),
+            segs,
             state: Parsed {
                 len: self.state.len,
                 hdr_offsets: info.offsets,
@@ -778,6 +857,23 @@ impl Packet<Initialized> {
 
     pub fn seg0_wtr(&mut self) -> PacketSegWriter {
         self.segs[0].get_writer()
+    }
+
+    pub fn seg_wtr(&mut self, i: usize) -> PacketSegWriter {
+        self.segs[i].get_writer()
+    }
+
+    pub fn add_seg(&mut self, size: usize) -> usize {
+        let mut seg = PacketSeg::alloc(size);
+        seg.expand_end(size).unwrap();
+        let len = self.segs.len();
+        if len > 0 {
+            let last_seg = &mut self.segs[len - 1];
+            last_seg.link(&seg);
+        }
+        self.segs.push(seg);
+        self.state.len += size;
+        len
     }
 
     /// Wrap the `mblk_t` packet in a [`Packet`], taking ownership of
@@ -1289,22 +1385,10 @@ impl Packet<Parsed> {
                 // In this case we need to "erase" the old headers and
                 // allocate an mblk to hold the new headers.
                 //
-                // XXX This assumes that the headers all reside in the
-                // first segment. For any typical implementation, this
-                // should be true (it's better for performance, and
-                // just makes the most sense). However, if that
-                // invariant doesn't hold true, this method of erasing
-                // the original header data is incomplete. It will
-                // only partially erase the data, leading to confusion
-                // downstream somewhere. The best solution is to check
-                // for this during parsing. If the header straddles
-                // segments, then just copy all header data into a new
-                // segment, and replace the old header data with that
-                // one segment. This means a hit on performance, but
-                // it also means sanity for all downstream code.
-                // Besides, any network stack that cares about
-                // performance will already make sure to place the
-                // headers in a single buffer.
+                // This assumes that the headers all reside in the
+                // first segment. This is checked for in parsing and if the
+                // headers are not all in the first segment, the leading
+                // segments are squashed into one until this becomes true.
                 segs[0].shrink_start(old_hdr_len).unwrap();
 
                 // Create the new segment for holding the new headers.

--- a/opte/src/engine/packet.rs
+++ b/opte/src/engine/packet.rs
@@ -843,10 +843,10 @@ impl Packet<Initialized> {
         if squash_to + 1 < orig_segs.len() {
             segs[0].link(&orig_segs[squash_to + 1]);
             segs.extend_from_slice(&orig_segs[squash_to + 1..]);
-            #[cfg(any(feature = "std", test))]
-            for s in &orig_segs[..squash_to + 1] {
-                mock_freeb(s.mp);
-            }
+        }
+        #[cfg(any(feature = "std", test))]
+        for s in &orig_segs[..squash_to + 1] {
+            mock_freemsg(s.mp);
         }
 
         // Recompute info after squash.

--- a/opte/src/engine/snat.rs
+++ b/opte/src/engine/snat.rs
@@ -220,8 +220,9 @@ impl SNat {
             if icmp.msg_type() != Icmpv4Message::EchoRequest {
                 return Err(GenDescError::Unexpected {
                     msg: format!(
-                        "Expected ICMP Echo Request, found: {}",
-                        icmp.msg_type()
+                        "Expected ICMP Echo Request, found: {} \n{:x?}",
+                        icmp.msg_type(),
+                        body_segs,
                     ),
                 });
             }

--- a/opte/src/engine/snat.rs
+++ b/opte/src/engine/snat.rs
@@ -220,9 +220,8 @@ impl SNat {
             if icmp.msg_type() != Icmpv4Message::EchoRequest {
                 return Err(GenDescError::Unexpected {
                     msg: format!(
-                        "Expected ICMP Echo Request, found: {} \n{:x?}",
+                        "Expected ICMP Echo Request, found: {}",
                         icmp.msg_type(),
-                        body_segs,
                     ),
                 });
             }

--- a/oxide-vpc/src/engine/mod.rs
+++ b/oxide-vpc/src/engine/mod.rs
@@ -192,7 +192,7 @@ impl NetworkParser for VpcParser {
         let ether_type = ether_hi.meta.ether_type;
 
         // Allocate a message block and copy in the squashed data. Provide
-        // enough extra space for genve encapsulation to not require an extra
+        // enough extra space for geneve encapsulation to not require an extra
         // allocation later on. 128 is based on
         // - 18 byte ethernet header (vlan space)
         // - 40 byte ipv6 header

--- a/oxide-vpc/src/engine/mod.rs
+++ b/oxide-vpc/src/engine/mod.rs
@@ -193,7 +193,12 @@ impl NetworkParser for VpcParser {
 
         let (ip_hi, pseudo_csum) = match ether_type {
             EtherType::Arp => {
-                return Ok(PacketInfo { meta, offsets, body_csum: None });
+                return Ok(PacketInfo {
+                    meta,
+                    offsets,
+                    body_csum: None,
+                    extra_hdr_space: None,
+                });
             }
 
             EtherType::Ipv4 => {
@@ -212,9 +217,24 @@ impl NetworkParser for VpcParser {
         meta.inner.ip = Some(ip_hi.meta);
         offsets.inner.ip = Some(ip_hi.offset);
 
+        // Allocate a message block and copy in the squashed data. Provide
+        // enough extra space for genve encapsulation to not require an extra
+        // allocation later on. 128 is based on
+        // - 18 byte ethernet header (vlan space)
+        // - 40 byte ipv6 header
+        // - 8 byte udp header
+        // - 8 byte geneve header
+        // - space for geneve options
+        const EXTRA_SPACE: Option<usize> = Some(128);
+
         let (ulp_hi, ulp_hdr) = match ip_hi.meta.proto() {
             Protocol::ICMP => {
-                return Ok(PacketInfo { meta, offsets, body_csum: None });
+                return Ok(PacketInfo {
+                    meta,
+                    offsets,
+                    body_csum: None,
+                    extra_hdr_space: EXTRA_SPACE,
+                });
                 // todo!("need to reintrodouce ICMP as pseudo-ULP header");
                 // pkt.parse_icmp()?,
             }
@@ -235,7 +255,12 @@ impl NetworkParser for VpcParser {
             None
         };
 
-        Ok(PacketInfo { meta, offsets, body_csum })
+        Ok(PacketInfo {
+            meta,
+            offsets,
+            body_csum,
+            extra_hdr_space: EXTRA_SPACE,
+        })
     }
 
     fn parse_inbound(
@@ -293,7 +318,12 @@ impl NetworkParser for VpcParser {
                 // XXX-EXT-IP Need to allow inbound ARP for proxy ARP
                 // to work.
                 if self.proxy_arp_enable {
-                    return Ok(PacketInfo { meta, offsets, body_csum: None });
+                    return Ok(PacketInfo {
+                        meta,
+                        offsets,
+                        body_csum: None,
+                        extra_hdr_space: None,
+                    });
                 } else {
                     return Err(ParseError::UnexpectedEtherType(inner_et));
                 }
@@ -307,7 +337,12 @@ impl NetworkParser for VpcParser {
 
         let (inner_ulp_hi, inner_ulp_hdr) = match inner_ip_hi.meta.proto() {
             Protocol::ICMP => {
-                return Ok(PacketInfo { meta, offsets, body_csum: None });
+                return Ok(PacketInfo {
+                    meta,
+                    offsets,
+                    body_csum: None,
+                    extra_hdr_space: None,
+                });
                 // todo!("need to reintrodouce ICMP as pseudo-ULP header");
                 // pkt.parse_icmp()?,
             }
@@ -327,6 +362,6 @@ impl NetworkParser for VpcParser {
             None
         };
 
-        Ok(PacketInfo { meta, offsets, body_csum })
+        Ok(PacketInfo { meta, offsets, body_csum, extra_hdr_space: None })
     }
 }

--- a/oxide-vpc/tests/common/icmp.rs
+++ b/oxide-vpc/tests/common/icmp.rs
@@ -121,22 +121,6 @@ pub fn gen_icmp_echo(
         let mut pkt = Packet::alloc_and_expand(EtherHdr::SIZE);
         let mut wtr = pkt.seg_wtr(0);
         eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
-
-        /*
-         * TODO
-         * It seems like this should also work, but it does not. Leaving this as
-         * a todo, as I've not actually seen packets like this in the wild yet.
-         *
-         *   let i = pkt.add_seg(ip4.hdr_len()).unwrap();
-         *   let mut wtr = pkt.seg_wtr(i);
-         *   ip4.emit(wtr.slice_mut(ip4.hdr_len()).unwrap());
-         *
-         *   let i = pkt.add_seg(icmp_bytes.len()).unwrap();
-         *   let mut wtr = pkt.seg_wtr(i);
-         *   wtr.write(&icmp_bytes).unwrap();
-         *
-         */
-
         let i = pkt.add_seg(ip4.hdr_len() + icmp_bytes.len()).unwrap();
         let mut wtr = pkt.seg_wtr(i);
         ip4.emit(wtr.slice_mut(ip4.hdr_len()).unwrap());
@@ -170,7 +154,7 @@ pub fn gen_icmpv6_echo_req(
         proto: Protocol::ICMPv6,
         next_hdr: IpProtocol::Icmpv6,
         hop_limit: 64,
-        pay_len: (Ipv6Hdr::BASE_SIZE + req.buffer_len()) as u16,
+        pay_len: req.buffer_len() as u16,
         ..Default::default()
     };
     let eth =

--- a/oxide-vpc/tests/common/icmp.rs
+++ b/oxide-vpc/tests/common/icmp.rs
@@ -123,16 +123,21 @@ pub fn gen_icmp_echo(
         eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
 
         /*
-        let i = pkt.add_seg(ip4.hdr_len());
-        let mut wtr = pkt.seg_wtr(i);
-        ip4.emit(wtr.slice_mut(ip4.hdr_len()).unwrap());
+         * TODO
+         * It seems like this should also work, but it does not. Leaving this as
+         * a todo, as I've not actually seen packets like this in the wild yet.
+         *
+         *   let i = pkt.add_seg(ip4.hdr_len()).unwrap();
+         *   let mut wtr = pkt.seg_wtr(i);
+         *   ip4.emit(wtr.slice_mut(ip4.hdr_len()).unwrap());
+         *
+         *   let i = pkt.add_seg(icmp_bytes.len()).unwrap();
+         *   let mut wtr = pkt.seg_wtr(i);
+         *   wtr.write(&icmp_bytes).unwrap();
+         *
+         */
 
-        let i = pkt.add_seg(icmp_bytes.len());
-        let mut wtr = pkt.seg_wtr(i);
-        wtr.write(&icmp_bytes).unwrap();
-        */
-
-        let i = pkt.add_seg(ip4.hdr_len() + icmp_bytes.len());
+        let i = pkt.add_seg(ip4.hdr_len() + icmp_bytes.len()).unwrap();
         let mut wtr = pkt.seg_wtr(i);
         ip4.emit(wtr.slice_mut(ip4.hdr_len()).unwrap());
         wtr.write(&icmp_bytes).unwrap();
@@ -181,6 +186,13 @@ pub fn gen_icmpv6_echo_req(
         wtr.write(&body_bytes).unwrap();
         pkt.parse(Out, VpcParser::new()).unwrap()
     } else {
-        todo!();
+        let mut pkt = Packet::alloc_and_expand(EtherHdr::SIZE);
+        let mut wtr = pkt.seg_wtr(0);
+        eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
+        let i = pkt.add_seg(ip6.hdr_len() + body_bytes.len()).unwrap();
+        let mut wtr = pkt.seg_wtr(i);
+        ip6.emit(wtr.slice_mut(ip6.hdr_len()).unwrap());
+        wtr.write(&body_bytes).unwrap();
+        pkt.parse(Out, VpcParser::new()).unwrap()
     }
 }

--- a/oxide-vpc/tests/common/icmp.rs
+++ b/oxide-vpc/tests/common/icmp.rs
@@ -33,14 +33,14 @@ pub fn gen_icmp_echo_req(
     ident: u16,
     seq_no: u16,
     data: &[u8],
-    multi_seg: bool,
+    segments: usize,
 ) -> Packet<Parsed> {
     match (ip_src, ip_dst) {
         (IpAddr::Ip4(src), IpAddr::Ip4(dst)) => gen_icmpv4_echo_req(
-            eth_src, eth_dst, src, dst, ident, seq_no, data, multi_seg,
+            eth_src, eth_dst, src, dst, ident, seq_no, data, segments,
         ),
         (IpAddr::Ip6(src), IpAddr::Ip6(dst)) => gen_icmpv6_echo_req(
-            eth_src, eth_dst, src, dst, ident, seq_no, data, multi_seg,
+            eth_src, eth_dst, src, dst, ident, seq_no, data, segments,
         ),
         (_, _) => panic!("IP src and dst versions must match"),
     }
@@ -54,11 +54,11 @@ pub fn gen_icmpv4_echo_req(
     ident: u16,
     seq_no: u16,
     data: &[u8],
-    multi_seg: bool,
+    segments: usize,
 ) -> Packet<Parsed> {
     let etype = IcmpEchoType::Req;
     gen_icmp_echo(
-        etype, eth_src, eth_dst, ip_src, ip_dst, ident, seq_no, data, multi_seg,
+        etype, eth_src, eth_dst, ip_src, ip_dst, ident, seq_no, data, segments,
     )
 }
 
@@ -70,11 +70,11 @@ pub fn gen_icmp_echo_reply(
     ident: u16,
     seq_no: u16,
     data: &[u8],
-    multi_seg: bool,
+    segments: usize,
 ) -> Packet<Parsed> {
     let etype = IcmpEchoType::Reply;
     gen_icmp_echo(
-        etype, eth_src, eth_dst, ip_src, ip_dst, ident, seq_no, data, multi_seg,
+        etype, eth_src, eth_dst, ip_src, ip_dst, ident, seq_no, data, segments,
     )
 }
 
@@ -87,7 +87,7 @@ pub fn gen_icmp_echo(
     ident: u16,
     seq_no: u16,
     data: &[u8],
-    multi_seg: bool,
+    segments: usize,
 ) -> Packet<Parsed> {
     let icmp = match etype {
         IcmpEchoType::Req => Icmpv4Repr::EchoRequest { ident, seq_no, data },
@@ -110,22 +110,40 @@ pub fn gen_icmp_echo(
 
     let total_len = EtherHdr::SIZE + ip4.hdr_len() + icmp.buffer_len();
 
-    if !multi_seg {
-        let mut pkt = Packet::alloc_and_expand(total_len);
-        let mut wtr = pkt.seg0_wtr();
-        eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
-        ip4.emit(wtr.slice_mut(ip4.hdr_len()).unwrap());
-        wtr.write(&icmp_bytes).unwrap();
-        pkt.parse(Out, VpcParser::new()).unwrap()
-    } else {
-        let mut pkt = Packet::alloc_and_expand(EtherHdr::SIZE);
-        let mut wtr = pkt.seg_wtr(0);
-        eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
-        let i = pkt.add_seg(ip4.hdr_len() + icmp_bytes.len()).unwrap();
-        let mut wtr = pkt.seg_wtr(i);
-        ip4.emit(wtr.slice_mut(ip4.hdr_len()).unwrap());
-        wtr.write(&icmp_bytes).unwrap();
-        pkt.parse(Out, VpcParser::new()).unwrap()
+    match segments {
+        1 => {
+            let mut pkt = Packet::alloc_and_expand(total_len);
+            let mut wtr = pkt.seg0_wtr();
+            eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
+            ip4.emit(wtr.slice_mut(ip4.hdr_len()).unwrap());
+            wtr.write(&icmp_bytes).unwrap();
+            pkt.parse(Out, VpcParser::new()).unwrap()
+        }
+        2 => {
+            let mut pkt = Packet::alloc_and_expand(EtherHdr::SIZE);
+            let mut wtr = pkt.seg_wtr(0);
+            eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
+            let i = pkt.add_seg(ip4.hdr_len() + icmp_bytes.len()).unwrap();
+            let mut wtr = pkt.seg_wtr(i);
+            ip4.emit(wtr.slice_mut(ip4.hdr_len()).unwrap());
+            wtr.write(&icmp_bytes).unwrap();
+            pkt.parse(Out, VpcParser::new()).unwrap()
+        }
+        3 => {
+            let mut pkt = Packet::alloc_and_expand(EtherHdr::SIZE);
+            let mut wtr = pkt.seg_wtr(0);
+            eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
+            let i = pkt.add_seg(ip4.hdr_len()).unwrap();
+            let mut wtr = pkt.seg_wtr(i);
+            ip4.emit(wtr.slice_mut(ip4.hdr_len()).unwrap());
+            let i = pkt.add_seg(icmp_bytes.len()).unwrap();
+            let mut wtr = pkt.seg_wtr(i);
+            wtr.write(&icmp_bytes).unwrap();
+            pkt.parse(Out, VpcParser::new()).unwrap()
+        }
+        _ => {
+            panic!("only 1 2 or 3 segments allowed")
+        }
     }
 }
 
@@ -137,7 +155,7 @@ pub fn gen_icmpv6_echo_req(
     ident: u16,
     seq_no: u16,
     data: &[u8],
-    multi_seg: bool,
+    segments: usize,
 ) -> Packet<Parsed> {
     let req = Icmpv6Repr::EchoRequest { ident, seq_no, data };
     let mut body_bytes = vec![0u8; req.buffer_len()];
@@ -162,21 +180,39 @@ pub fn gen_icmpv6_echo_req(
 
     let total_len = EtherHdr::SIZE + ip6.hdr_len() + req.buffer_len();
 
-    if !multi_seg {
-        let mut pkt = Packet::alloc_and_expand(total_len);
-        let mut wtr = pkt.seg0_wtr();
-        eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
-        ip6.emit(wtr.slice_mut(ip6.hdr_len()).unwrap());
-        wtr.write(&body_bytes).unwrap();
-        pkt.parse(Out, VpcParser::new()).unwrap()
-    } else {
-        let mut pkt = Packet::alloc_and_expand(EtherHdr::SIZE);
-        let mut wtr = pkt.seg_wtr(0);
-        eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
-        let i = pkt.add_seg(ip6.hdr_len() + body_bytes.len()).unwrap();
-        let mut wtr = pkt.seg_wtr(i);
-        ip6.emit(wtr.slice_mut(ip6.hdr_len()).unwrap());
-        wtr.write(&body_bytes).unwrap();
-        pkt.parse(Out, VpcParser::new()).unwrap()
+    match segments {
+        1 => {
+            let mut pkt = Packet::alloc_and_expand(total_len);
+            let mut wtr = pkt.seg0_wtr();
+            eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
+            ip6.emit(wtr.slice_mut(ip6.hdr_len()).unwrap());
+            wtr.write(&body_bytes).unwrap();
+            pkt.parse(Out, VpcParser::new()).unwrap()
+        }
+        2 => {
+            let mut pkt = Packet::alloc_and_expand(EtherHdr::SIZE);
+            let mut wtr = pkt.seg_wtr(0);
+            eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
+            let i = pkt.add_seg(ip6.hdr_len() + body_bytes.len()).unwrap();
+            let mut wtr = pkt.seg_wtr(i);
+            ip6.emit(wtr.slice_mut(ip6.hdr_len()).unwrap());
+            wtr.write(&body_bytes).unwrap();
+            pkt.parse(Out, VpcParser::new()).unwrap()
+        }
+        3 => {
+            let mut pkt = Packet::alloc_and_expand(EtherHdr::SIZE);
+            let mut wtr = pkt.seg_wtr(0);
+            eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
+            let i = pkt.add_seg(ip6.hdr_len()).unwrap();
+            let mut wtr = pkt.seg_wtr(i);
+            ip6.emit(wtr.slice_mut(ip6.hdr_len()).unwrap());
+            let i = pkt.add_seg(body_bytes.len()).unwrap();
+            let mut wtr = pkt.seg_wtr(i);
+            wtr.write(&body_bytes).unwrap();
+            pkt.parse(Out, VpcParser::new()).unwrap()
+        }
+        _ => {
+            panic!("only 1 2 or 3 segments allowed")
+        }
     }
 }

--- a/oxide-vpc/tests/integration_tests.rs
+++ b/oxide-vpc/tests/integration_tests.rs
@@ -370,7 +370,7 @@ fn gateway_icmp4_ping() {
         ident,
         seq_no,
         &data[..],
-        false,
+        1,
     );
     pcap.add_pkt(&pkt1);
 
@@ -984,7 +984,7 @@ fn snat_icmp4_echo_rewrite() {
         ident,
         seq_no,
         &data[..],
-        true,
+        2,
     );
 
     let res = g1.port.process(Out, &mut pkt1, ActionMeta::new());
@@ -1035,7 +1035,7 @@ fn snat_icmp4_echo_rewrite() {
         mapped_port,
         seq_no,
         &data[..],
-        false,
+        3,
     );
     let bsvc_phys = TestIpPhys {
         ip: g1_cfg.boundary_services.ip,
@@ -1091,7 +1091,7 @@ fn snat_icmp4_echo_rewrite() {
         ident,
         seq_no,
         &data[..],
-        false,
+        1,
     );
 
     assert_eq!(g1.port.stats_snap().out_uft_hit, 0);
@@ -1137,7 +1137,7 @@ fn snat_icmp4_echo_rewrite() {
         mapped_port,
         seq_no,
         &data[..],
-        false,
+        2,
     );
 
     assert_eq!(g1.port.stats_snap().in_uft_hit, 0);
@@ -1359,7 +1359,7 @@ fn test_guest_to_gateway_icmpv6_ping(
         ident,
         seq_no,
         &data[..],
-        true,
+        3,
     );
     pcap.add_pkt(&pkt1);
 

--- a/oxide-vpc/tests/integration_tests.rs
+++ b/oxide-vpc/tests/integration_tests.rs
@@ -1359,7 +1359,7 @@ fn test_guest_to_gateway_icmpv6_ping(
         ident,
         seq_no,
         &data[..],
-        false,
+        true,
     );
     pcap.add_pkt(&pkt1);
 

--- a/oxide-vpc/tests/integration_tests.rs
+++ b/oxide-vpc/tests/integration_tests.rs
@@ -1000,7 +1000,7 @@ fn snat_icmp4_echo_rewrite() {
     );
 
     assert_eq!(pkt1.body_offset(), VPC_ENCAP_SZ + IP4_SZ);
-    assert_eq!(pkt1.body_seg(), 1);
+    assert_eq!(pkt1.body_seg(), 0);
     let meta = pkt1.meta();
 
     let eth = meta.inner.ether;

--- a/oxide-vpc/tests/integration_tests.rs
+++ b/oxide-vpc/tests/integration_tests.rs
@@ -370,6 +370,7 @@ fn gateway_icmp4_ping() {
         ident,
         seq_no,
         &data[..],
+        false,
     );
     pcap.add_pkt(&pkt1);
 
@@ -983,6 +984,7 @@ fn snat_icmp4_echo_rewrite() {
         ident,
         seq_no,
         &data[..],
+        true,
     );
 
     let res = g1.port.process(Out, &mut pkt1, ActionMeta::new());
@@ -1033,6 +1035,7 @@ fn snat_icmp4_echo_rewrite() {
         mapped_port,
         seq_no,
         &data[..],
+        false,
     );
     let bsvc_phys = TestIpPhys {
         ip: g1_cfg.boundary_services.ip,
@@ -1088,6 +1091,7 @@ fn snat_icmp4_echo_rewrite() {
         ident,
         seq_no,
         &data[..],
+        false,
     );
 
     assert_eq!(g1.port.stats_snap().out_uft_hit, 0);
@@ -1133,6 +1137,7 @@ fn snat_icmp4_echo_rewrite() {
         mapped_port,
         seq_no,
         &data[..],
+        false,
     );
 
     assert_eq!(g1.port.stats_snap().in_uft_hit, 0);
@@ -1354,6 +1359,7 @@ fn test_guest_to_gateway_icmpv6_ping(
         ident,
         seq_no,
         &data[..],
+        false,
     );
     pcap.add_pkt(&pkt1);
 


### PR DESCRIPTION
This PR fixes the issue described in the following [comment](https://github.com/oxidecomputer/opte/blob/master/opte/src/engine/packet.rs#L1292-L1307). 

```
XXX This assumes that the headers all reside in the
first segment. For any typical implementation, this
should be true (it's better for performance, and
just makes the most sense). However, if that
invariant doesn't hold true, this method of erasing
the original header data is incomplete. It will
only partially erase the data, leading to confusion
downstream somewhere. The best solution is to check
for this during parsing. If the header straddles
segments, then just copy all header data into a new
segment, and replace the old header data with that
one segment. This means a hit on performance, but
it also means sanity for all downstream code.
Besides, any network stack that cares about
performance will already make sure to place the
headers in a single buffer.
```

This has resulted in panics in a few different environments.

This patch takes the advice of the comment and squashes the headers down into a single segment during parsing.

## Testing

A test is also added that captures the panic behavior.

### Without patch

```
ry@masaka:~/src/opte/oxide-vpc$ RUST_BACKTRACE=1 cargo test snat_icmp4_echo_rewrite
    Finished test [unoptimized + debuginfo] target(s) in 0.07s
     Running unittests src/lib.rs (target/debug/deps/oxide_vpc-09fa660a95f8ab19)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s

     Running tests/firewall_tests.rs (target/debug/deps/firewall_tests-e22257a8a15a7116)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s

     Running tests/integration_tests.rs (target/debug/deps/integration_tests-8e7dfa9921effefa)

running 1 test
test snat_icmp4_echo_rewrite ... FAILED

failures:

---- snat_icmp4_echo_rewrite stdout ----
thread 'snat_icmp4_echo_rewrite' panicked at 'called `Result::unwrap()` on an `Err` value: StartPastEnd', /home/ry/src/opte/opte/src/engine/packet.rs:1392:51
stack backtrace:
   0: rust_begin_unwind
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/panicking.rs:65:14
   2: core::result::unwrap_failed
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/result.rs:1791:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/result.rs:1113:23
   4: opte::engine::packet::Packet<opte::engine::packet::Parsed>::hdr_seg
             at /home/ry/src/opte/opte/src/engine/packet.rs:1392:17
   5: opte::engine::packet::Packet<opte::engine::packet::Parsed>::emit_new_headers
             at /home/ry/src/opte/opte/src/engine/packet.rs:1494:9
   6: opte::engine::port::Port<N>::process
             at /home/ry/src/opte/opte/src/engine/port.rs:1112:13
   7: integration_tests::snat_icmp4_echo_rewrite
             at ./tests/integration_tests.rs:990:15
   8: integration_tests::snat_icmp4_echo_rewrite::{{closure}}
             at ./tests/integration_tests.rs:956:1
   9: core::ops::function::FnOnce::call_once
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/ops/function.rs:251:5
  10: core::ops::function::FnOnce::call_once
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/ops/function.rs:251:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    snat_icmp4_echo_rewrite

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 23 filtered out; finished in 0.05s

error: test failed, to rerun pass `--test integration_tests`
```

### With patch

```
ry@masaka:~/src/opte/oxide-vpc$ RUST_BACKTRACE=1 cargo test snat_icmp4_echo_rewrite
   Compiling opte v0.1.0 (/home/ry/src/opte/opte)
   Compiling oxide-vpc v0.1.0 (/home/ry/src/opte/oxide-vpc)
    Finished test [unoptimized + debuginfo] target(s) in 6.85s
     Running unittests src/lib.rs (target/debug/deps/oxide_vpc-09fa660a95f8ab19)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s

     Running tests/firewall_tests.rs (target/debug/deps/firewall_tests-e22257a8a15a7116)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s

     Running tests/integration_tests.rs (target/debug/deps/integration_tests-8e7dfa9921effefa)

running 1 test
test snat_icmp4_echo_rewrite ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 23 filtered out; finished in 0.01s
```

Fixes #349 
Fixes #351 
