### PR TITLE
Fix kstat/dhcp doctests and `cargo test`

### DIFF
--- a/lib/opte/src/ddi/kstat.rs
+++ b/lib/opte/src/ddi/kstat.rs
@@ -41,6 +41,9 @@ cfg_if! {
 /// fields with type [`KStatU64`] and derive [`KStatProvider`].
 ///
 /// ```
+/// use opte::ddi::kstat::{self, KStatProvider, KStatU64};
+/// use kstat_macro::KStatProvider;
+///
 /// #[derive(KStatProvider)]
 /// struct SomeStats {
 ///     bytes_out: KStatU64,
@@ -52,7 +55,7 @@ cfg_if! {
 ///
 /// To update the values use the `+=` operator.
 ///
-/// ```
+/// ```ignore
 /// some_val.stats.bytes_out += 54;
 /// ```
 ///
@@ -82,8 +85,11 @@ pub trait KStatProvider {
 /// the provider is unregistered from the kstats list.
 ///
 /// ```
+/// use opte::ddi::kstat::{self, KStatNamed, KStatProvider, KStatU64};
+/// use kstat_macro::KStatProvider;
+///
 /// #[derive(KStatProvider)]
-/// pub StatProvider {
+/// pub struct StatProvider {
 ///     my_counter: KStatU64,
 /// }
 ///

--- a/lib/opte/src/engine/dhcpv6/options.rs
+++ b/lib/opte/src/engine/dhcpv6/options.rs
@@ -9,7 +9,7 @@
 //! The majority of data transferred in DHCPv6 is done so via Options. They have
 //! a simple format:
 //!
-//! ```
+//! ```text
 //!  0                   1                   2                   3
 //!  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 //! +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+


### PR DESCRIPTION
`cargo test` was getting caught up on some doctests, correct and accidental. Code snippets in `ddi::kstat` were missing imports and had some obvious typos, while a packet diagram in `dhcp` was missing the `text` label.