### PR TITLE
Filter all uncaught {In, Out} NDP traffic

### DIFF
--- a/lib/opte/src/engine/dhcp.rs
+++ b/lib/opte/src/engine/dhcp.rs
@@ -63,9 +63,15 @@ cfg_if! {
 /// therefore it must be serializable. There are ways to get around
 /// this without creating a new type; the author prefers this way as
 /// it's less "magic".
-#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct MessageType {
     inner: smoltcp::wire::DhcpMessageType,
+}
+
+impl PartialOrd for MessageType {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        u8::from(*self).partial_cmp(&u8::from(*other))
+    }
 }
 
 impl From<smoltcp::wire::DhcpMessageType> for MessageType {

--- a/lib/opte/src/engine/dhcp.rs
+++ b/lib/opte/src/engine/dhcp.rs
@@ -63,7 +63,7 @@ cfg_if! {
 /// therefore it must be serializable. There are ways to get around
 /// this without creating a new type; the author prefers this way as
 /// it's less "magic".
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
 pub struct MessageType {
     inner: smoltcp::wire::DhcpMessageType,
 }
@@ -316,15 +316,15 @@ impl HairpinAction for DhcpAction {
 
         let data_preds = match self.reply_type {
             DhcpReplyType::Offer => {
-                vec![DataPredicate::DhcpMsgType(MessageType::from(
-                    SmolDMT::Discover,
-                ))]
+                vec![DataPredicate::DhcpMsgType(
+                    MessageType::from(SmolDMT::Discover).into(),
+                )]
             }
 
             DhcpReplyType::Ack => {
-                vec![DataPredicate::DhcpMsgType(MessageType::from(
-                    SmolDMT::Request,
-                ))]
+                vec![DataPredicate::DhcpMsgType(
+                    MessageType::from(SmolDMT::Request).into(),
+                )]
             }
         };
 

--- a/lib/opte/src/engine/dhcpv6/protocol.rs
+++ b/lib/opte/src/engine/dhcpv6/protocol.rs
@@ -128,6 +128,12 @@ impl From<MessageType> for u8 {
     }
 }
 
+impl PartialOrd for MessageType {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        u8::from(*self).partial_cmp(&u8::from(*other))
+    }
+}
+
 /// A DHCPv6 message.
 ///
 /// All DHCPv6 transactions occur through this type. Clients send messages,

--- a/lib/opte/src/engine/icmp.rs
+++ b/lib/opte/src/engine/icmp.rs
@@ -140,12 +140,16 @@ impl HairpinAction for IcmpEchoReply {
 /// predicates. We call this "message type" instead of just "message"
 /// because that's what it is: the type field of the larger ICMP
 /// message.
-#[derive(
-    Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize,
-)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(from = "u8", into = "u8")]
 pub struct MessageType {
     inner: wire::Icmpv4Message,
+}
+
+impl PartialOrd for MessageType {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        u8::from(*self).partial_cmp(&u8::from(*other))
+    }
 }
 
 impl From<wire::Icmpv4Message> for MessageType {

--- a/lib/opte/src/engine/icmp.rs
+++ b/lib/opte/src/engine/icmp.rs
@@ -61,9 +61,9 @@ impl HairpinAction for IcmpEchoReply {
             Predicate::InnerIpProto(vec![IpProtoMatch::Exact(Protocol::ICMP)]),
         ];
 
-        let data_preds = vec![DataPredicate::IcmpMsgType(MessageType::from(
-            wire::Icmpv4Message::EchoRequest,
-        ))];
+        let data_preds = vec![DataPredicate::IcmpMsgType(
+            MessageType::from(wire::Icmpv4Message::EchoRequest).into(),
+        )];
 
         (hdr_preds, data_preds)
     }
