### PR TITLE
prevent zero-sized continuation blocks

### DIFF
--- a/opte/src/engine/packet.rs
+++ b/opte/src/engine/packet.rs
@@ -1892,10 +1892,10 @@ impl PacketSeg {
             // sized blocks. This is not a generally expected thing and has
             // caused NIC hardware to stop working. Stopping short of a
             // production panic, but this should fail any tests.
-            #[cfg(any(feature = "std", test))]
-            if (*seg.mp).b_wptr == (*seg.mp).b_rptr {
-                panic!("zero-length continuation");
-            }
+            debug_assert!(
+                (*seg.mp).b_wptr != (*seg.mp).b_rptr,
+                "zero-length continuation",
+            );
             (*self.mp).b_cont = seg.mp
         };
     }

--- a/oxide-vpc/tests/integration_tests.rs
+++ b/oxide-vpc/tests/integration_tests.rs
@@ -615,7 +615,7 @@ fn guest_to_guest() {
         ]
     );
     assert_eq!(pkt2.body_offset(), TCP4_SZ + HTTP_SYN_OPTS_LEN);
-    assert_eq!(pkt2.body_seg(), 1);
+    assert_eq!(pkt2.body_seg(), 0);
 
     let g2_meta = pkt2.meta();
     assert!(g2_meta.outer.ether.is_none());


### PR DESCRIPTION
When emitting headers, the structure of the message block for the packet being modified is somtimes altered. If the block holding the current headers is too small for the new headers, we shrink the old block by the size of the old headers, allocate a new block for the new headers and link the new block to the previous block through its continuation pointer. If the block being shurnk also contains ULP data this is fine. However, if it's purely a header block, then we wind up shrinking the old block to zero, and our new block has a zero sized continuation. This is not a generally expected situation and has caused NIC hardware to stop working. This commit prevents this from happening.

I placed a panic in `PacketSeg::link` that fires if we try to make a zero-sized continuation (only during tests) to see if any tests currently trigger this behavior. It turns out several of the integration tests in `oxide-vpc` do.