### PR TITLE
Add base configuration for renovate.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>oxidecomputer/renovate-config",
+    "local>oxidecomputer/renovate-config//rust/autocreate",
+    "local>oxidecomputer/renovate-config//actions/pin"
+  ]
+}


### PR DESCRIPTION
This is almost identical to the configuration in omicron today. We don't need to perform any post-upgrade commands, so we can remove the line of config that adds that functionality.

Closes #401.