### PR TITLE
Move `Moment::now()` into lock for UFT expiry

### DIFF
--- a/lib/oxide-vpc/tests/integration_tests.rs
+++ b/lib/oxide-vpc/tests/integration_tests.rs
@@ -261,10 +261,7 @@ fn port_transition_pause() {
     // Verify that APIs which modify state are not allowed.
     // ================================================================
     assert!(matches!(g2.port.clear_uft(), Err(OpteError::BadState(_))));
-    assert!(matches!(
-        g2.port.expire_flows(Moment::now()),
-        Err(OpteError::BadState(_))
-    ));
+    assert!(matches!(g2.port.expire_flows(), Err(OpteError::BadState(_))));
     // This exercises Port::remove_rule().
     assert!(matches!(
         router::del_entry(
@@ -1966,11 +1963,13 @@ fn flow_expiration() {
     // ================================================================
     // Verify expiration
     // ================================================================
-    g1.port.expire_flows(now + Duration::new(FLOW_DEF_EXPIRE_SECS, 0)).unwrap();
+    g1.port
+        .expire_flows_at(now + Duration::new(FLOW_DEF_EXPIRE_SECS, 0))
+        .unwrap();
     assert_port!(g1);
 
     g1.port
-        .expire_flows(now + Duration::new(FLOW_DEF_EXPIRE_SECS + 1, 0))
+        .expire_flows_at(now + Duration::new(FLOW_DEF_EXPIRE_SECS + 1, 0))
         .unwrap();
     zero_flows!(g1);
 }

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -54,7 +54,6 @@ use opte::ddi::sync::KMutexType;
 use opte::ddi::sync::KRwLock;
 use opte::ddi::sync::KRwLockType;
 use opte::ddi::time::Interval;
-use opte::ddi::time::Moment;
 use opte::ddi::time::Periodic;
 use opte::engine::ether::EtherAddr;
 use opte::engine::geneve::Vni;
@@ -563,7 +562,7 @@ fn expire_periodic(port: &mut Arc<Port<VpcNetwork>>) {
     // ignore the error. Eventually xde will also have logic for
     // moving a port to a paused state, and in that state the periodic
     // should probably be canceled.
-    let _ = port.expire_flows(Moment::now());
+    let _ = port.expire_flows();
 }
 
 #[no_mangle]


### PR DESCRIPTION
Closes #426. #427 had already patched over this behaviour by preventing wrap on timestamp comparison, but now we can be certain that this is the race window which was being hit.