### PR TITLE
Add UFT Hit probe for DTrace

### DIFF
--- a/dtrace/opte-uft-hit.d
+++ b/dtrace/opte-uft-hit.d
@@ -1,0 +1,47 @@
+/*
+ * Track UFT entry hits as they happen. A hit occurs whenever a packet
+ * matches an existing flow table entry (in- or outbound) with the same
+ * epoch as the port. This is the 'fast-path' of packet matching.
+ *
+ * dtrace -L ./lib -I . -Cqs ./opte-uft-hit.d
+ */
+#include "common.h"
+#include "protos.d"
+
+#define	HDR_FMT		"%-8s %-3s %-43s %s\n"
+#define	LINE_FMT	"%-8s %-3s %-43s %u\n"
+
+BEGIN {
+	printf(HDR_FMT, "PORT", "DIR", "FLOW", "EPOCH");
+	num = 0;
+}
+
+uft-hit {
+	this->dir = DIR_STR(arg0);
+	this->port = stringof(arg1);
+	this->flow = (flow_id_sdt_arg_t *)arg2;
+	this->epoch = arg3;
+	this->af = this->flow->af;
+
+	if (num >= 10) {
+		printf(HDR_FMT, "PORT", "DIR", "FLOW", "EPOCH");
+		num = 0;
+	}
+
+	if (this->af != AF_INET && this->af != AF_INET6) {
+		printf("BAD ADDRESS FAMILY: %d\n", this->af);
+	}
+}
+
+uft-hit /this->af == AF_INET/ {
+	FLOW_FMT(this->s, this->flow);
+	printf(LINE_FMT, this->port, this->dir, this->s, this->epoch);
+	num++;
+}
+
+uft-hit /this->af == AF_INET6/ {
+	FLOW_FMT6(this->s, this->flow);
+	printf(LINE_FMT, this->port, this->dir, this->s, this->epoch);
+	num++;
+}
+

--- a/dtrace/opte-uft-invalidate.d
+++ b/dtrace/opte-uft-invalidate.d
@@ -18,7 +18,7 @@ BEGIN {
 	num = 0;
 }
 
-flow-entry-invalidated {
+uft-invalidate {
 	this->dir = DIR_STR(arg0);
 	this->port = stringof(arg1);
 	this->flow = (flow_id_sdt_arg_t *)arg2;
@@ -35,15 +35,15 @@ flow-entry-invalidated {
 	}
 }
 
-ft-entry-invliadated /this->af == AF_INET/ {
+uft-invalidate /this->af == AF_INET/ {
 	FLOW_FMT(this->s, this->flow);
-	printf(LINE_FMT, this->dir, this->port, this->s, this->epoch);
+	printf(LINE_FMT, this->port, this->dir, this->s, this->epoch);
 	num++;
 }
 
-ft-entry-invliadated /this->af == AF_INET6/ {
+uft-invalidate /this->af == AF_INET6/ {
 	FLOW_FMT6(this->s, this->flow);
-	printf(LINE_FMT, this->dir, this->port, this->s, this->epoch);
+	printf(LINE_FMT, this->port, this->dir, this->s, this->epoch);
 	num++;
 }
 

--- a/lib/opte/src/lib.rs
+++ b/lib/opte/src/lib.rs
@@ -70,6 +70,7 @@ pub const fn bit_on(bit: u8) -> u8 {
 mod opte_provider {
     use opte_api::Direction;
 
+    fn uft__hit(dir: Direction, port: &str, flow: &str, epoch: u64) {}
     fn uft__invalidate(dir: Direction, port: &str, flow: &str, epoch: u64) {}
     fn uft__tcp__closed(dir: Direction, port: &str, flow: &str) {}
     fn flow__expired(port: &str, ft_name: &str, flow: &str) {}


### PR DESCRIPTION
Adds a DTrace probe on UFT hit to allow us some observability, and adds a matching `.d` script using this probe. Additionally fixes up typos/old symbol names in `uft-hit-invaildate.d` (sic).

Closes #101.