### PR TITLE
pkg: minor tweaks for Helios 2.0 packages

### DIFF
--- a/.github/buildomat/jobs/opte-api.sh
+++ b/.github/buildomat/jobs/opte-api.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "opte-api"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: rust_toolchain = "nightly"
 #: output_rules = []
 #:

--- a/.github/buildomat/jobs/opte-api.sh
+++ b/.github/buildomat/jobs/opte-api.sh
@@ -3,7 +3,7 @@
 #: name = "opte-api"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly"
+#: rust_toolchain = "nightly-2023-01-12"
 #: output_rules = []
 #:
 

--- a/.github/buildomat/jobs/opte-api.sh
+++ b/.github/buildomat/jobs/opte-api.sh
@@ -24,7 +24,7 @@ header "check API_VERSION"
 ./check-api-version.sh
 
 header "check style"
-ptime -m cargo +nightly fmt -- --check
+ptime -m cargo +nightly-2023-01-12 fmt -- --check
 
 header "analyze std"
 ptime -m cargo clippy --all-targets

--- a/.github/buildomat/jobs/opte-ioctl.sh
+++ b/.github/buildomat/jobs/opte-ioctl.sh
@@ -3,7 +3,7 @@
 #: name = "opte-ioctl"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly"
+#: rust_toolchain = "nightly-2023-01-12"
 #: output_rules = []
 #:
 

--- a/.github/buildomat/jobs/opte-ioctl.sh
+++ b/.github/buildomat/jobs/opte-ioctl.sh
@@ -21,7 +21,7 @@ rustc --version
 cd lib/opte-ioctl
 
 header "check style"
-ptime -m cargo +nightly fmt -- --check
+ptime -m cargo +nightly-2023-01-12 fmt -- --check
 
 header "analyze"
 ptime -m cargo clippy --all-targets

--- a/.github/buildomat/jobs/opte-ioctl.sh
+++ b/.github/buildomat/jobs/opte-ioctl.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "opte-ioctl"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: rust_toolchain = "nightly"
 #: output_rules = []
 #:

--- a/.github/buildomat/jobs/opte.sh
+++ b/.github/buildomat/jobs/opte.sh
@@ -3,7 +3,7 @@
 #: name = "opte"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly"
+#: rust_toolchain = "nightly-2023-01-12"
 #: output_rules = []
 #:
 

--- a/.github/buildomat/jobs/opte.sh
+++ b/.github/buildomat/jobs/opte.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "opte"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: rust_toolchain = "nightly"
 #: output_rules = []
 #:

--- a/.github/buildomat/jobs/opte.sh
+++ b/.github/buildomat/jobs/opte.sh
@@ -21,7 +21,7 @@ rustc --version
 cd lib/opte
 
 header "check style"
-ptime -m cargo +nightly fmt -- --check
+ptime -m cargo +nightly-2023-01-12 fmt -- --check
 
 header "check docs"
 #
@@ -30,13 +30,13 @@ header "check docs"
 #
 # Use nightly which is needed for the `kernel` feature.
 RUSTDOCFLAGS="-D warnings" ptime -m \
-	    cargo +nightly doc --no-default-features --features=api,std,engine,kernel
+	    cargo +nightly-2023-01-12 doc --no-default-features --features=api,std,engine,kernel
 
 header "analyze std + api"
 ptime -m cargo clippy --all-targets
 
 header "analyze no_std + engine + kernel"
-ptime -m cargo +nightly clippy --no-default-features --features engine,kernel
+ptime -m cargo +nightly-2023-01-12 clippy --no-default-features --features engine,kernel
 
 header "test"
 ptime -m cargo test

--- a/.github/buildomat/jobs/opteadm.sh
+++ b/.github/buildomat/jobs/opteadm.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "opteadm"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: rust_toolchain = "nightly"
 #: output_rules = [
 #:   "=/work/debug/opteadm",

--- a/.github/buildomat/jobs/opteadm.sh
+++ b/.github/buildomat/jobs/opteadm.sh
@@ -26,7 +26,7 @@ rustc --version
 pushd bin/opteadm
 
 header "check style"
-ptime -m cargo +nightly fmt -- --check
+ptime -m cargo +nightly-2023-01-12 fmt -- --check
 
 header "analyze"
 ptime -m cargo clippy --all-targets

--- a/.github/buildomat/jobs/opteadm.sh
+++ b/.github/buildomat/jobs/opteadm.sh
@@ -3,7 +3,7 @@
 #: name = "opteadm"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly"
+#: rust_toolchain = "nightly-2023-01-12"
 #: output_rules = [
 #:   "=/work/debug/opteadm",
 #:   "=/work/debug/opteadm.debug.sha256",

--- a/.github/buildomat/jobs/oxide-vpc.sh
+++ b/.github/buildomat/jobs/oxide-vpc.sh
@@ -21,7 +21,7 @@ rustc --version
 cd lib/oxide-vpc
 
 header "check style"
