### PR TITLE
Handle IPv4 options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ default-members = [
   "bin/*",
   "crates/*",
   "lib/*",
-  "xde-tests",
 ]
 resolver = "2"
 

--- a/lib/opte/src/engine/layer.rs
+++ b/lib/opte/src/engine/layer.rs
@@ -1755,9 +1755,10 @@ mod test {
             proto: Protocol::TCP,
             ttl: 64,
             ident: 1,
-            hdr_len: 20,
             total_len: 40,
             csum: [0; 2],
+            options_bytes: None,
+            options_len: 0,
         });
         let ulp = UlpMeta::from(TcpMeta {
             src: 5555,

--- a/lib/opte/src/engine/packet.rs
+++ b/lib/opte/src/engine/packet.rs
@@ -869,7 +869,10 @@ impl Packet<Initialized> {
         self.segs[i].get_writer()
     }
 
-    pub fn add_seg(&mut self, size: usize) -> Result<usize, SegAdjustError> {
+    pub fn add_seg(
+        &mut self,
+        size: usize,
+    ) -> Result<PacketSegWriter, SegAdjustError> {
         let mut seg = PacketSeg::alloc(size);
         seg.expand_end(size)?;
         let len = self.segs.len();
@@ -879,7 +882,8 @@ impl Packet<Initialized> {
         }
         self.segs.push(seg);
         self.state.len += size;
-        Ok(len)
+
+        Ok(self.seg_wtr(len))
     }
 
     /// Wrap the `mblk_t` packet in a [`Packet`], taking ownership of

--- a/lib/opte/src/engine/packet.rs
+++ b/lib/opte/src/engine/packet.rs
@@ -660,7 +660,7 @@ impl Packet<Initialized> {
         rdr: &mut PacketReaderMut<'a>,
     ) -> Result<(HdrInfo<IpMeta>, Ipv4Hdr<'a>), ParseError> {
         let ip = Ipv4Hdr::parse(rdr)?;
-        let offset = HdrOffset::new(rdr.offset(), usize::from(ip.hdr_len()));
+        let offset = HdrOffset::new(rdr.offset(), ip.hdr_len());
         let meta = IpMeta::from(Ipv4Meta::from(&ip));
         Ok((HdrInfo { meta, offset }, ip))
     }
@@ -2885,9 +2885,10 @@ mod test {
             proto: Protocol::TCP,
             ttl: 64,
             ident: 99,
-            hdr_len: Ipv4Hdr::BASE_SIZE.try_into().unwrap(),
             total_len: ip4_total_len.try_into().unwrap(),
             csum: [0; 2],
+            options_bytes: None,
+            options_len: 0,
         };
 
         let eth = EtherMeta {

--- a/lib/opte/src/engine/rule.rs
+++ b/lib/opte/src/engine/rule.rs
@@ -921,9 +921,10 @@ fn rule_matching() {
         proto: Protocol::TCP,
         ttl: 64,
         ident: 1,
-        hdr_len: 20,
         total_len: 40,
         csum: [0; 2],
+        options_bytes: None,
+        options_len: 0,
     });
     let ulp = UlpMeta::from(TcpMeta {
         src: src_port,
@@ -958,9 +959,10 @@ fn rule_matching() {
         proto: Protocol::TCP,
         ttl: 64,
         ident: 1,
-        hdr_len: 20,
         total_len: 40,
         csum: [0; 2],
+        options_bytes: None,
+        options_len: 0,
     });
     let ulp = UlpMeta::from(TcpMeta {
         src: src_port,

--- a/lib/oxide-vpc/tests/common/icmp.rs
+++ b/lib/oxide-vpc/tests/common/icmp.rs
@@ -127,8 +127,8 @@ pub fn gen_icmp_echo(
             let mut pkt = Packet::alloc_and_expand(EtherHdr::SIZE);
             let mut wtr = pkt.seg_wtr(0);
             eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
-            let i = pkt.add_seg(ip4.hdr_len() + icmp_bytes.len()).unwrap();
-            let mut wtr = pkt.seg_wtr(i);
+            let mut wtr =
+                pkt.add_seg(ip4.hdr_len() + icmp_bytes.len()).unwrap();
             ip4.emit(wtr.slice_mut(ip4.hdr_len()).unwrap());
             wtr.write(&icmp_bytes).unwrap();
             pkt.parse(Out, VpcParser::new()).unwrap()
@@ -137,11 +137,9 @@ pub fn gen_icmp_echo(
             let mut pkt = Packet::alloc_and_expand(EtherHdr::SIZE);
             let mut wtr = pkt.seg_wtr(0);
             eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
-            let i = pkt.add_seg(ip4.hdr_len()).unwrap();
-            let mut wtr = pkt.seg_wtr(i);
+            let mut wtr = pkt.add_seg(ip4.hdr_len()).unwrap();
             ip4.emit(wtr.slice_mut(ip4.hdr_len()).unwrap());
-            let i = pkt.add_seg(icmp_bytes.len()).unwrap();
-            let mut wtr = pkt.seg_wtr(i);
+            let mut wtr = pkt.add_seg(icmp_bytes.len()).unwrap();
             wtr.write(&icmp_bytes).unwrap();
             pkt.parse(Out, VpcParser::new()).unwrap()
         }
@@ -198,8 +196,8 @@ pub fn gen_icmpv6_echo_req(
             let mut pkt = Packet::alloc_and_expand(EtherHdr::SIZE);
             let mut wtr = pkt.seg_wtr(0);
             eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
-            let i = pkt.add_seg(ip6.hdr_len() + body_bytes.len()).unwrap();
-            let mut wtr = pkt.seg_wtr(i);
+            let mut wtr =
+                pkt.add_seg(ip6.hdr_len() + body_bytes.len()).unwrap();
             ip6.emit(wtr.slice_mut(ip6.hdr_len()).unwrap());
             wtr.write(&body_bytes).unwrap();
             pkt.parse(Out, VpcParser::new()).unwrap()
@@ -208,11 +206,9 @@ pub fn gen_icmpv6_echo_req(
             let mut pkt = Packet::alloc_and_expand(EtherHdr::SIZE);
             let mut wtr = pkt.seg_wtr(0);
             eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
-            let i = pkt.add_seg(ip6.hdr_len()).unwrap();
-            let mut wtr = pkt.seg_wtr(i);
+            let mut wtr = pkt.add_seg(ip6.hdr_len()).unwrap();
             ip6.emit(wtr.slice_mut(ip6.hdr_len()).unwrap());
-            let i = pkt.add_seg(body_bytes.len()).unwrap();
-            let mut wtr = pkt.seg_wtr(i);
+            let mut wtr = pkt.add_seg(body_bytes.len()).unwrap();
             wtr.write(&body_bytes).unwrap();
             pkt.parse(Out, VpcParser::new()).unwrap()
         }

--- a/lib/oxide-vpc/tests/integration_tests.rs
+++ b/lib/oxide-vpc/tests/integration_tests.rs
@@ -1185,8 +1185,7 @@ fn bad_ip_len() {
         proto: Protocol::UDP,
         ttl: 64,
         ident: 1,
-        hdr_len: 20,
-        // We write a total legnth of 4 bytes, which is completely
+        // We write a total length of 4 bytes, which is completely
         // bogus for an IP header and should return an error during
         // processing.
         total_len: 4,
@@ -1194,7 +1193,7 @@ fn bad_ip_len() {
     };
 
     let udp = UdpMeta { src: 68, dst: 67, ..Default::default() };
-    let total_len = EtherHdr::SIZE + usize::from(ip.hdr_len) + udp.hdr_len();
+    let total_len = EtherHdr::SIZE + ip.hdr_len() + udp.hdr_len();
     let mut pkt = Packet::alloc_and_expand(total_len);
     let mut wtr = pkt.seg0_wtr();
     eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());


### PR DESCRIPTION
An IPv4 header, although not common, may include some options that increase it beyond the base 20 bytes.

