### PR TITLE
Add `last_hit` to uft hit/expire probes, prevent `Moment` time delta wrapping

### DIFF
--- a/dtrace/opte-flow-expire.d
+++ b/dtrace/opte-flow-expire.d
@@ -8,7 +8,8 @@
 #include "common.h"
 #include "protos.d"
 
-#define	HDR_FMT "%-24s %-18s %s %s %s\n"
+#define	HDR_FMT		"%-24s %-18s %s %s %s\n"
+#define	LINE_FMT	"%-24s %-18s %s %u %u\n"
 
 BEGIN {
 	printf(HDR_FMT, "PORT", "FT NAME", "FLOW", "LAST_HIT", "NOW");
@@ -19,8 +20,8 @@ flow-expired {
 	this->port = stringof(arg0);
 	this->name = stringof(arg1);
 	this->flow = (flow_id_sdt_arg_t *)arg2;
-	this->last_hit = stringof(arg3);
-	this->now = stringof(arg4);
+	this->last_hit = arg3;
+	this->now = arg4;
 
 	if (num >= 10) {
 		printf(HDR_FMT, "PORT", "FT NAME", "FLOW", "LAST_HIT", "NOW");
@@ -36,13 +37,13 @@ flow-expired {
 
 flow-expired /this->af == AF_INET/ {
 	FLOW_FMT(this->s, this->flow);
-	printf(HDR_FMT, this->port, this->name, this->s, this->last_hit, this->now);
+	printf(LINE_FMT, this->port, this->name, this->s, this->last_hit, this->now);
 	num++;
 }
 
 flow-expired /this->af == AF_INET6/ {
 	FLOW_FMT6(this->s, this->flow);
-	printf(HDR_FMT, this->port, this->name, this->s, this->last_hit, this->now);
+	printf(LINE_FMT, this->port, this->name, this->s, this->last_hit, this->now);
 	num++;
 }
 

--- a/dtrace/opte-flow-expire.d
+++ b/dtrace/opte-flow-expire.d
@@ -8,10 +8,10 @@
 #include "common.h"
 #include "protos.d"
 
-#define	HDR_FMT "%-24s %-18s %s\n"
+#define	HDR_FMT "%-24s %-18s %s %s %s\n"
 
 BEGIN {
-	printf(HDR_FMT, "PORT", "FT NAME", "FLOW");
+	printf(HDR_FMT, "PORT", "FT NAME", "FLOW", "LAST_HIT", "NOW");
 	num = 0;
 }
 
@@ -19,9 +19,11 @@ flow-expired {
 	this->port = stringof(arg0);
 	this->name = stringof(arg1);
 	this->flow = (flow_id_sdt_arg_t *)arg2;
+	this->last_hit = stringof(arg3);
+	this->now = stringof(arg4);
 
 	if (num >= 10) {
-		printf(HDR_FMT, "PORT", "FT NAME", "FLOW");
+		printf(HDR_FMT, "PORT", "FT NAME", "FLOW", "LAST_HIT", "NOW");
 		num = 0;
 	}
 
@@ -34,13 +36,13 @@ flow-expired {
 
 flow-expired /this->af == AF_INET/ {
 	FLOW_FMT(this->s, this->flow);
-	printf(HDR_FMT, this->port, this->name, this->s);
+	printf(HDR_FMT, this->port, this->name, this->s, this->last_hit, this->now);
 	num++;
 }
 
 flow-expired /this->af == AF_INET6/ {
 	FLOW_FMT6(this->s, this->flow);
-	printf(HDR_FMT, this->port, this->name, this->s);
+	printf(HDR_FMT, this->port, this->name, this->s, this->last_hit, this->now);
 	num++;
 }
 

--- a/dtrace/opte-uft-hit.d
+++ b/dtrace/opte-uft-hit.d
@@ -8,11 +8,11 @@
 #include "common.h"
 #include "protos.d"
 
-#define	HDR_FMT		"%-8s %-3s %-43s %s\n"
-#define	LINE_FMT	"%-8s %-3s %-43s %u\n"
+#define	HDR_FMT		"%-8s %-3s %-43s %s %s\n"
+#define	LINE_FMT	"%-8s %-3s %-43s %u %u\n"
 
 BEGIN {
-	printf(HDR_FMT, "PORT", "DIR", "FLOW", "EPOCH");
+	printf(HDR_FMT, "PORT", "DIR", "FLOW", "EPOCH", "LAST_HIT");
 	num = 0;
 }
 
@@ -22,9 +22,10 @@ uft-hit {
 	this->flow = (flow_id_sdt_arg_t *)arg2;
 	this->epoch = arg3;
 	this->af = this->flow->af;
+	this->last_hit = arg4;
 
 	if (num >= 10) {
-		printf(HDR_FMT, "PORT", "DIR", "FLOW", "EPOCH");
+		printf(HDR_FMT, "PORT", "DIR", "FLOW", "EPOCH", "LAST_HIT");
 		num = 0;
 	}
 
@@ -35,13 +36,13 @@ uft-hit {
 
 uft-hit /this->af == AF_INET/ {
 	FLOW_FMT(this->s, this->flow);
-	printf(LINE_FMT, this->port, this->dir, this->s, this->epoch);
+	printf(LINE_FMT, this->port, this->dir, this->s, this->epoch, this->last_hit);
 	num++;
 }
 
 uft-hit /this->af == AF_INET6/ {
 	FLOW_FMT6(this->s, this->flow);
-	printf(LINE_FMT, this->port, this->dir, this->s, this->epoch);
+	printf(LINE_FMT, this->port, this->dir, this->s, this->epoch, this->last_hit);
 	num++;
 }
 

--- a/dtrace/usdt-opte-flow-expire.d
+++ b/dtrace/usdt-opte-flow-expire.d
@@ -6,7 +6,7 @@
 #define	HDR_FMT "%-24s %-18s %s\n"
 
 BEGIN {
-	printf(HDR_FMT, "PORT", "FT NAME", "FLOW");
+	printf(HDR_FMT, "PORT", "FT NAME", "FLOW", "LAST_HIT", "NOW");
 	num = 0;
 }
 
@@ -14,6 +14,8 @@ flow-expired {
 	this->port = copyinstr(arg0);
 	this->layer = copyinstr(arg1);
 	this->flow = copyinstr(arg2);
+	this->last_hit = stringof(arg3);
+	this->now = stringof(arg4);
 
-	printf(HDR_FMT, this->port, this->layer, this->flow);
+	printf(HDR_FMT, this->port, this->layer, this->flow, this->last_hit, this->now);
 }

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -118,7 +118,7 @@ where
     }
 
     pub fn expire(&mut self, flowid: &InnerFlowId) {
-        flow_expired_probe(&self.port_c, &self.name_c, flowid);
+        flow_expired_probe(&self.port_c, &self.name_c, flowid, None, None);
         self.map.remove(flowid);
     }
 
@@ -133,7 +133,13 @@ where
 
         self.map.retain(|flowid, entry| {
             if entry.is_expired(now, ttl) {
-                flow_expired_probe(port_c, name_c, flowid);
+                flow_expired_probe(
+                    port_c,
+                    name_c,
+                    flowid,
+                    Some(entry.last_hit),
+                    Some(now),
+                );
                 expired.push(f(entry.state()));
                 return false;
             }
@@ -206,7 +212,15 @@ where
     }
 }
 
-fn flow_expired_probe(port: &CString, name: &CString, flowid: &InnerFlowId) {
+#[allow(unused_variables)]
+fn flow_expired_probe(
+    port: &CString,
+    name: &CString,
+    flowid: &InnerFlowId,
+    last_hit: Option<Moment>,
+    now: Option<Moment>,
+) {
+    last_hit.unwrap_or_default();
     cfg_if! {
         if #[cfg(all(not(feature = "std"), not(test)))] {
             let arg = flow_id_sdt_arg::from(flowid);
@@ -216,6 +230,8 @@ fn flow_expired_probe(port: &CString, name: &CString, flowid: &InnerFlowId) {
                     port.as_ptr() as uintptr_t,
                     name.as_ptr() as uintptr_t,
                     &arg as *const flow_id_sdt_arg as uintptr_t,
+                    last_hit.and_then(Moment::raw_millis).unwrap_or_default(),
+                    now.and_then(Moment::raw_millis).unwrap_or_default(),
                 );
             }
         } else if #[cfg(feature = "usdt")] {
@@ -223,7 +239,7 @@ fn flow_expired_probe(port: &CString, name: &CString, flowid: &InnerFlowId) {
             let port_s = port.to_str().unwrap();
             let name_s = name.to_str().unwrap();
             crate::opte_provider::flow__expired!(
-                || (port_s, name_s, flowid.to_string())
+                || (port_s, name_s, flowid.to_string(), 0, 0)
             );
         } else {
             let (_, _, _) = (port, name, flowid);
@@ -308,6 +324,8 @@ extern "C" {
         port: uintptr_t,
         layer: uintptr_t,
         flowid: uintptr_t,
+        last_hit: uintptr_t,
+        now: uintptr_t,
     );
 
     pub fn __dtrace_probe_ft__entry__invalidated(

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -230,8 +230,8 @@ fn flow_expired_probe(
                     port.as_ptr() as uintptr_t,
                     name.as_ptr() as uintptr_t,
                     &arg as *const flow_id_sdt_arg as uintptr_t,
-                    last_hit.and_then(Moment::raw_millis).unwrap_or_default(),
-                    now.and_then(Moment::raw_millis).unwrap_or_default(),
+                    last_hit.and_then(|m| m.raw_millis()).unwrap_or_default() as usize,
+                    now.and_then(|m| m.raw_millis()).unwrap_or_default() as usize,
                 );
             }
         } else if #[cfg(feature = "usdt")] {

--- a/lib/opte/src/engine/port.rs
+++ b/lib/opte/src/engine/port.rs
@@ -1718,7 +1718,14 @@ impl<N: NetworkImpl> Port<N> {
         }
     }
 
-    fn uft_hit_probe(&self, dir: Direction, ufid: &InnerFlowId, epoch: u64) {
+    #[allow(unused_variables)]
+    fn uft_hit_probe(
+        &self,
+        dir: Direction,
+        ufid: &InnerFlowId,
+        epoch: u64,
+        last_hit: &Moment,
+    ) {
         cfg_if::cfg_if! {
             if #[cfg(all(not(feature = "std"), not(test)))] {
                 let ufid_arg = flow_id_sdt_arg::from(ufid);
@@ -1729,13 +1736,14 @@ impl<N: NetworkImpl> Port<N> {
                         self.name_cstr.as_ptr() as uintptr_t,
                         &ufid_arg as *const flow_id_sdt_arg as uintptr_t,
                         epoch as uintptr_t,
+                        last_hit.raw_millis()
                     );
                 }
             } else if #[cfg(feature = "usdt")] {
                 let port_s = self.name_cstr.to_str().unwrap();
                 let ufid_s = ufid.to_string();
                 crate::opte_provider::uft__hit!(
-                    || (dir, port_s, ufid_s, epoch)
+                    || (dir, port_s, ufid_s, epoch, 0)
                 );
             } else {
                 let (_, _, _) = (dir, ufid, epoch);
@@ -1763,7 +1771,7 @@ impl<N: NetworkImpl> Port<N> {
                 // for lookup.
                 entry.hit();
                 data.stats.vals.in_uft_hit += 1;
-                self.uft_hit_probe(In, pkt.flow(), epoch);
+                self.uft_hit_probe(In, pkt.flow(), epoch, entry.last_hit());
 
                 for ht in &entry.state().xforms.hdr {
                     pkt.hdr_transform(ht)?;
@@ -2066,7 +2074,7 @@ impl<N: NetworkImpl> Port<N> {
             Some(entry) if entry.state().epoch == epoch => {
                 entry.hit();
                 data.stats.vals.out_uft_hit += 1;
-                self.uft_hit_probe(Out, pkt.flow(), epoch);
+                self.uft_hit_probe(Out, pkt.flow(), epoch, entry.last_hit());
 
                 let mut invalidated = false;
                 let mut ufid_in = None;

--- a/lib/opte/src/engine/port.rs
+++ b/lib/opte/src/engine/port.rs
@@ -1736,7 +1736,7 @@ impl<N: NetworkImpl> Port<N> {
                         self.name_cstr.as_ptr() as uintptr_t,
                         &ufid_arg as *const flow_id_sdt_arg as uintptr_t,
                         epoch as uintptr_t,
-                        last_hit.raw_millis()
+                        last_hit.raw_millis().unwrap_or_default() as usize
                     );
                 }
             } else if #[cfg(feature = "usdt")] {
@@ -2459,6 +2459,7 @@ extern "C" {
         port: uintptr_t,
         ifid: uintptr_t,
         epoch: uintptr_t,
+        last_hit: uintptr_t,
     );
     pub fn __dtrace_probe_uft__invalidate(
         dir: uintptr_t,

--- a/lib/opte/src/lib.rs
+++ b/lib/opte/src/lib.rs
@@ -65,10 +65,24 @@ pub const fn bit_on(bit: u8) -> u8 {
 mod opte_provider {
     use opte_api::Direction;
 
-    fn uft__hit(dir: Direction, port: &str, flow: &str, epoch: u64) {}
+    fn uft__hit(
+        dir: Direction,
+        port: &str,
+        flow: &str,
+        epoch: u64,
+        last_hit: u64,
+    ) {
+    }
     fn uft__invalidate(dir: Direction, port: &str, flow: &str, epoch: u64) {}
     fn uft__tcp__closed(dir: Direction, port: &str, flow: &str) {}
-    fn flow__expired(port: &str, ft_name: &str, flow: &str) {}
+    fn flow__expired(
+        port: &str,
+        ft_name: &str,
+        flow: &str,
+        last_hit: u64,
+        now: u64,
+    ) {
+    }
     fn gen__desc__fail(
         port: &str,
         layer: &str,


### PR DESCRIPTION
Adds some extra probes to help us track down and verify #426, and also
slightly changes up `Moment::delta_as_millis()` to saturate if the order
if `now` and `earlier` are seemingly back to front (as is apparently
now standard behaviour in std).