### PR TITLE
Expose API for clearing a specific layer's flow table entries.

### DIFF
--- a/bin/opteadm/src/bin/opteadm.rs
+++ b/bin/opteadm/src/bin/opteadm.rs
@@ -72,6 +72,13 @@ enum Command {
         port: String,
     },
 
+    /// Clear all entries from the given Layer's Flow Table.
+    ClearLft {
+        #[arg(short)]
+        port: String,
+        layer: String,
+    },
+
     /// Dump the Unified Flow Table.
     DumpUft {
         #[arg(short)]
@@ -335,6 +342,11 @@ fn main() -> anyhow::Result<()> {
         Command::ClearUft { port } => {
             let hdl = opteadm::OpteAdm::open(OpteAdm::XDE_CTL)?;
             hdl.clear_uft(&port)?;
+        }
+
+        Command::ClearLft { port, layer } => {
+            let hdl = opteadm::OpteAdm::open(OpteAdm::XDE_CTL)?;
+            hdl.clear_lft(&port, &layer)?;
         }
 
         Command::DumpUft { port } => {

--- a/bin/opteadm/src/lib.rs
+++ b/bin/opteadm/src/lib.rs
@@ -187,6 +187,23 @@ impl OpteAdm {
         )
     }
 
+    /// Clear all entries from the given Layer's Flow Table (LFT).
+    pub fn clear_lft(
+        &self,
+        port_name: &str,
+        layer_name: &str,
+    ) -> Result<NoResp, Error> {
+        let cmd = OpteCmd::ClearLft;
+        run_cmd_ioctl(
+            self.device.as_raw_fd(),
+            cmd,
+            Some(&api::ClearLftReq {
+                port_name: port_name.to_string(),
+                layer_name: layer_name.to_string(),
+            }),
+        )
+    }
+
     /// Return the Unified Flow Table (UFT).
     pub fn dump_uft(&self, port_name: &str) -> Result<api::DumpUftResp, Error> {
         let cmd = OpteCmd::DumpUft;

--- a/crates/opte-api/src/cmd.rs
+++ b/crates/opte-api/src/cmd.rs
@@ -36,6 +36,7 @@ pub enum OpteCmd {
     DumpUft = 32,        // dump the Unified Flow Table
     ListLayers = 33,     // list the layers on a given port
     ClearUft = 40,       // clear the UFT
+    ClearLft = 41,       // clear the given Layer's Flow Table
     SetVirt2Phys = 50,   // set a v2p mapping
     DumpVirt2Phys = 51,  // dump the v2p mappings
     AddRouterEntry = 60, // add a router entry for IP dest
@@ -58,6 +59,7 @@ impl TryFrom<c_int> for OpteCmd {
             32 => Ok(Self::DumpUft),
             33 => Ok(Self::ListLayers),
             40 => Ok(Self::ClearUft),
+            41 => Ok(Self::ClearLft),
             50 => Ok(Self::SetVirt2Phys),
             51 => Ok(Self::DumpVirt2Phys),
             60 => Ok(Self::AddRouterEntry),

--- a/crates/opte-api/src/lib.rs
+++ b/crates/opte-api/src/lib.rs
@@ -58,7 +58,7 @@ pub use ulp::*;
 ///
 /// We rely on CI and the check-api-version.sh script to verify that
 /// this number is incremented anytime the oxide-api code changes.
-pub const API_VERSION: u64 = 23;
+pub const API_VERSION: u64 = 24;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Direction {

--- a/lib/opte/src/engine/ioctl.rs
+++ b/lib/opte/src/engine/ioctl.rs
@@ -97,6 +97,12 @@ pub struct ClearUftReq {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct ClearLftReq {
+    pub port_name: String,
+    pub layer_name: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct DumpUftReq {
     pub port_name: String,
 }

--- a/lib/opte/src/engine/port.rs
+++ b/lib/opte/src/engine/port.rs
@@ -920,6 +920,25 @@ impl<N: NetworkImpl> Port<N> {
         Ok(())
     }
 
+    /// Clear all entries from the Layer Flow Table (LFT) of
+    /// the layer named `layer`.
+    ///
+    /// # States
+    ///
+    /// This command is valid for the following states.
+    ///
+    /// * [`PortState::Running`]
+    pub fn clear_lft(&self, layer: &str) -> Result<()> {
+        let mut data = self.data.lock();
+        check_state!(data.state, [PortState::Running])?;
+        data.layers
+            .iter_mut()
+            .find(|l| l.name() == layer)
+            .ok_or_else(|| OpteError::LayerNotFound(layer.to_string()))?
+            .clear_flows();
+        Ok(())
+    }
+
     /// Dump the contents of the Unified Flow Table (UFT).
     ///
     /// # States

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -512,6 +512,11 @@ unsafe extern "C" fn xde_ioc_opte_cmd(karg: *mut c_void, mode: c_int) -> c_int {
             hdlr_resp(&mut env, resp)
         }
 
+        OpteCmd::ClearLft => {
+            let resp = clear_lft_hdlr(&mut env);
+            hdlr_resp(&mut env, resp)
+        }
+
         OpteCmd::DumpUft => {
             let resp = dump_uft_hdlr(&mut env);
             hdlr_resp(&mut env, resp)
@@ -2178,6 +2183,20 @@ fn clear_uft_hdlr(env: &mut IoctlEnvelope) -> Result<NoResp, OpteError> {
     };
 
     dev.port.clear_uft()?;
+    Ok(NoResp::default())
+}
+
+#[no_mangle]
+fn clear_lft_hdlr(env: &mut IoctlEnvelope) -> Result<NoResp, OpteError> {
+    let req: api::ClearLftReq = env.copy_in_req()?;
+    let devs = unsafe { xde_devs.read() };
+    let mut iter = devs.iter();
+    let dev = match iter.find(|x| x.devname == req.port_name) {
+        Some(dev) => dev,
+        None => return Err(OpteError::PortNotFound(req.port_name)),
+    };
+
+    dev.port.clear_lft(&req.layer_name)?;
     Ok(NoResp::default())
 }
 


### PR DESCRIPTION
- Add `OpteCmd::ClearLft` & `ClearLftReq` to ioctl API.
- Update xde to handle new req (^) and plumb down to existing `Layer::clear_flows` method in opte.
- Update `opteadm` with new `clear-lft` command.

Closes #397.