### PR TITLE
Filter and detect external traffic using Geneve option tags

### DIFF
--- a/lib/opte/src/engine/geneve.rs
+++ b/lib/opte/src/engine/geneve.rs
@@ -27,13 +27,22 @@ pub const GENEVE_VSN: u8 = 0;
 pub const GENEVE_VER_MASK: u8 = 0xC0;
 pub const GENEVE_VER_SHIFT: u8 = 6;
 pub const GENEVE_OPT_LEN_MASK: u8 = 0x3F;
+pub const GENEVE_OPT_LEN_SCALE_SHIFT: u8 = 2;
 pub const GENEVE_PORT: u16 = 6081;
+
+pub const GENEVE_OPT_CRIT_SHIFT: u8 = 7;
+pub const GENEVE_OPT_TYPE_MASK: u8 = (1 << GENEVE_OPT_CRIT_SHIFT) - 1;
+pub const GENEVE_OPT_RESERVED_SHIFT: u8 = 5;
+pub const GENEVE_OPT_RESERVED_MASK: u8 = (1 << GENEVE_OPT_RESERVED_SHIFT) - 1;
+pub const GENEVE_OPT_CLASS_OXIDE: u16 = 0x0129;
 
 #[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct GeneveMeta {
     pub entropy: u16,
     pub vni: Vni,
     pub len: u16,
+
+    pub oxide_external_pkt: bool,
 }
 
 #[derive(