@@ -140,7 +140,9 @@ impl HairpinAction for IcmpEchoReply {
 /// predicates. We call this "message type" instead of just "message"
 /// because that's what it is: the type field of the larger ICMP
 /// message.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Serialize, Deserialize,
+)]
 #[serde(from = "u8", into = "u8")]
 pub struct MessageType {
     inner: wire::Icmpv4Message,

--- a/lib/opte/src/engine/icmpv6.rs
+++ b/lib/opte/src/engine/icmpv6.rs
@@ -176,7 +176,7 @@ impl<'a> RawHeader<'a> for Icmpv6HdrRaw {
 }
 
 /// An ICMPv6 message type
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(from = "u8", into = "u8")]
 pub struct MessageType {
     inner: Icmpv6Message,
@@ -184,7 +184,13 @@ pub struct MessageType {
 
 impl PartialOrd for MessageType {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        u8::from(*self).partial_cmp(&u8::from(*other))
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for MessageType {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        u8::from(*self).cmp(&u8::from(*other))
     }
 }
 

--- a/lib/opte/src/engine/icmpv6.rs
+++ b/lib/opte/src/engine/icmpv6.rs
@@ -226,9 +226,9 @@ impl HairpinAction for Icmpv6EchoReply {
             )]),
         ];
 
-        let data_preds = vec![DataPredicate::Icmpv6MsgType(MessageType::from(
-            Icmpv6Message::EchoRequest,
-        ))];
+        let data_preds = vec![DataPredicate::Icmpv6MsgType(
+            MessageType::from(Icmpv6Message::EchoRequest).into(),
+        )];
 
         (hdr_preds, data_preds)
     }
@@ -363,9 +363,9 @@ impl HairpinAction for RouterAdvertisement {
 
         let data_preds = vec![
             // This must be a Router Solicitation message.
-            DataPredicate::Icmpv6MsgType(MessageType::from(
-                Icmpv6Message::RouterSolicit,
-            )),
+            DataPredicate::Icmpv6MsgType(
+                MessageType::from(Icmpv6Message::RouterSolicit).into(),
+            ),
         ];
 
         (hdr_preds, data_preds)
@@ -702,9 +702,9 @@ impl HairpinAction for NeighborAdvertisement {
 
         let data_preds = vec![
             // This must be an actual Neighbor Solicitation message
-            DataPredicate::Icmpv6MsgType(MessageType::from(
-                Icmpv6Message::NeighborSolicit,
-            )),
+            DataPredicate::Icmpv6MsgType(
+                MessageType::from(Icmpv6Message::NeighborSolicit).into(),
+            ),
         ];
 
         (hdr_preds, data_preds)

--- a/lib/opte/src/engine/icmpv6.rs
+++ b/lib/opte/src/engine/icmpv6.rs
@@ -176,12 +176,16 @@ impl<'a> RawHeader<'a> for Icmpv6HdrRaw {
 }
 
 /// An ICMPv6 message type
-#[derive(
-    Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
-)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, Serialize)]
 #[serde(from = "u8", into = "u8")]
 pub struct MessageType {
     inner: Icmpv6Message,
+}
+
+impl PartialOrd for MessageType {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        u8::from(*self).partial_cmp(&u8::from(*other))
+    }
 }
 
 impl From<Icmpv6Message> for MessageType {

--- a/lib/opte/src/engine/predicate.rs
+++ b/lib/opte/src/engine/predicate.rs
@@ -709,7 +709,7 @@ mod tests {
         // in case the underlying repr adds support for a test opcode.
         assert!(dhcp_range.is_match(&SmolDhcpType::Unknown(2).into()));
         assert!(icmp_range.is_match(&Icmpv4Message::Unknown(3).into()));
-        assert!(dhcp6_range.is_match(&Dhcpv6MessageType::Other(6).into()));
+        assert!(dhcp6_range.is_match(&Dhcpv6MessageType::Other(6)));
         assert!(icmp6_range.is_match(&Icmpv6Message::Unknown(0x86).into()));
     }
 }

--- a/lib/oxide-vpc/src/engine/gateway/icmpv6.rs
+++ b/lib/oxide-vpc/src/engine/gateway/icmpv6.rs
@@ -9,10 +9,8 @@
 cfg_if! {
     if #[cfg(all(not(feature = "std"), not(test)))] {
         use alloc::sync::Arc;
-        use alloc::vec::Vec;
     } else {
         use std::sync::Arc;
-        use std::vec::Vec;
     }
 }
 
