### PR TITLE
Enable ICMP Echo Request/Reply rewriting through IPv6 SNAT

### DIFF
--- a/lib/opte/src/engine/headers.rs
+++ b/lib/opte/src/engine/headers.rs
@@ -224,6 +224,30 @@ pub enum IpMod {
     Ip6(Ipv6Mod),
 }
 
+impl IpMod {
+    pub fn new_src(ip: IpAddr) -> Self {
+        match ip {
+            IpAddr::Ip4(ip) => {
+                Self::Ip4(Ipv4Mod { src: Some(ip), ..Default::default() })
+            }
+            IpAddr::Ip6(ip) => {
+                Self::Ip6(Ipv6Mod { src: Some(ip), ..Default::default() })
+            }
+        }
+    }
+
+    pub fn new_dst(ip: IpAddr) -> Self {
+        match ip {
+            IpAddr::Ip4(ip) => {
+                Self::Ip4(Ipv4Mod { dst: Some(ip), ..Default::default() })
+            }
+            IpAddr::Ip6(ip) => {
+                Self::Ip6(Ipv6Mod { dst: Some(ip), ..Default::default() })
+            }
+        }
+    }
+}
+
 impl ModifyAction<IpMeta> for IpMod {
     fn modify(&self, meta: &mut IpMeta) {
         match (self, meta) {

--- a/lib/opte/src/engine/icmp/v4.rs
+++ b/lib/opte/src/engine/icmp/v4.rs
@@ -148,7 +148,7 @@ impl HairpinAction for IcmpEchoReply {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(from = "u8", into = "u8")]
 pub struct MessageType {
-    pub inner: wire::Icmpv4Message,
+    inner: wire::Icmpv4Message,
 }
 
 impl PartialOrd for MessageType {

--- a/lib/opte/src/engine/nat.rs
+++ b/lib/opte/src/engine/nat.rs
@@ -8,8 +8,6 @@
 
 use super::headers::HeaderAction;
 use super::headers::IpMod;
-use super::ip4::Ipv4Mod;
-use super::ip6::Ipv6Mod;
 use super::packet::InnerFlowId;
 use super::packet::Packet;
 use super::packet::Parsed;
@@ -83,16 +81,7 @@ impl ActionDesc for NatDesc {
     fn gen_ht(&self, dir: Direction) -> HdrTransform {
         match dir {
             Direction::Out => {
-                let ip = match self.external_ip {
-                    IpAddr::Ip4(ipv4) => IpMod::from(Ipv4Mod {
-                        src: Some(ipv4),
-                        ..Default::default()
-                    }),
-                    IpAddr::Ip6(ipv6) => IpMod::from(Ipv6Mod {
-                        src: Some(ipv6),
-                        ..Default::default()
-                    }),
-                };
+                let ip = IpMod::new_src(self.external_ip.into());
 
                 HdrTransform {
                     name: NAT_NAME.to_string(),
@@ -102,16 +91,8 @@ impl ActionDesc for NatDesc {
             }
 
             Direction::In => {
-                let ip = match self.priv_ip {
-                    IpAddr::Ip4(ipv4) => IpMod::from(Ipv4Mod {
-                        dst: Some(ipv4),
-                        ..Default::default()
-                    }),
-                    IpAddr::Ip6(ipv6) => IpMod::from(Ipv6Mod {
-                        dst: Some(ipv6),
-                        ..Default::default()
-                    }),
-                };
+                let ip = IpMod::new_dst(self.priv_ip.into());
+
                 HdrTransform {
                     name: NAT_NAME.to_string(),
                     inner_ip: HeaderAction::Modify(ip, PhantomData),

--- a/lib/opte/src/engine/nat.rs
+++ b/lib/opte/src/engine/nat.rs
@@ -81,7 +81,7 @@ impl ActionDesc for NatDesc {
     fn gen_ht(&self, dir: Direction) -> HdrTransform {
         match dir {
             Direction::Out => {
-                let ip = IpMod::new_src(self.external_ip.into());
+                let ip = IpMod::new_src(self.external_ip);
 
                 HdrTransform {
                     name: NAT_NAME.to_string(),
@@ -91,7 +91,7 @@ impl ActionDesc for NatDesc {
             }
 
             Direction::In => {
-                let ip = IpMod::new_dst(self.priv_ip.into());
+                let ip = IpMod::new_dst(self.priv_ip);
 
                 HdrTransform {
                     name: NAT_NAME.to_string(),

--- a/lib/opte/src/engine/snat.rs
+++ b/lib/opte/src/engine/snat.rs
@@ -246,9 +246,8 @@ impl<T: ConcreteIpAddr + 'static> SNat<T> {
                 icmp6.echo_id()
             }
             _ => Err(GenDescError::Unexpected {
-                msg:
-                    "Mistakenly called gen_icmp_desc on non Protocol::ICMP(v6)."
-                        .to_string(),
+                msg: "Mistakenly called gen_icmp_desc on non ICMP(v6)."
+                    .to_string(),
             })?,
         }
         .ok_or(GenDescError::Unexpected {
@@ -403,7 +402,7 @@ pub struct SNatIcmpEchoDesc<T: ConcreteIpAddr> {
 pub const SNAT_ICMP_ECHO_NAME: &str = "SNAT_ICMP_ECHO";
 
 impl<T: ConcreteIpAddr> ActionDesc for SNatIcmpEchoDesc<T> {
-    // SNAT needs to generate a payload transform for ICMP traffic in
+    // SNAT needs to generate an additional transform for ICMP traffic in
     // order to treat the Echo Identifier as a psuedo ULP port.
     fn gen_ht(&self, dir: Direction) -> HdrTransform {
         match dir {

--- a/lib/opte/src/engine/snat.rs
+++ b/lib/opte/src/engine/snat.rs
@@ -86,9 +86,19 @@ impl<T: ConcreteIpAddr> Default for NatPool<T> {
 }
 
 mod private {
-    pub trait Ip: Into<super::IpAddr> {}
-    impl Ip for super::Ipv4Addr {}
-    impl Ip for super::Ipv6Addr {}
+    use opte_api::Protocol;
+
+    pub trait Ip: Into<super::IpAddr> {
+        const MESSAGE_PROTOCOL: Protocol;
+    }
+
+    impl Ip for super::Ipv4Addr {
+        const MESSAGE_PROTOCOL: Protocol = Protocol::ICMP;
+    }
+
+    impl Ip for super::Ipv6Addr {
+        const MESSAGE_PROTOCOL: Protocol = Protocol::ICMPv6;
+    }
 }
 /// A marker trait for IP addresses of a concrete protocol version.
 ///
@@ -176,206 +186,145 @@ impl<T: ConcreteIpAddr> FiniteResource for NatPool<T> {
 
 /// A NAT pool mapping provided for Source NAT (only outbound connections).
 #[derive(Clone)]
-pub struct SNat {
-    priv_ip: Ipv4Addr,
-    ip_pool: Arc<NatPool<Ipv4Addr>>,
+pub struct SNat<T: ConcreteIpAddr> {
+    priv_ip: T,
+    ip_pool: Arc<NatPool<T>>,
 }
 
-impl SNat {
-    pub fn new(addr: Ipv4Addr, ip_pool: Arc<NatPool<Ipv4Addr>>) -> Self {
-        SNat { priv_ip: addr, ip_pool }
-    }
+enum GenIcmpErr<T: Display> {
+    MetaNotFound,
+    NotRequest(T),
+}
 
-    // A helper method for generating an SNAT + ICMP action descriptor.
-    fn gen_icmp_desc(
-        &self,
-        nat: NatPoolEntry<Ipv4Addr>,
-        pkt: &Packet<Parsed>,
-    ) -> GenDescResult {
-        let meta = pkt.meta();
-
-        if let Some(icmp) = meta.inner_icmp() {
-            if icmp.msg_type != Icmpv4Message::EchoRequest.into() {
-                return Err(GenDescError::Unexpected {
-                    msg: format!(
-                        "Expected ICMP Echo Request, found: {}",
-                        icmp.msg_type,
-                    ),
-                });
-            }
-
-            // Panic: We know this is safe because we make it here
-            // only if this ICMP message is an Echo Request.
-            let echo_ident = icmp.echo_id().unwrap();
-
-            let desc = SNatIcmpEchoDesc {
-                pool: self.ip_pool.clone(),
-                priv_ip: self.priv_ip,
-                nat,
-                echo_ident,
-            };
-
-            Ok(AllowOrDeny::Allow(Arc::new(desc)))
-        } else {
-            Err(GenDescError::Unexpected {
-                msg: "No ICMP metadata found despite Protocol::ICMP"
-                    .to_string(),
-            })
+impl<T: Display> From<GenIcmpErr<T>> for GenDescError {
+    fn from(val: GenIcmpErr<T>) -> Self {
+        GenDescError::Unexpected {
+            msg: match val {
+                GenIcmpErr::MetaNotFound => {
+                    "No ICMP metadata found despite Protocol::ICMP".to_string()
+                }
+                GenIcmpErr::NotRequest(v) => {
+                    format!("Expected ICMP Echo Request, found: {}", v)
+                }
+            },
         }
     }
 }
 
-impl Display for SNat {
+impl<T: ConcreteIpAddr + 'static> SNat<T> {
+    pub fn new(addr: T, ip_pool: Arc<NatPool<T>>) -> Self {
+        SNat { priv_ip: addr, ip_pool }
+    }
+
+    // A helper method for generating an SNAT + ICMP(v6) action descriptor.
+    fn gen_icmp_desc(
+        &self,
+        nat: NatPoolEntry<T>,
+        pkt: &Packet<Parsed>,
+    ) -> GenDescResult {
+        let meta = pkt.meta();
+
+        let echo_ident = match T::MESSAGE_PROTOCOL {
+            Protocol::ICMP => {
+                let icmp = meta
+                    .inner_icmp()
+                    .ok_or(GenIcmpErr::<Icmpv4Message>::MetaNotFound)?;
+                if icmp.msg_type != Icmpv4Message::EchoRequest.into() {
+                    Err(GenIcmpErr::NotRequest(icmp.msg_type))?;
+                }
+
+                icmp.echo_id()
+            }
+            Protocol::ICMPv6 => {
+                let icmp6 = meta
+                    .inner_icmp6()
+                    .ok_or(GenIcmpErr::<Icmpv6Message>::MetaNotFound)?;
+                if icmp6.msg_type != Icmpv6Message::EchoRequest.into() {
+                    Err(GenIcmpErr::NotRequest(icmp6.msg_type))?;
+                }
+
+                icmp6.echo_id()
+            }
+            _ => Err(GenDescError::Unexpected {
+                msg:
+                    "Mistakenly called gen_icmp_desc on non Protocol::ICMP(v6)."
+                        .to_string(),
+            })?,
+        }
+        .ok_or(GenDescError::Unexpected {
+            msg: "No ICMP(v6) echo ID found in metadata".to_string(),
+        })?;
+
+        let desc = SNatIcmpEchoDesc {
+            pool: self.ip_pool.clone(),
+            priv_ip: self.priv_ip,
+            nat,
+            echo_ident,
+        };
+
+        Ok(AllowOrDeny::Allow(Arc::new(desc)))
+    }
+}
+
+impl Display for SNat<Ipv4Addr> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (pub_ip, ports) = self.ip_pool.mapping(self.priv_ip).unwrap();
         write!(f, "{}:{}-{}", pub_ip, ports.start(), ports.end())
     }
 }
 
-impl StatefulAction for SNat {
-    fn gen_desc(
-        &self,
-        flow_id: &InnerFlowId,
-        pkt: &Packet<Parsed>,
-        _meta: &mut ActionMeta,
-    ) -> GenDescResult {
-        let pool = &self.ip_pool;
-        let priv_port = flow_id.src_port;
-        match pool.obtain(&self.priv_ip) {
-            Ok(nat) => match flow_id.proto {
-                Protocol::ICMP => self.gen_icmp_desc(nat, pkt),
-
-                _ => {
-                    let desc = SNatDesc {
-                        pool: pool.clone(),
-                        priv_ip: self.priv_ip,
-                        priv_port,
-                        nat,
-                    };
-
-                    Ok(AllowOrDeny::Allow(Arc::new(desc)))
-                }
-            },
-
-            Err(ResourceError::Exhausted) => {
-                Err(GenDescError::ResourceExhausted {
-                    name: "SNAT Pool (exhausted)".to_string(),
-                })
-            }
-
-            Err(ResourceError::NoMatch(ip)) => Err(GenDescError::Unexpected {
-                msg: format!("SNAT pool (no match: {})", ip),
-            }),
-        }
-    }
-
-    // XXX we should be able to set implicit predicates if we add an
-    // IpCidr field to describe which subnet the client is on; but for
-    // now just keep the predicates fully explicit.
-    fn implicit_preds(&self) -> (Vec<Predicate>, Vec<DataPredicate>) {
-        (vec![], vec![])
-    }
-}
-
-#[derive(Clone)]
-pub struct SNat6 {
-    priv_ip: Ipv6Addr,
-    ip_pool: Arc<NatPool<Ipv6Addr>>,
-}
-
-impl SNat6 {
-    pub fn new(addr: Ipv6Addr, ip_pool: Arc<NatPool<Ipv6Addr>>) -> Self {
-        SNat6 { priv_ip: addr, ip_pool }
-    }
-
-    // A helper method for generating an SNAT + ICMP action descriptor.
-    fn gen_icmp_desc(
-        &self,
-        nat: NatPoolEntry<Ipv6Addr>,
-        pkt: &Packet<Parsed>,
-    ) -> GenDescResult {
-        let meta = pkt.meta();
-
-        if let Some(icmp) = meta.inner_icmp6() {
-            if icmp.msg_type != Icmpv6Message::EchoRequest.into() {
-                return Err(GenDescError::Unexpected {
-                    msg: format!(
-                        "Expected ICMP Echo Request, found: {}",
-                        icmp.msg_type,
-                    ),
-                });
-            }
-
-            // Panic: We know this is safe because we make it here
-            // only if this ICMP message is an Echo Request.
-            let echo_ident = icmp.echo_id().unwrap();
-
-            let desc = SNatIcmpEchoDesc {
-                pool: self.ip_pool.clone(),
-                priv_ip: self.priv_ip,
-                nat,
-                echo_ident,
-            };
-
-            Ok(AllowOrDeny::Allow(Arc::new(desc)))
-        } else {
-            Err(GenDescError::Unexpected {
-                msg: "No ICMP metadata found despite Protocol::ICMP"
-                    .to_string(),
-            })
-        }
-    }
-}
-
-impl StatefulAction for SNat6 {
-    fn gen_desc(
-        &self,
-        flow_id: &InnerFlowId,
-        pkt: &Packet<Parsed>,
-        _meta: &mut ActionMeta,
-    ) -> GenDescResult {
-        let pool = &self.ip_pool;
-        let priv_port = flow_id.src_port;
-        match pool.obtain(&self.priv_ip) {
-            Ok(nat) => match flow_id.proto {
-                Protocol::ICMPv6 => self.gen_icmp_desc(nat, pkt),
-
-                _ => {
-                    let desc = SNatDesc {
-                        pool: pool.clone(),
-                        priv_ip: self.priv_ip,
-                        priv_port,
-                        nat,
-                    };
-
-                    Ok(AllowOrDeny::Allow(Arc::new(desc)))
-                }
-            },
-
-            Err(ResourceError::Exhausted) => {
-                Err(GenDescError::ResourceExhausted {
-                    name: "SNAT Pool (exhausted)".to_string(),
-                })
-            }
-
-            Err(ResourceError::NoMatch(ip)) => Err(GenDescError::Unexpected {
-                msg: format!("SNAT pool (no match: {})", ip),
-            }),
-        }
-    }
-
-    // XXX we should be able to set implicit predicates if we add an
-    // IpCidr field to describe which subnet the client is on; but for
-    // now just keep the predicates fully explicit.
-    fn implicit_preds(&self) -> (Vec<Predicate>, Vec<DataPredicate>) {
-        (vec![], vec![])
-    }
-}
-
-impl Display for SNat6 {
+impl Display for SNat<Ipv6Addr> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (pub_ip, ports) = self.ip_pool.mapping(self.priv_ip).unwrap();
         write!(f, "[{}]:{}-{}", pub_ip, ports.start(), ports.end())
+    }
+}
+
+impl<T: ConcreteIpAddr + 'static> StatefulAction for SNat<T>
+where
+    SNat<T>: Display,
+{
+    fn gen_desc(
+        &self,
+        flow_id: &InnerFlowId,
+        pkt: &Packet<Parsed>,
+        _meta: &mut ActionMeta,
+    ) -> GenDescResult {
+        let pool = &self.ip_pool;
+        let priv_port = flow_id.src_port;
+        match pool.obtain(&self.priv_ip) {
+            Ok(nat) if flow_id.proto == T::MESSAGE_PROTOCOL => {
+                self.gen_icmp_desc(nat, pkt)
+            }
+
+            Ok(nat) => {
+                let desc = SNatDesc {
+                    pool: pool.clone(),
+                    priv_ip: self.priv_ip,
+                    priv_port,
+                    nat,
+                };
+
+                Ok(AllowOrDeny::Allow(Arc::new(desc)))
+            }
+
+            Err(ResourceError::Exhausted) => {
+                Err(GenDescError::ResourceExhausted {
+                    name: "SNAT Pool (exhausted)".to_string(),
+                })
+            }
+
+            Err(ResourceError::NoMatch(ip)) => Err(GenDescError::Unexpected {
+                msg: format!("SNAT pool (no match: {})", ip),
+            }),
+        }
+    }
+
+    // XXX we should be able to set implicit predicates if we add an
+    // IpCidr field to describe which subnet the client is on; but for
+    // now just keep the predicates fully explicit.
+    fn implicit_preds(&self) -> (Vec<Predicate>, Vec<DataPredicate>) {
+        (vec![], vec![])
     }
 }
 
@@ -454,6 +403,8 @@ pub struct SNatIcmpEchoDesc<T: ConcreteIpAddr> {
 pub const SNAT_ICMP_ECHO_NAME: &str = "SNAT_ICMP_ECHO";
 
 impl<T: ConcreteIpAddr> ActionDesc for SNatIcmpEchoDesc<T> {
+    // SNAT needs to generate a payload transform for ICMP traffic in
+    // order to treat the Echo Identifier as a psuedo ULP port.
     fn gen_ht(&self, dir: Direction) -> HdrTransform {
         match dir {
             // Outbound traffic needs its source IP rewritten, and its
@@ -491,8 +442,6 @@ impl<T: ConcreteIpAddr> ActionDesc for SNatIcmpEchoDesc<T> {
         }
     }
 
-    // SNAT needs to generate a payload transform for ICMP traffic in
-    // order to treat the Echo Identifier as a psuedo ULP port.
     fn gen_bt(
         &self,
         _dir: Direction,

--- a/lib/opte/src/engine/snat.rs
+++ b/lib/opte/src/engine/snat.rs
@@ -230,26 +230,26 @@ impl<T: ConcreteIpAddr + 'static> SNat<T> {
                     .inner_icmp()
                     .ok_or(GenIcmpErr::<Icmpv4Message>::MetaNotFound)?;
                 if icmp.msg_type != Icmpv4Message::EchoRequest.into() {
-                    Err(GenIcmpErr::NotRequest(icmp.msg_type))?;
+                    Err(GenIcmpErr::NotRequest(icmp.msg_type).into())
+                } else {
+                    Ok(icmp.echo_id())
                 }
-
-                icmp.echo_id()
             }
             Protocol::ICMPv6 => {
                 let icmp6 = meta
                     .inner_icmp6()
                     .ok_or(GenIcmpErr::<Icmpv6Message>::MetaNotFound)?;
                 if icmp6.msg_type != Icmpv6Message::EchoRequest.into() {
-                    Err(GenIcmpErr::NotRequest(icmp6.msg_type))?;
+                    Err(GenIcmpErr::NotRequest(icmp6.msg_type).into())
+                } else {
+                    Ok(icmp6.echo_id())
                 }
-
-                icmp6.echo_id()
             }
             _ => Err(GenDescError::Unexpected {
                 msg: "Mistakenly called gen_icmp_desc on non ICMP(v6)."
                     .to_string(),
-            })?,
-        }
+            }),
+        }?
         .ok_or(GenDescError::Unexpected {
             msg: "No ICMP(v6) echo ID found in metadata".to_string(),
         })?;

--- a/lib/oxide-vpc/src/api.rs
+++ b/lib/oxide-vpc/src/api.rs
@@ -248,6 +248,15 @@ impl VpcCfg {
     }
 
     #[cfg(any(feature = "test-help", test))]
+    pub fn ipv6(&self) -> &Ipv6Cfg {
+        match &self.ip_cfg {
+            IpCfg::Ipv6(ipv6) | IpCfg::DualStack { ipv6, .. } => ipv6,
+
+            _ => panic!("expected an IPv6 configuration"),
+        }
+    }
+
+    #[cfg(any(feature = "test-help", test))]
     /// Return the physical address of the guest.
     pub fn phys_addr(&self) -> PhysNet {
         PhysNet { ether: self.guest_mac, ip: self.phys_ip, vni: self.vni }

--- a/lib/oxide-vpc/src/api.rs
+++ b/lib/oxide-vpc/src/api.rs
@@ -249,11 +249,7 @@ impl VpcCfg {
 
     #[cfg(any(feature = "test-help", test))]
     pub fn ipv6(&self) -> &Ipv6Cfg {
-        match &self.ip_cfg {
-            IpCfg::Ipv6(ipv6) | IpCfg::DualStack { ipv6, .. } => ipv6,
-
-            _ => panic!("expected an IPv6 configuration"),
-        }
+        self.ipv6_cfg().expect("expected an IPv6 configuration")
     }
 
     #[cfg(any(feature = "test-help", test))]

--- a/lib/oxide-vpc/src/engine/nat.rs
+++ b/lib/oxide-vpc/src/engine/nat.rs
@@ -32,7 +32,6 @@ use opte::engine::rule::Action;
 use opte::engine::rule::Rule;
 use opte::engine::snat::NatPool;
 use opte::engine::snat::SNat;
-use opte::engine::snat::SNat6;
 
 pub const NAT_LAYER_NAME: &str = "nat";
 const ONE_TO_ONE_NAT_PRIORITY: u16 = 10;
@@ -153,7 +152,7 @@ fn setup_ipv6_nat(
             snat_cfg.external_ip,
             snat_cfg.ports.clone(),
         );
-        let snat = SNat6::new(ip_cfg.private_ip, Arc::new(pool));
+        let snat = SNat::new(ip_cfg.private_ip, Arc::new(pool));
         let mut rule =
             Rule::new(SNAT_PRIORITY, Action::Stateful(Arc::new(snat)));
 

--- a/lib/oxide-vpc/tests/common/icmp.rs
+++ b/lib/oxide-vpc/tests/common/icmp.rs
@@ -68,6 +68,28 @@ pub fn gen_icmpv4_echo_req(
 pub fn gen_icmp_echo_reply(
     eth_src: MacAddr,
     eth_dst: MacAddr,
+    ip_src: IpAddr,
+    ip_dst: IpAddr,
+    ident: u16,
+    seq_no: u16,
+    data: &[u8],
+    segments: usize,
+) -> Packet<Parsed> {
+    match (ip_src, ip_dst) {
+        (IpAddr::Ip4(src), IpAddr::Ip4(dst)) => gen_icmpv4_echo_reply(
+            eth_src, eth_dst, src, dst, ident, seq_no, data, segments,
+        ),
+        (IpAddr::Ip6(src), IpAddr::Ip6(dst)) => gen_icmpv6_echo_reply(
+            eth_src, eth_dst, src, dst, ident, seq_no, data, segments,
+        ),
+        (_, _) => panic!("IP src and dst versions must match"),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn gen_icmpv4_echo_reply(
+    eth_src: MacAddr,
+    eth_dst: MacAddr,
     ip_src: Ipv4Addr,
     ip_dst: Ipv4Addr,
     ident: u16,
@@ -160,10 +182,49 @@ pub fn gen_icmpv6_echo_req(
     data: &[u8],
     segments: usize,
 ) -> Packet<Parsed> {
-    let req = Icmpv6Repr::EchoRequest { ident, seq_no, data };
-    let mut body_bytes = vec![0u8; req.buffer_len()];
+    let etype = IcmpEchoType::Req;
+    gen_icmpv6_echo(
+        etype, eth_src, eth_dst, ip_src, ip_dst, ident, seq_no, data, segments,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn gen_icmpv6_echo_reply(
+    eth_src: MacAddr,
+    eth_dst: MacAddr,
+    ip_src: Ipv6Addr,
+    ip_dst: Ipv6Addr,
+    ident: u16,
+    seq_no: u16,
+    data: &[u8],
+    segments: usize,
+) -> Packet<Parsed> {
+    let etype = IcmpEchoType::Reply;
+    gen_icmpv6_echo(
+        etype, eth_src, eth_dst, ip_src, ip_dst, ident, seq_no, data, segments,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn gen_icmpv6_echo(
+    etype: IcmpEchoType,
+    eth_src: MacAddr,
+    eth_dst: MacAddr,
+    ip_src: Ipv6Addr,
+    ip_dst: Ipv6Addr,
+    ident: u16,
+    seq_no: u16,
+    data: &[u8],
+    segments: usize,
+) -> Packet<Parsed> {
+    let icmp = match etype {
+        IcmpEchoType::Req => Icmpv6Repr::EchoRequest { ident, seq_no, data },
+        IcmpEchoType::Reply => Icmpv6Repr::EchoReply { ident, seq_no, data },
+    };
+
+    let mut body_bytes = vec![0u8; icmp.buffer_len()];
     let mut req_pkt = Icmpv6Packet::new_unchecked(&mut body_bytes);
-    req.emit(
+    icmp.emit(
         &Ipv6Address::from_bytes(&ip_src).into(),
         &Ipv6Address::from_bytes(&ip_dst).into(),
         &mut req_pkt,
@@ -175,13 +236,13 @@ pub fn gen_icmpv6_echo_req(
         proto: Protocol::ICMPv6,
         next_hdr: IpProtocol::Icmpv6,
         hop_limit: 64,
-        pay_len: req.buffer_len() as u16,
+        pay_len: icmp.buffer_len() as u16,
         ..Default::default()
     };
     let eth =
         &EtherMeta { dst: eth_dst, src: eth_src, ether_type: EtherType::Ipv6 };
 
-    let total_len = EtherHdr::SIZE + ip6.hdr_len() + req.buffer_len();
+    let total_len = EtherHdr::SIZE + ip6.hdr_len() + icmp.buffer_len();
 
     match segments {
         1 => {

--- a/lib/oxide-vpc/tests/integration_tests.rs
+++ b/lib/oxide-vpc/tests/integration_tests.rs
@@ -998,7 +998,7 @@ fn unpack_and_verify_icmp(
             assert_eq!(IpAddr::from(meta.dst), dst_ip);
             assert_eq!(meta.proto, Protocol::ICMP);
 
-            unpack_and_verify_icmp4(&pkt, ident, seq_no, encapped, body_seg);
+            unpack_and_verify_icmp4(pkt, ident, seq_no, encapped, body_seg);
         }
         (IpAddr::Ip6(_), IpMeta::Ip6(meta)) => {
             assert_eq!(eth.ether_type, EtherType::Ipv6);
@@ -1007,7 +1007,7 @@ fn unpack_and_verify_icmp(
             assert_eq!(meta.proto, Protocol::ICMPv6);
 
             unpack_and_verify_icmp6(
-                &pkt, ident, seq_no, encapped, body_seg, meta.src, meta.dst,
+                pkt, ident, seq_no, encapped, body_seg, meta.src, meta.dst,
             );
         }
         (IpAddr::Ip4(_), ip6) => {
@@ -1167,7 +1167,7 @@ fn snat_icmp_shared_echo_rewrite(dst_ip: IpAddr) {
         g1_cfg.guest_mac,
         g1_cfg.gateway_mac,
         private_ip,
-        dst_ip.into(),
+        dst_ip,
         ident,
         seq_no,
         &data[..],


### PR DESCRIPTION
This PR takes advantage of the extra plumbing added in #408 to add ICMP Echo ID/SNAT port substitution to ICMPv6, allowing `ping` to function for IPv6 hosts/VMs without ephemeral IPs. This follows on from how ICMP v4 and v6 are both now treated as full ULPs, and makes use of the newer `icmp_id` header transform.

Additionally, there's some amount of cleanup done here. Now that we can handle these protocols identically, OPTE folds `SNat` and `SNat6` into a single `SNat<T: ConcreteIpAddr>` -- this lets us remove a lot of duplicated code between V4 and V6 impls of e.g. `ActionDesc`.

Closes #411.