### PR TITLE
TCP flow state refactor and fixes

### DIFF
--- a/lib/opte/src/engine/port.rs
+++ b/lib/opte/src/engine/port.rs
@@ -845,7 +845,6 @@ impl<N: NetworkImpl> Port<N> {
         }
     }
 
-    #[allow(unused_variables)]
     fn tcp_err_probe(
         &self,
         dir: Direction,
@@ -874,7 +873,7 @@ impl<N: NetworkImpl> Port<N> {
                     || (dir, &self.name, flow_s, mblk_addr, &msg)
                 );
             } else {
-                let (..) = (dir, pkt, msg);
+                let (..) = (dir, pkt, msg, flow, mblk_addr);
             }
         }
     }

--- a/lib/opte/src/engine/port.rs
+++ b/lib/opte/src/engine/port.rs
@@ -845,6 +845,7 @@ impl<N: NetworkImpl> Port<N> {
         }
     }
 
+    #[allow(unused_variables)]
     fn tcp_err_probe(
         &self,
         dir: Direction,

--- a/lib/opte/src/engine/tcp.rs
+++ b/lib/opte/src/engine/tcp.rs
@@ -8,6 +8,7 @@
 
 use super::checksum::Checksum;
 use super::checksum::HeaderChecksum;
+use super::flow_table::Ttl;
 use super::headers::HeaderActionModify;
 use super::headers::ModifyAction;
 use super::headers::PushAction;
@@ -31,6 +32,24 @@ pub const TCP_HDR_OFFSET_SHIFT: u8 = 4;
 
 pub const TCP_PORT_RDP: u16 = 3389;
 pub const TCP_PORT_SSH: u16 = 22;
+
+/// The duration after which a connection in TIME-WAIT should be
+/// considered free for either side to reuse.
+///
+/// This value is chosen by Windows and MacOS, which is larger
+/// than Linux's default 60s. Allowances for tuned servers and/or
+/// more aggressive reuse via RFCs 1323/7323 and/or 6191 are made in
+/// `tcp_state`.
+pub const TIME_WAIT_EXPIRE_SECS: u64 = 120;
+/// The duration after which otherwise healthy TCP flows should be pruned.
+///
+/// Currently, this is tuned to be 2.5 hours: higher than the default behaviour
+/// for SO_KEEPALIVE on linux/illumos. Each will wait 2 hours before sending a
+/// keepalive, when interval + probe count will result in a timeout after
+/// 8mins (illumos) / 11mins (linux).
+pub const KEEPALIVE_EXPIRE_SECS: u64 = 8_000;
+pub const TIME_WAIT_EXPIRE_TTL: Ttl = Ttl::new_seconds(TIME_WAIT_EXPIRE_SECS);
+pub const KEEPALIVE_EXPIRE_TTL: Ttl = Ttl::new_seconds(KEEPALIVE_EXPIRE_SECS);
 
 /// The standard TCP flags. We don't bother with the experimental NS
 /// flag.

--- a/lib/oxide-vpc/tests/common/mod.rs
+++ b/lib/oxide-vpc/tests/common/mod.rs
@@ -546,7 +546,7 @@ pub fn http_syn2(
     eth_dst: MacAddr,
     ip_dst: impl Into<IpAddr>,
 ) -> Packet<Parsed> {
-    http_syn3(eth_src, ip_src, eth_dst, ip_dst, 44490)
+    http_syn3(eth_src, ip_src, eth_dst, ip_dst, 44490, 80)
 }
 
 pub fn http_syn3(
@@ -555,6 +555,7 @@ pub fn http_syn3(
     eth_dst: MacAddr,
     ip_dst: impl Into<IpAddr>,
     sport: u16,
+    dport: u16,
 ) -> Packet<Parsed> {
     let body = vec![];
     let mut options = [0x00; TcpHdr::MAX_OPTION_SIZE];
@@ -576,7 +577,7 @@ pub fn http_syn3(
 
     let tcp = TcpMeta {
         src: sport,
-        dst: 80,
+        dst: dport,
         flags: TcpFlags::SYN,
         seq: 2382112979,
         ack: 0,

--- a/lib/oxide-vpc/tests/integration_tests.rs
+++ b/lib/oxide-vpc/tests/integration_tests.rs
@@ -3602,17 +3602,6 @@ fn tcp_outbound() {
     .unwrap();
     incr!(g1, ["epoch", "router.rules.out"]);
 
-    let bs_phys = TestIpPhys {
-        ip: g1_cfg.boundary_services.ip,
-        mac: g1_cfg.boundary_services.mac,
-        vni: g1_cfg.boundary_services.vni,
-    };
-    let g1_phys = TestIpPhys {
-        ip: g1_cfg.phys_ip,
-        mac: g1_cfg.guest_mac,
-        vni: g1_cfg.vni,
-    };
-
     // ================================================================
     // Main test on an HTTP flow.
     // ================================================================
@@ -3674,17 +3663,6 @@ fn early_tcp_invalidation() {
     .unwrap();
     incr!(g1, ["epoch", "router.rules.out"]);
 
-    let bs_phys = TestIpPhys {
-        ip: g1_cfg.boundary_services.ip,
-        mac: g1_cfg.boundary_services.mac,
-        vni: g1_cfg.boundary_services.vni,
-    };
-    let g1_phys = TestIpPhys {
-        ip: g1_cfg.phys_ip,
-        mac: g1_cfg.guest_mac,
-        vni: g1_cfg.vni,
-    };
-
     // ================================================================
     // Setup TIME_WAIT state.
     // ================================================================
@@ -3711,7 +3689,6 @@ fn early_tcp_invalidation() {
             "stats.port.out_uft_hit",
         ]
     );
-    let snat_port = pkt1.meta().inner.ulp.unwrap().src_port().unwrap();
     assert_eq!(TcpState::SynSent, g1.port.tcp_state(&flow).unwrap());
 
     // ================================================================


### PR DESCRIPTION
This PR introduces two key changes to how we handle TCP flows, and refactors to give us some more consistency between how they're handled by {in, out}bound packets when we {do, don't} have an existing UFT entry.

### 1. Time-based flow expiry for TCP flows.
At present, TCP sessions which have been passive-closed by the guest are correctly moved to the CLOSED state and removed, while those which are active-closed become stuck in a TIME_WAIT state.

To remedy this, we add two fairly pessimistic cleanup timers: 120s for TIME-WAIT, and 2.5 hours for other states (the default 2 hour SO_KEEPALIVE time with a fudge factor). The CLOSED -> ESTABLISHED shortcut should allow an entry to be readded with shorter timers, however we might in future store more detailed flow state which would be lost with a shorter timeout.

### 2. Allow unexpected segments and reset flow stats when needed.
Existing TCP flows will no longer filter any packets which would correspond to unexpected state transitions, and instead fire a dtrace probe.

However, to keep stats consistent we have to do some more work to invalidate flows if we see an unexpected *SYN*-flagged packet. The main value of this is that if our flow state tracking is affected by out-of-order delivery, we can no longer be stuck in `Established` as in #442, but this also allows port reuse faster than every 120s (which is the other component of #436).

---

Should close #436 and close #442.