@@ -92,16 +101,30 @@ impl GeneveMeta {
 
 impl<'a> From<&GeneveHdr<'a>> for GeneveMeta {
     fn from(geneve: &GeneveHdr<'a>) -> Self {
-        Self {
+        let mut out = Self {
             vni: geneve.vni(),
             entropy: geneve.entropy(),
             len: geneve.len() as u16,
+            ..Default::default()
+        };
+
+        if let Some(ref opts) = geneve.opts {
+            // XXX: Prevent duplication by making Meta generation fallible
+            //      in same way as Parsing?
+            // Unwrap safety: Invalid options will have been caught in
+            // GeneveHdr::parse.
+            GeneveOption::parse_all(&opts, Some(&mut out)).unwrap();
         }
+
+        out
     }
 }
 
 pub struct GeneveHdr<'a> {
+    /// Main body of the Geneve Header.
     bytes: LayoutVerified<&'a mut [u8], GeneveHdrRaw>,
+    /// Byte slice occupied by Geneve options.
+    opts: Option<&'a mut [u8]>,
 }
 
 impl<'a> GeneveHdr<'a> {
@@ -125,7 +148,22 @@ impl<'a> GeneveHdr<'a> {
         R: PacketReadMut<'a>,
     {
         let src = rdr.slice_mut(GeneveHdrRaw::SIZE)?;
-        Ok(Self { bytes: GeneveHdrRaw::new_mut(src)? })
+        let bytes = GeneveHdrRaw::new_mut(src)?;
+        let opt_len = bytes.options_len_bytes().into();
+        let opts = if opt_len != 0 {
+            let opts_body = rdr.slice_mut(opt_len)?;
+
+            // Check for malformed options.
+            // XXX: Can we use this to elide some checks when building GeneveMeta?
+            //      Otherwise, currently repeated to filter packets at parse time.
+            GeneveOption::parse_all(&opts_body, None)?;
+
+            Some(opts_body)
+        } else {
+            None
+        };
+
+        Ok(Self { bytes, opts })
     }
 
     /// Set the length, in bytes.
@@ -163,6 +201,7 @@ pub enum GeneveHdrError {
     BadVni { vni: u32 },
     ReadError { error: ReadErr },
     UnexpectedProtocol { protocol: u16 },
+    UnknownCriticalOption { class: u16, opt_type: u8 },
 }
 
 impl From<ReadErr> for GeneveHdrError {
@@ -187,11 +226,14 @@ pub struct GeneveHdrRaw {
 }
 
 impl GeneveHdrRaw {
-    // Return the length of the Geneve options.
-    //
-    // NOTE: The Geneve header specifies options length in 4-byte units.
+    /// Return the length of the Geneve options in 4-byte units.
     pub fn options_len(&self) -> u8 {
         self.ver_opt_len & GENEVE_OPT_LEN_MASK
+    }
+
+    /// Return the length of the Geneve options in bytes.
+    pub fn options_len_bytes(&self) -> u8 {
+        self.options_len() << GENEVE_OPT_LEN_SCALE_SHIFT
     }
 
     pub fn version(&self) -> u8 {
@@ -245,17 +287,156 @@ impl From<&GeneveMeta> for GeneveHdrRaw {
     }
 }
 
+#[non_exhaustive]
+pub enum GeneveOption {
+    Oxide(OxideOption),
+}
+
+impl GeneveOption {
+    pub fn parse_all(
+        mut src: &[u8],
+        mut meta: Option<&mut GeneveMeta>,
+    ) -> Result<(), GeneveHdrError> {
+        while !src.is_empty() {
+            let option = GeneveOption::parse(&mut src)?;
+            if let Some(ref mut meta) = meta {
+                match option {
+                    Some(GeneveOption::Oxide(OxideOption::External)) => {
+                        meta.oxide_external_pkt = true
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn parse(src: &mut &[u8]) -> Result<Option<Self>, GeneveHdrError> {
+        let (head, tail) = src.split_at(GeneveOptHdrRaw::SIZE);
+        let opt_header = GeneveOptHdrRaw::new(head)?;
+        let needed_bytes = opt_header.options_len_bytes() as usize;
+        if tail.len() < needed_bytes.into() {
+            return Err(GeneveHdrError::BadLength { len: needed_bytes as u16 });
+        }
+        let class = u16::from_be_bytes(opt_header.option_class);
+        let opt_type = opt_header.option_type();
+
+        // We don't yet have any options which need body parsing.
+        let (_body, tail) = tail.split_at(needed_bytes);
+        *src = tail;
+
+        // XXX: Break this out into a trait/impls to handle more cleanly.
+        Ok(match (class, opt_header.option_type()) {
+            (GENEVE_OPT_CLASS_OXIDE, 0) => {
+                Some(GeneveOption::Oxide(OxideOption::External))
+            }
+            _ if opt_header.is_critical() => {
+                return Err(GeneveHdrError::UnknownCriticalOption {
+                    class,
+                    opt_type,
+                })
+            }
+            _ => None,
+        })
+    }
+
+    /// Return the wire-length of this option in bytes, including headers.
+    pub fn len(&self) -> usize {
+        4 + match self {
+            GeneveOption::Oxide(o) => o.len(),
+        }
+    }
+}
+
+#[non_exhaustive]
+pub enum OxideOption {
+    /// A tag indicating that this packet originated from outside the VPC.
+    External,
+}
+
+impl OxideOption {
+    /// Return the wire-length of this option in bytes, excluding headers.
+    pub fn len(&self) -> usize {
+        match self {
+            OxideOption::External => 0,
+        }
+    }
+}
+
+/// Field layout for a single Geneve option.
+///
+/// Note: Unaligned on the same rationale as [`GeneveHdrRaw`].
+#[repr(C)]
+#[derive(Clone, Debug, FromBytes, AsBytes, Unaligned)]
+pub struct GeneveOptHdrRaw {
+    option_class: [u8; 2],
+    crit_type: u8,
+    reserved_len: u8,
+}
+
+impl GeneveOptHdrRaw {
+    /// Indicates whether this option is critical, and MUST be dropped
+    /// if not understood by a tunnel endpoint.
+    pub fn is_critical(&self) -> bool {
+        (self.crit_type >> GENEVE_OPT_CRIT_SHIFT) != 0
+    }
+
+    /// Return the type of this header.
+    pub fn option_type(&self) -> u8 {
+        self.crit_type & GENEVE_OPT_TYPE_MASK
+    }
+
+    /// Return the length of this Geneve option's body in 4-byte units.
+    pub fn options_len(&self) -> u8 {
+        self.reserved_len & GENEVE_OPT_RESERVED_MASK
+    }
+
+    /// Return the length of the Geneve options in bytes.
+    pub fn options_len_bytes(&self) -> u8 {
+        self.options_len() << GENEVE_OPT_LEN_SCALE_SHIFT
+    }
+}
+
+impl<'a> RawHeader<'a> for GeneveOptHdrRaw {
+    #[inline]
+    fn new_mut(
+        src: &mut [u8],
+    ) -> Result<LayoutVerified<&mut [u8], Self>, ReadErr> {
+        debug_assert_eq!(src.len(), mem::size_of::<Self>());
+        let hdr = match LayoutVerified::new(src) {
+            Some(hdr) => hdr,
+            None => return Err(ReadErr::BadLayout),
+        };
+        Ok(hdr)
+    }
+
+    #[inline]
+    fn new(src: &[u8]) -> Result<LayoutVerified<&[u8], Self>, ReadErr> {
+        debug_assert_eq!(src.len(), mem::size_of::<Self>());
+        let hdr = match LayoutVerified::new(src) {
+            Some(hdr) => hdr,
+            None => return Err(ReadErr::BadLayout),
+        };
+        Ok(hdr)
+    }
+}
+
 #[cfg(test)]
 mod test {
+    use core::matches;
+
     use super::*;
     use crate::engine::packet::Packet;
 
     #[test]
-    fn emit() {
+    fn emit_no_opts() {
         let geneve = GeneveMeta {
             entropy: 7777,
             vni: Vni::new(1234u32).unwrap(),
             len: GeneveHdr::BASE_SIZE as u16,
+
+            ..Default::default()
         };
 
         let len = geneve.hdr_len();
@@ -284,5 +465,188 @@ mod test {
             0x00, 0x04, 0xD2, 0x00
         ];
         assert_eq!(&expected_bytes, pkt.seg_bytes(0));
+    }
+
+    #[test]
+    fn parse_single_opt() {
+        // Create a packet with one extension header.
+        #[rustfmt::skip]
+        let buf = vec![
+            // source
+            0x1E, 0x61,
+            // dest
+            0x17, 0xC1,
+            // length
+            0x00, 0x14,
+            // csum
+            0x00, 0x00,
+            // ver + opt len
+            0x01,
+            // flags
+            0x00,
+            // proto
+            0x65, 0x58,
+            // vni + reserved
+            0x00, 0x04, 0xD2, 0x00,
+
+            // option class
+            0x01, 0x29,
+            // crt + type
+            0x00,
+            // rsvd + len
+            0x00,
+        ];
+        let mut pkt = Packet::copy(&buf);
+        let mut reader = pkt.get_rdr_mut();
+        let header = GeneveHdr::parse(&mut reader).unwrap();
+
+        // Previously, the `Ipv6Meta::total_len` method double-counted the
+        // extension header length. Assert we don't do that here.
+        let meta = GeneveMeta::from(&header);
+        assert_eq!(
+            meta.entropy,
+            u16::from_be_bytes(buf[0..2].try_into().unwrap())
+        );
+        assert!(meta.oxide_external_pkt);
+    }
+
+    #[test]
+    fn bad_opt_len_fails() {
+        // Create a packet with one extension header.
+        #[rustfmt::skip]
+        let buf = vec![
+            // source
+            0x1E, 0x61,
+            // dest
+            0x17, 0xC1,
+            // length
+            0x00, 0x14,
+            // csum
+            0x00, 0x00,
+            // ver + BAD opt len
+            0x01,
+            // flags
+            0x00,
+            // proto
+            0x65, 0x58,
+            // vni + reserved
+            0x00, 0x04, 0xD2, 0x00,
+
+            // option class
+            0x01, 0x29,
+            // crt + type
+            0x01,
+            // rsvd + len
+            0x01,
+            // body
+            0x00, 0x00, 0x00, 0x00
+        ];
+        let mut pkt = Packet::copy(&buf);
+        let mut reader = pkt.get_rdr_mut();
+        assert!(matches!(
+            GeneveHdr::parse(&mut reader),
+            Err(GeneveHdrError::BadLength { .. }),
+        ));
+    }
+
+    #[test]
+    fn unknown_crit_option_fails() {
+        // Create a packet with one extension header.
+        #[rustfmt::skip]
+        let buf = vec![
+            // source
+            0x1E, 0x61,
+            // dest
+            0x17, 0xC1,
+            // length
+            0x00, 0x14,
+            // csum
+            0x00, 0x00,
+            // ver + opt len
+            0x01,
+            // flags
+            0b0100_0000,
+            // proto
+            0x65, 0x58,
+            // vni + reserved
+            0x00, 0x04, 0xD2, 0x00,
+
+            // experimenter option class
+            0xff, 0xff,
+            // crt + type
+            0x80,
+            // rsvd + len
+            0x00,
+        ];
+        let mut pkt = Packet::copy(&buf);
+        let mut reader = pkt.get_rdr_mut();
+        assert!(matches!(
+            GeneveHdr::parse(&mut reader),
+            Err(GeneveHdrError::UnknownCriticalOption {
+                class: 0xff_ff,
+                opt_type: 0
+            }),
+        ));
+    }
+
+    #[test]
+    fn parse_multi_opt() {
+        // Create a packet with one extension header.
+        #[rustfmt::skip]
+        let buf = vec![
+            // source
+            0x1E, 0x61,
+            // dest
+            0x17, 0xC1,
+            // length
+            0x00, 0x1c,
+            // csum
+            0x00, 0x00,
+            // ver + opt len
+            0x05,
+            // flags
+            0x00,
+            // proto
+            0x65, 0x58,
+            // vni + reserved
+            0x00, 0x04, 0xD2, 0x00,
+
+            // option class
+            0x01, 0x29,
+            // crt + type
+            0x00,
+            // rsvd + len
+            0x00,
+
+            // experimenter option class
+            0xff, 0xff,
+            // crt + type
+            0x05,
+            // rsvd + len
+            0x01,
+            // body
+            0x00, 0x00, 0x00, 0x00,
+
+            // experimenter option class
+            0xff, 0xff,
+            // crt + type
+            0x06,
+            // rsvd + len
+            0x01,
+            // body
+            0x00, 0x00, 0x00, 0x00,
+        ];
+        let mut pkt = Packet::copy(&buf);
+        let mut reader = pkt.get_rdr_mut();
+        let header = GeneveHdr::parse(&mut reader).unwrap();
+
+        // Previously, the `Ipv6Meta::total_len` method double-counted the
+        // extension header length. Assert we don't do that here.
+        let meta = GeneveMeta::from(&header);
+        assert_eq!(
+            meta.entropy,
+            u16::from_be_bytes(buf[0..2].try_into().unwrap())
+        );
+        assert!(meta.oxide_external_pkt);
     }
 }

--- a/lib/opte/src/engine/headers.rs
+++ b/lib/opte/src/engine/headers.rs
@@ -57,6 +57,12 @@ pub trait RawHeader<'a>: Sized {
     fn new_mut(
         src: &mut [u8],
     ) -> Result<LayoutVerified<&mut [u8], Self>, ReadErr>;
+
+    /// Create an immutable, zerocopy version of the raw header from the
+    /// src.
+    fn new(_src: &[u8]) -> Result<LayoutVerified<&[u8], Self>, ReadErr> {
+        Err(ReadErr::NotImplemented)
+    }
 }
 
 pub trait PushAction<HdrM> {

--- a/lib/opte/src/engine/packet.rs
+++ b/lib/opte/src/engine/packet.rs
@@ -2251,6 +2251,7 @@ pub enum ReadErr {
     NotEnoughBytes,
     OutOfRange,
     StraddledRead,
+    NotImplemented,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/lib/oxide-vpc/src/engine/overlay.rs
+++ b/lib/oxide-vpc/src/engine/overlay.rs
@@ -379,10 +379,12 @@ impl StaticAction for DecapAction {
     ) -> GenHtResult {
         match &pkt_meta.outer.encap {
             Some(EncapMeta::Geneve(geneve)) => {
-                // XXX: This is now slightly overloaded to mean "packet
-                //      originated from the VPC which has this VNI".
-                //      Unsure if we want to have sled agent add a
-                //      VNI && (not external) predicate.
+                // We only conditionally add this metadata because the
+                // `Address::VNI` filter uses it to select VPC-originated
+                // traffic.
+                // External packets carry an extra Geneve tag from the
+                // switch during NAT -- if found, `oxide_external_packet`
+                // is filled.
                 if !geneve.oxide_external_pkt {
                     action_meta.insert(
                         ACTION_META_VNI.to_string(),

--- a/lib/oxide-vpc/src/engine/overlay.rs
+++ b/lib/oxide-vpc/src/engine/overlay.rs
@@ -379,10 +379,16 @@ impl StaticAction for DecapAction {
     ) -> GenHtResult {
         match &pkt_meta.outer.encap {
             Some(EncapMeta::Geneve(geneve)) => {
-                action_meta.insert(
-                    ACTION_META_VNI.to_string(),
-                    geneve.vni.to_string(),
-                );
+                // XXX: This is now slightly overloaded to mean "packet
+                //      originated from the VPC which has this VNI".
+                //      Unsure if we want to have sled agent add a
+                //      VNI && (not external) predicate.
+                if !geneve.oxide_external_pkt {
+                    action_meta.insert(
+                        ACTION_META_VNI.to_string(),
+                        geneve.vni.to_string(),
+                    );
+                }
             }
 
             // This should be impossible. Non-encapsulated traffic

--- a/lib/oxide-vpc/tests/common/mod.rs
+++ b/lib/oxide-vpc/tests/common/mod.rs
@@ -881,6 +881,8 @@ pub fn encap(
         entropy: 99,
         vni: dst.vni,
         len: (UdpHdr::SIZE + GeneveHdr::BASE_SIZE + inner_len) as u16,
+
+        ..Default::default()
     };
 
     let ip = Ipv6Meta {

--- a/lib/oxide-vpc/tests/common/mod.rs
+++ b/lib/oxide-vpc/tests/common/mod.rs
@@ -23,6 +23,8 @@ pub use opte::engine::ether::EtherMeta;
 pub use opte::engine::ether::EtherType;
 pub use opte::engine::geneve::GeneveHdr;
 pub use opte::engine::geneve::GeneveMeta;
+pub use opte::engine::geneve::GeneveOption;
+pub use opte::engine::geneve::OxideOption;
 pub use opte::engine::geneve::Vni;
 pub use opte::engine::geneve::GENEVE_PORT;
 pub use opte::engine::headers::IpAddr;
@@ -863,12 +865,34 @@ pub struct TestIpPhys {
     pub vni: Vni,
 }
 
+/// Encapsulate a guest packet, marking that it has arrived from beyond
+/// the rack.
+#[must_use]
+pub fn encap_external(
+    inner_pkt: Packet<Parsed>,
+    src: TestIpPhys,
+    dst: TestIpPhys,
+) -> Packet<Parsed> {
+    _encap(inner_pkt, src, dst, true)
+}
+
 /// Encapsulate a guest packet.
 #[must_use]
 pub fn encap(
     inner_pkt: Packet<Parsed>,
     src: TestIpPhys,
     dst: TestIpPhys,
+) -> Packet<Parsed> {
+    _encap(inner_pkt, src, dst, false)
+}
+
+/// Encapsulate a guest packet.
+#[must_use]
+fn _encap(
+    inner_pkt: Packet<Parsed>,
+    src: TestIpPhys,
+    dst: TestIpPhys,
+    external_snat: bool,
 ) -> Packet<Parsed> {
     let inner_ip_len = inner_pkt.hdr_offsets().inner.ip.map(|off| off.hdr_len);
 
@@ -877,10 +901,17 @@ pub fn encap(
 
     let inner_len = inner_pkt.len();
 
+    let opt_len = if external_snat {
+        GeneveOption::Oxide(OxideOption::External).len()
+    } else {
+        0
+    };
+
     let geneve = GeneveMeta {
         entropy: 99,
         vni: dst.vni,
-        len: (UdpHdr::SIZE + GeneveHdr::BASE_SIZE + inner_len) as u16,
+        len: (UdpHdr::SIZE + GeneveHdr::BASE_SIZE + opt_len + inner_len) as u16,
+        oxide_external_pkt: external_snat,
 
         ..Default::default()
     };

--- a/lib/oxide-vpc/tests/integration_tests.rs
+++ b/lib/oxide-vpc/tests/integration_tests.rs
@@ -1045,7 +1045,7 @@ fn snat_icmp4_echo_rewrite() {
         mac: g1_cfg.guest_mac,
         vni: g1_cfg.vni,
     };
-    pkt2 = encap(pkt2, bsvc_phys, g1_phys);
+    pkt2 = encap_external(pkt2, bsvc_phys, g1_phys);
 
     let res = g1.port.process(In, &mut pkt2, ActionMeta::new());
     assert!(matches!(res, Ok(Modified)), "bad result: {:?}", res);
@@ -2344,7 +2344,7 @@ fn establish_http_conn(
         mac: g1_cfg.guest_mac,
         vni: g1_cfg.vni,
     };
-    pkt2 = encap(pkt2, bs_phys, g1_phys);
+    pkt2 = encap_external(pkt2, bs_phys, g1_phys);
     let res = g1.port.process(In, &mut pkt2, ActionMeta::new());
     assert!(matches!(res, Ok(Modified)));
     incr!(g1, ["uft.in", "stats.port.in_modified, stats.port.in_uft_miss"]);
@@ -2518,7 +2518,7 @@ fn uft_lft_invalidation_in() {
         g1_cfg.snat().external_ip,
         snat_port,
     );
-    pkt2 = encap(pkt2, bs_phys, g1_phys);
+    pkt2 = encap_external(pkt2, bs_phys, g1_phys);
     let res = g1.port.process(In, &mut pkt2, ActionMeta::new());
     incr!(g1, ["stats.port.in_modified, stats.port.in_uft_hit"]);
     assert!(matches!(res, Ok(Modified)));
@@ -2554,7 +2554,7 @@ fn uft_lft_invalidation_in() {
         g1_cfg.snat().external_ip,
         snat_port,
     );
-    pkt3 = encap(pkt3, bs_phys, g1_phys);
+    pkt3 = encap_external(pkt3, bs_phys, g1_phys);
     let res = g1.port.process(In, &mut pkt3, ActionMeta::new());
     assert_drop!(
         res,
@@ -2637,7 +2637,7 @@ fn tcp_outbound() {
         g1_cfg.snat().external_ip,
         snat_port,
     );
-    pkt2 = encap(pkt2, bs_phys, g1_phys);
+    pkt2 = encap_external(pkt2, bs_phys, g1_phys);
     let res = g1.port.process(In, &mut pkt2, ActionMeta::new());
     assert!(matches!(res, Ok(Modified)));
     incr!(g1, ["uft.in", "stats.port.in_modified, stats.port.in_uft_miss"]);
@@ -2681,7 +2681,7 @@ fn tcp_outbound() {
         g1_cfg.snat().external_ip,
         snat_port,
     );
-    pkt5 = encap(pkt5, bs_phys, g1_phys);
+    pkt5 = encap_external(pkt5, bs_phys, g1_phys);
     let res = g1.port.process(In, &mut pkt5, ActionMeta::new());
     assert!(matches!(res, Ok(Modified)));
     incr!(g1, ["stats.port.in_modified, stats.port.in_uft_hit"]);
@@ -2697,7 +2697,7 @@ fn tcp_outbound() {
         g1_cfg.snat().external_ip,
         snat_port,
     );
-    pkt6 = encap(pkt6, bs_phys, g1_phys);
+    pkt6 = encap_external(pkt6, bs_phys, g1_phys);
     let res = g1.port.process(In, &mut pkt6, ActionMeta::new());
     assert!(matches!(res, Ok(Modified)));
     incr!(g1, ["stats.port.in_modified, stats.port.in_uft_hit"]);
@@ -2741,7 +2741,7 @@ fn tcp_outbound() {
         g1_cfg.snat().external_ip,
         snat_port,
     );
-    pkt9 = encap(pkt9, bs_phys, g1_phys);
+    pkt9 = encap_external(pkt9, bs_phys, g1_phys);
     let res = g1.port.process(In, &mut pkt9, ActionMeta::new());
     assert!(matches!(res, Ok(Modified)));
     incr!(g1, ["stats.port.in_modified, stats.port.in_uft_hit"]);
@@ -2757,7 +2757,7 @@ fn tcp_outbound() {
         g1_cfg.snat().external_ip,
         snat_port,
     );
-    pkt10 = encap(pkt10, bs_phys, g1_phys);
+    pkt10 = encap_external(pkt10, bs_phys, g1_phys);
     let res = g1.port.process(In, &mut pkt10, ActionMeta::new());
     assert!(matches!(res, Ok(Modified)));
     incr!(g1, ["stats.port.in_modified, stats.port.in_uft_hit"]);


### PR DESCRIPTION
This PR uses the presence of a min-sized Geneve TLV to detect packets on a given VNI which are originally external to the rack. To correctly filter such traffic at the firewall, the semantics of the `Address::Vni` host filter have changed to mean '*internal traffic* on this Vni'. Accordingly, I've added simple option parsing/emission.

This will require changes to Dendrite to correctly emit the new option on any SNAT transformations on ingress to the rack, as well as an OANA registration for option type 0.

Aims to fix #380 (in tandem with oxidecomputer/dendrite#606).