@@ -49,39 +47,36 @@ pub fn setup(
     cfg: &VpcCfg,
     ip_cfg: &Ipv6Cfg,
 ) -> Result<(), OpteError> {
-    // We need to hairpin echo requests from either the VPC-private or
-    // link-local address of the guest, to OPTE's link-local.
-    let src_ips = [ip_cfg.private_ip, Ipv6Addr::from_eui64(&cfg.guest_mac)];
     let dst_ip = Ipv6Addr::from_eui64(&cfg.gateway_mac);
-    let n_pings = src_ips.len();
-    let mut rule_actions = Vec::with_capacity(n_pings + 2);
-    for src_ip in src_ips.iter().copied() {
-        let echo = Action::Hairpin(Arc::new(Icmpv6EchoReply {
+    let hairpins = [
+        // We need to hairpin echo requests from either the VPC-private or
+        // link-local address of the guest, to OPTE's link-local.
+        Action::Hairpin(Arc::new(Icmpv6EchoReply {
             src_mac: cfg.guest_mac,
-            src_ip,
+            src_ip: ip_cfg.private_ip,
             dst_mac: cfg.gateway_mac,
             dst_ip,
-        }));
-        rule_actions.push(echo);
-    }
-
-    // Map an NDP Router Solicitation from the guest to a Router Advertisement
-    // from the OPTE virtual gateway's link-local IPv6 address.
-    let router_advert = Action::Hairpin(Arc::new(RouterAdvertisement::new(
-        // From the guest's VPC MAC.
-        cfg.guest_mac,
-        // The MAC from which we respond, i.e., OPTE's MAC.
-        cfg.gateway_mac,
-        // "Managed Configuration", indicating the guest needs to use DHCPv6 to
-        // acquire an IPv6 address.
-        true,
-    )));
-    rule_actions.push(router_advert);
-
-    // Map an NDP Neighbor Solicitation from the guest to a neighbor
-    // advertisement from the OPTE virtual gateway. Note that this is required
-    // per RFC 4861 so that the guest does not mark the neighbor failed.
-    let neighbor_advert =
+        })),
+        Action::Hairpin(Arc::new(Icmpv6EchoReply {
+            src_mac: cfg.guest_mac,
+            src_ip: Ipv6Addr::from_eui64(&cfg.guest_mac),
+            dst_mac: cfg.gateway_mac,
+            dst_ip,
+        })),
+        // Map an NDP Router Solicitation from the guest to a Router Advertisement
+        // from the OPTE virtual gateway's link-local IPv6 address.
+        Action::Hairpin(Arc::new(RouterAdvertisement::new(
+            // From the guest's VPC MAC.
+            cfg.guest_mac,
+            // The MAC from which we respond, i.e., OPTE's MAC.
+            cfg.gateway_mac,
+            // "Managed Configuration", indicating the guest needs to use DHCPv6 to
+            // acquire an IPv6 address.
+            true,
+        ))),
+        // Map an NDP Neighbor Solicitation from the guest to a neighbor
+        // advertisement from the OPTE virtual gateway. Note that this is required
+        // per RFC 4861 so that the guest does not mark the neighbor failed.
         Action::Hairpin(Arc::new(NeighborAdvertisement::new(
             // From the guest's VPC MAC.
             cfg.guest_mac,
@@ -91,17 +86,17 @@ pub fn setup(
             true,
             // Respond to solicitations from `::`
             true,
-        )));
-    rule_actions.push(neighbor_advert);
+        ))),
+    ];
 
-    let n_rule_actions = rule_actions.len();
-
+    // UNWRAP SAFETY: There are far fewer than 65535 rules inserted here.
+    let next_out_prio = u16::try_from(hairpins.len() + 1).unwrap();
     // Add rules for the above actions.