-ptime -m cargo +nightly fmt -- --check
+ptime -m cargo +nightly-2023-01-12 fmt -- --check
 
 header "check docs"
 #
@@ -30,13 +30,13 @@ header "check docs"
 #
 # Use nightly which is needed for the `kernel` feature.
 RUSTDOCFLAGS="-D warnings" ptime -m \
-	    cargo +nightly doc --no-default-features --features=api,std,engine,kernel
+	    cargo +nightly-2023-01-12 doc --no-default-features --features=api,std,engine,kernel
 
 header "analyze std + api + usdt"
 ptime -m cargo clippy --features usdt --all-targets
 
 header "analyze no_std + engine + kernel"
-ptime -m cargo +nightly clippy --no-default-features --features engine,kernel
+ptime -m cargo +nightly-2023-01-12 clippy --no-default-features --features engine,kernel
 
 header "test"
 ptime -m cargo test

--- a/.github/buildomat/jobs/oxide-vpc.sh
+++ b/.github/buildomat/jobs/oxide-vpc.sh
@@ -3,7 +3,7 @@
 #: name = "oxide-vpc"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly"
+#: rust_toolchain = "nightly-2023-01-12"
 #: output_rules = []
 #:
 

--- a/.github/buildomat/jobs/oxide-vpc.sh
+++ b/.github/buildomat/jobs/oxide-vpc.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "oxide-vpc"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: rust_toolchain = "nightly"
 #: output_rules = []
 #:

--- a/.github/buildomat/jobs/p5p.sh
+++ b/.github/buildomat/jobs/p5p.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "opte-p5p"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: rust_toolchain = "nightly"
 #: output_rules = [
 #:   "=/out/opte.p5p",

--- a/.github/buildomat/jobs/p5p.sh
+++ b/.github/buildomat/jobs/p5p.sh
@@ -3,7 +3,7 @@
 #: name = "opte-p5p"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly"
+#: rust_toolchain = "nightly-2023-01-12"
 #: output_rules = [
 #:   "=/out/opte.p5p",
 #:   "=/out/opte.p5p.sha256",

--- a/.github/buildomat/jobs/test.sh
+++ b/.github/buildomat/jobs/test.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "test"
 #: variety = "basic"
-#: target = "lab-opte-0.22"
+#: target = "lab-2.0-opte-0.23"
 #: rust_toolchain = "stable"
 #: output_rules = [
 #:   "/work/*.log",

--- a/.github/buildomat/jobs/xde.sh
+++ b/.github/buildomat/jobs/xde.sh
@@ -3,7 +3,7 @@
 #: name = "opte-xde"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly"
+#: rust_toolchain = "nightly-2023-01-12"
 #: output_rules = [
 #:   "=/work/debug/xde.dbg",
 #:   "=/work/debug/xde.dbg.sha256",

--- a/.github/buildomat/jobs/xde.sh
+++ b/.github/buildomat/jobs/xde.sh
@@ -66,7 +66,7 @@ pushd xde
 cp xde.conf /work/xde.conf
 
 header "check style"
-ptime -m cargo +nightly fmt -p xde -p xde-link -- --check
+ptime -m cargo +nightly-2023-01-12 fmt -p xde -p xde-link -- --check
 
 header "analyze"
 ptime -m cargo clippy -- --allow clippy::uninlined-format-args
@@ -112,7 +112,7 @@ sha256sum $REL_TGT/xde_link.so > $REL_TGT/xde_link.so.sha256
 
 header "build xde integration tests"
 pushd xde-tests
-cargo +nightly fmt -- --check
+cargo +nightly-2023-01-12 fmt -- --check
 cargo clippy --all-targets
 cargo build --test loopback
 loopback_test=$(

--- a/.github/buildomat/jobs/xde.sh
+++ b/.github/buildomat/jobs/xde.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "opte-xde"
 #: variety = "basic"
-#: target = "helios"
+#: target = "helios-2.0"
 #: rust_toolchain = "nightly"
 #: output_rules = [
 #:   "=/work/debug/xde.dbg",

--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export PUBLISHER=helios-netdev
+export PUBLISHER=helios-dev
 export COMMIT_COUNT=`git rev-list --count HEAD`
 export REPO=packages/repo
 

--- a/pkg/opte.template.p5m
+++ b/pkg/opte.template.p5m
@@ -35,5 +35,3 @@ file path=kernel/drv/amd64/xde owner=root group=sys mode=0755 \
     pkg.depend.bypass-generate=.*dld.* \
     pkg.depend.bypass-generate=.*mac.*
 driver name=xde
-depend type=incorporate fmri=pkg:/driver/network/opte@0.%API_VSN%.%COMMIT_COUNT%
-depend type=require fmri=pkg:/driver/network/opte@0.%API_VSN%.%COMMIT_COUNT%


### PR DESCRIPTION
This change does a few things:

- removes the dependency the package has on itself
- changes the publisher name to **helios-dev** to match what we are presently using for Helios 2
- changes all the buildomat targets to Helios 2 targets