-    for i in 0..n_rule_actions {
+    hairpins.into_iter().enumerate().for_each(|(i, action)| {
         let priority = u16::try_from(i + 1).unwrap();
-        let rule = Rule::new(priority, rule_actions.remove(0));
+        let rule = Rule::new(priority, action);
         layer.add_rule(Direction::Out, rule.finalize());
-    }
+    });
 
     // Filter any uncaught in/out-bound NDP traffic.
     let pred = DataPredicate::Icmpv6MsgType(
@@ -110,8 +105,7 @@ pub fn setup(
     );
     let in_pred = pred.clone();
 
-    let mut ndp_filter =
-        Rule::new(u16::try_from(n_rule_actions + 1).unwrap(), Action::Deny);
+    let mut ndp_filter = Rule::new(next_out_prio, Action::Deny);
     ndp_filter.add_data_predicate(pred);
     layer.add_rule(Direction::Out, ndp_filter.finalize());
 

--- a/lib/oxide-vpc/tests/common/mod.rs
+++ b/lib/oxide-vpc/tests/common/mod.rs
@@ -164,7 +164,7 @@ pub fn g2_cfg() -> VpcCfg {
         },
         ipv6: Ipv6Cfg {
             vpc_subnet: "fd00::/64".parse().unwrap(),
-            private_ip: "fd00::5".parse().unwrap(),
+            private_ip: "fd00::6".parse().unwrap(),
             gateway_ip: "fd00::1".parse().unwrap(),
             snat: Some(SNat6Cfg {
                 external_ip: "2001:db8::1".parse().unwrap(),
@@ -311,7 +311,8 @@ pub fn oxide_net_setup2(
         "set:epoch=2",
         // * Allow inbound IPv6 traffic for guest.
         // * Allow inbound IPv4 traffic for guest.
-        "set:gateway.rules.in=2",
+        // * Deny inbound NDP for guest.
+        "set:gateway.rules.in=3",
         // IPv4
         // ----
         //
@@ -326,11 +327,12 @@ pub fn oxide_net_setup2(
         //
         // * NDP NA for Gateway
         // * NDP RA for Gateway
+        // * Deny all other NDP
         // * ICMPv6 Echo Reply for Gateway from Guest Link-Local
         // * ICMPv6 Echo Reply for Gateway from Guest VPC ULA
         // * DHCPv6
         // * Outbound traffic from Guest IPv6 + MAC Address
-        "set:gateway.rules.out=11",
+        "set:gateway.rules.out=12",
         // * Allow all outbound traffic
         "set:firewall.rules.out=0",
         // * Outbound IPv4 SNAT

--- a/lib/oxide-vpc/tests/integration_tests.rs
+++ b/lib/oxide-vpc/tests/integration_tests.rs
@@ -1543,7 +1543,8 @@ fn gateway_router_advert_reply() {
         "Router advertisement should be destined for the guest's MAC"
     );
 
-    let IpMeta::Ip6(ip6) = meta.inner.ip.as_ref().expect("No inner IP header") else {
+    let IpMeta::Ip6(ip6) = meta.inner.ip.as_ref().expect("No inner IP header")
+    else {
         panic!("Inner IP header is not IPv6");
     };
 
@@ -1690,6 +1691,53 @@ impl std::fmt::Display for SolicitInfo {
             .field("lladdr", &lladdr)
             .finish()
     }
+}
+
+// Create a Neighbor Advertisement.
+fn generate_neighbor_advertisement(
+    info: &AdvertInfo,
+    with_checksum: bool,
+) -> Packet<Parsed> {
+    let advert = NdiscRepr::NeighborAdvert {
+        flags: info.flags,
+        target_addr: info.target_addr.into(),
+        lladdr: info.lladdr.map(|x| RawHardwareAddress::from_bytes(&x)),
+    };
+    let req = Icmpv6Repr::Ndisc(advert);
+    let mut body = vec![0u8; req.buffer_len()];
+    let mut req_pkt = Icmpv6Packet::new_unchecked(&mut body);
+    let mut csum = CsumCapab::ignored();
+    if with_checksum {
+        csum.icmpv6 = smoltcp::phy::Checksum::Tx;
+    }
+    req.emit(
+        &IpAddress::Ipv6(info.src_ip.into()),
+        &IpAddress::Ipv6(info.dst_ip.into()),
+        &mut req_pkt,
+        &csum,
+    );
+    let ip6 = Ipv6Meta {
+        src: info.src_ip,
+        dst: info.dst_ip,
+        proto: Protocol::ICMPv6,
+        next_hdr: IpProtocol::Icmpv6,
+        hop_limit: 255,
+        pay_len: req.buffer_len() as u16,
+        ..Default::default()
+    };
+    let eth = EtherMeta {
+        dst: info.dst_mac,
+        src: info.src_mac,
+        ether_type: EtherType::Ipv6,
+    };
+
+    let total_len = EtherHdr::SIZE + ip6.hdr_len() + req.buffer_len();
+    let mut pkt = Packet::alloc_and_expand(total_len);
+    let mut wtr = pkt.seg0_wtr();
+    eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
+    ip6.emit(wtr.slice_mut(ip6.hdr_len()).unwrap());
+    wtr.write(&body).unwrap();
+    pkt.parse(Out, VpcParser::new()).unwrap()
 }
 
 // Helper type describing a Neighbor Advertisement
@@ -1989,7 +2037,6 @@ fn test_gateway_neighbor_advert_reply() {
                         "stats.port.out_uft_miss"
                     ]
                 );
-                continue;
             }
             (Ok(Hairpin(hp)), Some(na)) => {
                 incr!(g1, ["stats.port.out_uft_miss"]);
@@ -2007,6 +2054,132 @@ fn test_gateway_neighbor_advert_reply() {
                 );
             }
         };
+    }
+}
+
+// Neighbor advertisements (and any other NDP not targeted *at* the gateway)
+// are to be explicitly dropped.
+#[test]
+fn outbound_ndp_dropped() {
+    let g1_cfg = g1_cfg();
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
+    g1.port.start();
+    set!(g1, "port_state=running");
+
+    let IpCfg::DualStack { ipv4: _, ipv6 } = g1_cfg.ip_cfg else {
+        panic!("Host should be configured v6 or dual stack.");
+    };
+
+    router::add_entry(
+        &g1.port,
+        IpCidr::Ip6(ipv6.vpc_subnet),
+        RouterTarget::VpcSubnet(IpCidr::Ip6(ipv6.vpc_subnet)),
+    )
+    .unwrap();
+    incr!(g1, ["router.rules.out", "epoch"]);
+
+    // Add router entry that allows g1 to route to internet.
+    router::add_entry(
+        &g1.port,
+        IpCidr::Ip6("::/0".parse().unwrap()),
+        RouterTarget::InternetGateway,
+    )
+    .unwrap();
+    incr!(g1, ["router.rules.out", "epoch"]);
+
+    // Test case from Omicron #2857.
+    let outbound_na = AdvertInfo {
+        src_mac: g1_cfg.guest_mac,
+        dst_mac: MacAddr::BROADCAST,
+        src_ip: ipv6.private_ip,
+        dst_ip: Ipv6Addr::ALL_NODES,
+        target_addr: Ipv6Addr::from_const([
+            0xfd77, 0xe9d2, 0x9cd9, 0x2000, 0, 0, 0, 6,
+        ]),
+        lladdr: Some(g1_cfg.guest_mac),
+        flags: NdiscNeighborFlags::OVERRIDE,
+    };
+
+    let mut pkt = generate_neighbor_advertisement(&outbound_na, true);
+
+    let res = g1.port.process(Out, &mut pkt, ActionMeta::new()).unwrap();
+    match res {
+        ProcessResult::Drop { .. } => {
+            incr!(
+                g1,
+                [
+                    "stats.port.out_drop, stats.port.out_drop_layer",
+                    "stats.port.out_uft_miss"
+                ]
+            );
+        }
+        a => panic!(
+            "unexpected respondse for outbound NA. Got {a:?}, expected Drop."
+        ),
+    }
+}
+
+// All encapsulated NDP traffic received from elsewhere must be dropped --
+// all zones/VMs are technically on their own segment with the gateway.
+#[test]
+fn inbound_ndp_dropped_at_gateway() {
+    let g1_cfg = g1_cfg();
+    let g2_cfg = g2_cfg();
+    let mut g1 = oxide_net_setup("g1_port", &g1_cfg, None, None);
+    g1.port.start();
+    set!(g1, "port_state=running");
+
+    let g2_phys = TestIpPhys {
+        ip: g2_cfg.phys_ip,
+        mac: g2_cfg.gateway_mac,
+        vni: g2_cfg.vni,
+    };
+    let g1_phys = TestIpPhys {
+        ip: g1_cfg.phys_ip,
+        mac: g1_cfg.gateway_mac,
+        vni: g1_cfg.vni,
+    };
+
+    let IpCfg::DualStack { ipv4: _, ipv6: g1_v6 } = g1_cfg.ip_cfg else {
+        panic!("Host should be configured v6 or dual stack.");
+    };
+    let IpCfg::DualStack { ipv4: _, ipv6: g2_v6 } = g2_cfg.ip_cfg else {
+        panic!("Host should be configured v6 or dual stack.");
+    };
+
+    // Assume we have received an NS from another node: set up as two VMs
+    // here, but equally valid if rack-external on same subnet.
+    let ns = SolicitInfo {
+        src_mac: g2_cfg.guest_mac,
+        dst_mac: g2_cfg.gateway_mac,
+        src_ip: g2_v6.private_ip,
+        dst_ip: g1_v6.private_ip,
+        target_addr: g1_v6.private_ip,
+        lladdr: Some(g1_cfg.guest_mac),
+    };
+
+    let pkt = generate_neighbor_solicitation(&ns, true);
+    let mut pkt = encap(pkt, g2_phys, g1_phys);
+    let res = g1.port.process(In, &mut pkt, ActionMeta::new()).unwrap();
+    println!("{res:?}");
+    match res {
+        ProcessResult::Drop { .. } => {
+            incr!(
+                g1,
+                [
+                    "stats.port.in_drop, stats.port.in_drop_layer",
+                    "stats.port.in_uft_miss",
+                    // The firewall increments its flow count because
+                    // these two hosts *are allowed to talk to one
+                    // another* -- just not on this protocol!
+                    "firewall.flows.in",
+                    "firewall.flows.out"
+                ]
+            );
+        }
+        a => panic!(
+            "unexpected response for inbound NS. Got {a:?}, expected Drop."
+        ),
     }
 }
 
@@ -2273,7 +2446,8 @@ fn test_reply_to_dhcpv6_solicit_or_request() {
                 let domain_list = reply
                     .find_option(dhcpv6::options::Code::DomainList)
                     .expect("Expected a Domain Search List option");
-                let dhcpv6::options::Option::DomainList(bytes) = domain_list else {
+                let dhcpv6::options::Option::DomainList(bytes) = domain_list
+                else {
                     panic!("Expected an Option::DomainList");
                 };
                 let mut expected_bytes = Vec::new();

--- a/lib/oxide-vpc/tests/integration_tests.rs
+++ b/lib/oxide-vpc/tests/integration_tests.rs
@@ -2136,7 +2136,7 @@ fn inbound_ndp_dropped_at_gateway() {
                     "stats.port.in_uft_miss",
                     // The firewall increments its flow count because
                     // these two hosts *are allowed to talk to one
-                    // another* -- just not on this protocol!
+                    // another* -- just not on this *subset* of ICMPv6!
                     "firewall.flows.in",
                     "firewall.flows.out"
                 ]


### PR DESCRIPTION
Adds an additional gateway rule in each direction when v6-configured that will filter unexpected NDP traffic. I was unable to locally replicate the exact behaviour reported in omicron, but putting together some test cases similar enough to the original report confirmed the packets were uncaught (and should now be).

Also adds a `TypeMatch` so that we can express matches on collections with a little more ease. Predicates could also take another look, but that's out of scope for this bugfix PR.

Closes #356.