### PR TITLE
Add Xtask for XDE build/install/package operations

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/.github/buildomat/jobs/opte-api.sh
+++ b/.github/buildomat/jobs/opte-api.sh
@@ -3,7 +3,7 @@
 #: name = "opte-api"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly-2023-10-23"
+#: rust_toolchain = "nightly-2024-02-06"
 #: output_rules = []
 #:
 
@@ -24,7 +24,7 @@ header "check API_VERSION"
 ./check-api-version.sh
 
 header "check style"
-ptime -m cargo +nightly-2023-10-23 fmt -- --check
+ptime -m cargo +nightly-2024-02-06 fmt -- --check
 
 header "analyze std"
 ptime -m cargo clippy --all-targets

--- a/.github/buildomat/jobs/opte-ioctl.sh
+++ b/.github/buildomat/jobs/opte-ioctl.sh
@@ -3,7 +3,7 @@
 #: name = "opte-ioctl"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly-2023-10-23"
+#: rust_toolchain = "nightly-2024-02-06"
 #: output_rules = []
 #:
 
@@ -21,7 +21,7 @@ rustc --version
 cd lib/opte-ioctl
 
 header "check style"
-ptime -m cargo +nightly-2023-10-23 fmt -- --check
+ptime -m cargo +nightly-2024-02-06 fmt -- --check
 
 header "analyze"
 ptime -m cargo clippy --all-targets

--- a/.github/buildomat/jobs/opte.sh
+++ b/.github/buildomat/jobs/opte.sh
@@ -3,7 +3,7 @@
 #: name = "opte"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly-2023-10-23"
+#: rust_toolchain = "nightly-2024-02-06"
 #: output_rules = []
 #:
 
@@ -21,7 +21,7 @@ rustc --version
 cd lib/opte
 
 header "check style"
-ptime -m cargo +nightly-2023-10-23 fmt -- --check
+ptime -m cargo +nightly-2024-02-06 fmt -- --check
 
 header "check docs"
 #
@@ -30,13 +30,13 @@ header "check docs"
 #
 # Use nightly which is needed for the `kernel` feature.
 RUSTDOCFLAGS="-D warnings" ptime -m \
-	    cargo +nightly-2023-10-23 doc --no-default-features --features=api,std,engine,kernel
+	    cargo +nightly-2024-02-06 doc --no-default-features --features=api,std,engine,kernel
 
 header "analyze std + api"
 ptime -m cargo clippy --all-targets
 
 header "analyze no_std + engine + kernel"
-ptime -m cargo +nightly-2023-10-23 clippy --no-default-features --features engine,kernel
+ptime -m cargo +nightly-2024-02-06 clippy --no-default-features --features engine,kernel
 
 header "test"
 ptime -m cargo test

--- a/.github/buildomat/jobs/opteadm.sh
+++ b/.github/buildomat/jobs/opteadm.sh
@@ -3,7 +3,7 @@
 #: name = "opteadm"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly-2023-10-23"
+#: rust_toolchain = "nightly-2024-02-06"
 #: output_rules = [
 #:   "=/work/debug/opteadm",
 #:   "=/work/debug/opteadm.debug.sha256",
@@ -26,7 +26,7 @@ rustc --version
 pushd bin/opteadm
 
 header "check style"
-ptime -m cargo +nightly-2023-10-23 fmt -- --check
+ptime -m cargo +nightly-2024-02-06 fmt -- --check
 
 header "analyze"
 ptime -m cargo clippy --all-targets

--- a/.github/buildomat/jobs/oxide-vpc.sh
+++ b/.github/buildomat/jobs/oxide-vpc.sh
@@ -3,7 +3,7 @@
 #: name = "oxide-vpc"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly-2023-10-23"
+#: rust_toolchain = "nightly-2024-02-06"
 #: output_rules = []
 #:
 
@@ -21,7 +21,7 @@ rustc --version
 cd lib/oxide-vpc
 
 header "check style"
-ptime -m cargo +nightly-2023-10-23 fmt -- --check
+ptime -m cargo +nightly-2024-02-06 fmt -- --check
 
 header "check docs"
 #
@@ -30,13 +30,13 @@ header "check docs"
 #
 # Use nightly which is needed for the `kernel` feature.
 RUSTDOCFLAGS="-D warnings" ptime -m \
-	    cargo +nightly-2023-10-23 doc --no-default-features --features=api,std,engine,kernel
+	    cargo +nightly-2024-02-06 doc --no-default-features --features=api,std,engine,kernel
 
 header "analyze std + api + usdt"
 ptime -m cargo clippy --features usdt --all-targets
 
 header "analyze no_std + engine + kernel"
-ptime -m cargo +nightly-2023-10-23 clippy --no-default-features --features engine,kernel
+ptime -m cargo +nightly-2024-02-06 clippy --no-default-features --features engine,kernel
 
 header "test"
 ptime -m cargo test

--- a/.github/buildomat/jobs/p5p.sh
+++ b/.github/buildomat/jobs/p5p.sh
@@ -63,5 +63,5 @@ banner copy
 pfexec mkdir -p /out
 pfexec chown "$UID" /out
 PKG_NAME="/out/opte.p5p"
-mv packages/repo/*.p5p "$PKG_NAME"
+mv pkg/packages/repo/*.p5p "$PKG_NAME"
 sha256sum "$PKG_NAME" > "$PKG_NAME.sha256"

--- a/.github/buildomat/jobs/p5p.sh
+++ b/.github/buildomat/jobs/p5p.sh
@@ -44,10 +44,8 @@ function header {
 cargo --version
 rustc --version
 
-pushd xde
-header "build xde (release)"
-ptime -m ./build.sh
-popd
+header "build xde and opteadm (release+debug)"
+ptime -m cargo xtask build
 
 #
 # Inspect the kernel module for bad relocations in case the old
@@ -58,12 +56,8 @@ if elfdump $REL_SRC/xde | grep GOTPCREL; then
 	exit 1
 fi
 
-pushd bin/opteadm
-cargo build --release
-popd
-
-pushd pkg
-./build.sh
+header "package opte"
+cargo xtask package --skip-build
 
 banner copy
 pfexec mkdir -p /out

--- a/.github/buildomat/jobs/p5p.sh
+++ b/.github/buildomat/jobs/p5p.sh
@@ -3,7 +3,7 @@
 #: name = "opte-p5p"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly-2023-10-23"
+#: rust_toolchain = "nightly-2024-02-06"
 #: output_rules = [
 #:   "=/out/opte.p5p",
 #:   "=/out/opte.p5p.sha256",

--- a/.github/buildomat/jobs/xde.sh
+++ b/.github/buildomat/jobs/xde.sh
@@ -3,7 +3,7 @@
 #: name = "opte-xde"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly-2023-10-23"
+#: rust_toolchain = "nightly-2024-02-06"
 #: output_rules = [
 #:   "=/work/debug/xde.dbg",
 #:   "=/work/debug/xde.dbg.sha256",
@@ -75,7 +75,7 @@ pushd xde
 cp xde.conf /work/xde.conf
 
 header "check style"
-ptime -m cargo +nightly-2023-10-23 fmt -p xde -p xde-link -- --check
+ptime -m cargo +nightly-2024-02-06 fmt -p xde -p xde-link -- --check
 
 header "analyze"
 ptime -m cargo clippy -- \
@@ -123,7 +123,7 @@ sha256sum $REL_TGT/xde_link.so > $REL_TGT/xde_link.so.sha256
 
 header "build xde integration tests"
 pushd xde-tests
-cargo +nightly-2023-10-23 fmt -- --check
+cargo +nightly-2024-02-06 fmt -- --check
 cargo clippy --all-targets
 cargo build --test loopback
 loopback_test=$(

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,7 +1062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -1277,6 +1277,15 @@ checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
  "serde",
 ]
 
@@ -1583,10 +1592,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.21.0",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -1595,6 +1619,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -1933,6 +1970,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +224,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -438,6 +471,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +699,12 @@ dependencies = [
  "libc",
  "redox_syscall",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -1123,6 +1172,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.38.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
+dependencies = [
+ "bitflags 2.4.2",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1238,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1398,6 +1469,16 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1843,6 +1924,15 @@ dependencies = [
  "slog-term",
  "zone",
  "ztest",
+]
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ slog-term = "2.9"
 smoltcp = { version = "0.11", default-features = false }
 syn = "2"
 thiserror = "1.0"
+toml = "0.8"
 usdt = "0.5"
 version_check = "0.9"
 zerocopy = { version = "0.7", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "xde",
   "xde/xde-link",
   "xde-tests",
+  "xtask",
 ]
 default-members = [
   "bin/*",
@@ -34,8 +35,9 @@ oxide-vpc = { path = "lib/oxide-vpc", default-features = false }
 # External dependencies
 anyhow = "1.0"
 bitflags = "2"
+cargo_metadata = "0.18"
 cfg-if = "1"
-clap = { version = "4", features = ["derive", "string"] }
+clap = { version = "4", features = ["derive", "string", "wrap_help"] }
 crc32fast = { version = "1", default-features = false }
 ctor = "0.2"
 dyn-clone = "1.0"

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,10 @@
 = Oxide Packet Transformation Engine
 
+== Installation
+On helios systems, OPTE can be built and installed using the `cargo xtask install` command.
+
+For ease of development, the above command will bypass `pkg`. OPTE can instead be installed from a new IPS package using `cargo xtask install --from-package`, which may require the `--force-package-unfreeze` flag if OPTE has been installed as a prerequisite for omicron.
+
 == Contributing
 
 Please see the xref:CONTRIBUTING.adoc[CONTRIBUTING] doc if you are

--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -21,12 +21,9 @@ cp ../target/i686-unknown-illumos/release/libxde_link.so proto/usr/lib/devfsadm/
 if [ -z ${RELEASE_ONLY+x} ]; then
     cp ../target/debug/opteadm proto/opt/oxide/opte/bin/opteadm.dbg
     cp ../target/x86_64-unknown-unknown/debug/xde.dbg proto/kernel/drv/amd64/xde.dbg
+    INC_DEBUG=""
 else
-    # A bit of a hack for local release-only pkg builds.
-    # There are probably pkgmogrify transforms to do this correctly,
-    # based on RELEASE_ONLY!
-    cp proto/opt/oxide/opte/bin/opteadm proto/opt/oxide/opte/bin/opteadm.dbg
-    cp proto/kernel/drv/amd64/xde proto/kernel/drv/amd64/xde.dbg
+    INC_DEBUG="#"
 fi
 
 API_VSN=$(./print-api-version.sh)
@@ -35,7 +32,7 @@ API_VSN=$(./print-api-version.sh)
 sed -e "s/%PUBLISHER%/$PUBLISHER/g" \
     -e "s/%COMMIT_COUNT%/$COMMIT_COUNT/g" \
     -e "s/%API_VSN%/$API_VSN/g" \
-    opte.template.p5m | pkgmogrify -v -O opte.base.p5m
+    opte.template.p5m | pkgmogrify -v -D inc_debug="$INC_DEBUG" -O opte.base.p5m
 
 pkgdepend generate -d proto opte.base.p5m > opte.generate.p5m
 

--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -14,9 +14,20 @@ mkdir -p proto/kernel/drv/amd64
 mkdir -p proto/opt/oxide/opte/bin
 mkdir -p proto/usr/lib/devfsadm/linkmod
 cp ../target/release/opteadm proto/opt/oxide/opte/bin/
-cp ../target/x86_64-unknown-unknown/release/xde proto/kernel/drv/amd64/xde
+cp ../target/x86_64-unknown-unknown/release/xde proto/kernel/drv/amd64
 cp ../xde/xde.conf proto/kernel/drv/
 cp ../target/i686-unknown-illumos/release/libxde_link.so proto/usr/lib/devfsadm/linkmod/SUNW_xde_link.so
+
+if [ -z ${RELEASE_ONLY+x} ]; then
+    cp ../target/debug/opteadm proto/opt/oxide/opte/bin/opteadm.dbg
+    cp ../target/x86_64-unknown-unknown/debug/xde.dbg proto/kernel/drv/amd64/xde.dbg
+else
+    # A bit of a hack for local release-only pkg builds.
+    # There are probably pkgmogrify transforms to do this correctly,
+    # based on RELEASE_ONLY!
+    cp proto/opt/oxide/opte/bin/opteadm proto/opt/oxide/opte/bin/opteadm.dbg
+    cp proto/kernel/drv/amd64/xde proto/kernel/drv/amd64/xde.dbg
+fi
 
 API_VSN=$(./print-api-version.sh)
 

--- a/pkg/opte.template.p5m
+++ b/pkg/opte.template.p5m
@@ -22,23 +22,9 @@ dir path=usr/lib/devfsadm owner=root group=sys mode=0755
 dir path=usr/lib/devfsadm/linkmod owner=root group=sys mode=0755
 file path=usr/lib/devfsadm/linkmod/SUNW_xde_link.so owner=root group=sys mode=0755
 
-# XXX the bypasses below are a hack, but idk what the right thing to do is.
-# Without the bypass this happens
-#:
-#:  + pkgdepend resolve -d packages -s resolve.p5m opte.generate.p5m
-#:  /home/ry/src/opte/pkg/opte.generate.p5m has unresolved dependency '
-#:     depend type=require fmri=__TBD pkg.debug.depend.file=mac \
-#:         pkg.debug.depend.reason=kernel/drv/amd64/xde \
-#:         pkg.debug.depend.type=elf \
-#:         pkg.debug.depend.path=kernel/drv/amd64 \
-#:         pkg.debug.depend.path=usr/kernel/drv/amd64
-#:  ' under the following combinations of variants:
-#:  variant.opensolaris.zone:global
-#:
 file path=kernel/drv/amd64/xde owner=root group=sys mode=0755 \
     variant.debug.illumos=false \
     variant.opensolaris.zone=global
-
 $(inc_debug)file kernel/drv/amd64/xde.dbg path=kernel/drv/amd64/xde owner=root group=sys mode=0755 \
     variant.debug.illumos=true \
     variant.opensolaris.zone=global

--- a/pkg/opte.template.p5m
+++ b/pkg/opte.template.p5m
@@ -13,7 +13,7 @@ dir path=opt/oxide/opte owner=root group=bin mode=0755
 dir path=opt/oxide/opte/bin owner=root group=bin mode=0755
 file path=opt/oxide/opte/bin/opteadm owner=root group=bin mode=0755 \
     variant.debug.illumos=false
-file opt/oxide/opte/bin/opteadm.dbg path=opt/oxide/opte/bin/opteadm owner=root group=bin mode=0755 \
+$(inc_debug)file opt/oxide/opte/bin/opteadm.dbg path=opt/oxide/opte/bin/opteadm owner=root group=bin mode=0755 \
     variant.debug.illumos=true
 dir path=kernel owner=root group=sys mode=0755
 dir path=kernel/drv owner=root group=sys mode=0755
@@ -40,7 +40,7 @@ file path=kernel/drv/amd64/xde owner=root group=sys mode=0755 \
     pkg.depend.bypass-generate=.*mac.* \
     variant.debug.illumos=false
 
-file kernel/drv/amd64/xde.dbg path=kernel/drv/amd64/xde owner=root group=sys mode=0755 \
+$(inc_debug)file kernel/drv/amd64/xde.dbg path=kernel/drv/amd64/xde owner=root group=sys mode=0755 \
     pkg.depend.bypass-generate=.*dld.* \
     pkg.depend.bypass-generate=.*mac.* \
     variant.debug.illumos=true

--- a/pkg/opte.template.p5m
+++ b/pkg/opte.template.p5m
@@ -6,11 +6,15 @@ set name=info.classification \
     value=org.opensolaris.category.2008:Drivers/Networking
 set name=variant.opensolaris.zone value=global
 set name=variant.arch value=i386
+set name=variant.debug.illumos value=false value=true
 dir path=opt owner=root group=sys mode=0755
 dir path=opt/oxide owner=root group=bin mode=0755
 dir path=opt/oxide/opte owner=root group=bin mode=0755
 dir path=opt/oxide/opte/bin owner=root group=bin mode=0755
-file path=opt/oxide/opte/bin/opteadm owner=root group=bin mode=0755
+file path=opt/oxide/opte/bin/opteadm owner=root group=bin mode=0755 \
+    variant.debug.illumos=false
+file opt/oxide/opte/bin/opteadm.dbg path=opt/oxide/opte/bin/opteadm owner=root group=bin mode=0755 \
+    variant.debug.illumos=true
 dir path=kernel owner=root group=sys mode=0755
 dir path=kernel/drv owner=root group=sys mode=0755
 file path=kernel/drv/xde.conf owner=root group=sys mode=0644 preserve=renamenew
@@ -33,5 +37,12 @@ file path=usr/lib/devfsadm/linkmod/SUNW_xde_link.so owner=root group=sys mode=07
 #:
 file path=kernel/drv/amd64/xde owner=root group=sys mode=0755 \
     pkg.depend.bypass-generate=.*dld.* \
-    pkg.depend.bypass-generate=.*mac.*
+    pkg.depend.bypass-generate=.*mac.* \
+    variant.debug.illumos=false
+
+file kernel/drv/amd64/xde.dbg path=kernel/drv/amd64/xde owner=root group=sys mode=0755 \
+    pkg.depend.bypass-generate=.*dld.* \
+    pkg.depend.bypass-generate=.*mac.* \
+    variant.debug.illumos=true
+
 driver name=xde

--- a/pkg/opte.template.p5m
+++ b/pkg/opte.template.p5m
@@ -4,7 +4,7 @@ set name=pkg.fmri \
 set name=pkg.summary value="The Oxide Packet Transformation Engine"
 set name=info.classification \
     value=org.opensolaris.category.2008:Drivers/Networking
-set name=variant.opensolaris.zone value=global
+set name=variant.opensolaris.zone value=global value=nonglobal
 set name=variant.arch value=i386
 set name=variant.debug.illumos value=false value=true
 dir path=opt owner=root group=sys mode=0755
@@ -36,13 +36,11 @@ file path=usr/lib/devfsadm/linkmod/SUNW_xde_link.so owner=root group=sys mode=07
 #:  variant.opensolaris.zone:global
 #:
 file path=kernel/drv/amd64/xde owner=root group=sys mode=0755 \
-    pkg.depend.bypass-generate=.*dld.* \
-    pkg.depend.bypass-generate=.*mac.* \
-    variant.debug.illumos=false
+    variant.debug.illumos=false \
+    variant.opensolaris.zone=global
 
 $(inc_debug)file kernel/drv/amd64/xde.dbg path=kernel/drv/amd64/xde owner=root group=sys mode=0755 \
-    pkg.depend.bypass-generate=.*dld.* \
-    pkg.depend.bypass-generate=.*mac.* \
-    variant.debug.illumos=true
+    variant.debug.illumos=true \
+    variant.opensolaris.zone=global
 
 driver name=xde

--- a/xde/build-debug.sh
+++ b/xde/build-debug.sh
@@ -5,11 +5,10 @@ DBG_DIR=../target/x86_64-unknown-unknown/debug/
 cargo -v build
 
 ld -ztype=kmod \
-   -N"drv/mac" \
+   -N"drv/dld" \
    -N"drv/ip" \
-   -N"misc/mac" \
    -N"misc/dls" \
-   -N"misc/dld" \
+   -N"misc/mac" \
    -z allextract $DBG_DIR/xde.a \
    -o $DBG_DIR/xde.dbg
 

--- a/xde/build.sh
+++ b/xde/build.sh
@@ -7,11 +7,10 @@ REL_DIR=../target/x86_64-unknown-unknown/release/
 cargo -v build --release
 
 ld -ztype=kmod \
-   -N"drv/mac" \
+   -N"drv/dld" \
    -N"drv/ip" \
-   -N"misc/mac" \
    -N"misc/dls" \
-   -N"misc/dld" \
+   -N"misc/mac" \
    -z allextract $REL_DIR/xde.a \
    -o $REL_DIR/xde
 

--- a/xde/rust-toolchain.toml
+++ b/xde/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-10-23"
+channel = "nightly-2024-02-06"
 target = "x86_64-unknown-illumos"
 components = [ "clippy", "rustfmt", "rust-src" ]
 profile = "minimal"

--- a/xde/x86_64-unknown-unknown.json
+++ b/xde/x86_64-unknown-unknown.json
@@ -16,7 +16,6 @@
     "linker": "ld",
     "llvm-target": "x86_64-none-none",
     "max-atomic-width": 64,
-    "needs-plt": true,
     "no-default-libraries": true,
     "os": "none",
     "panic-strategy": "abort",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,3 +11,4 @@ repository.workspace = true
 anyhow.workspace = true
 cargo_metadata.workspace = true
 clap.workspace = true
+toml.workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow.workspace = true
+cargo_metadata.workspace = true
+clap.workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,315 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2024 Oxide Computer Company
+
+use anyhow::Context;
+use anyhow::Result;
+use cargo_metadata::Metadata;
+use clap::Args;
+use clap::Parser;
+use std::io::Write;
+use std::process::Command;
+use std::sync::OnceLock;
+
+static METADATA: OnceLock<Metadata> = OnceLock::new();
+fn cargo_meta() -> &'static Metadata {
+    METADATA
+        .get_or_init(|| cargo_metadata::MetadataCommand::new().exec().unwrap())
+}
+
+const KMOD_TARGET: &str = "x86_64-unknown-unknown";
+
+/// Development functions for OPTE.
+#[derive(Debug, Parser)]
+enum Xtask {
+    Build(BuildOptions),
+
+    /// Build and install the XDE kernel driver.
+    Install {
+        /// Install from an illumos package file rather than ...
+        #[arg(long)]
+        from_package: bool,
+
+        /// Skips building opteadm and XDE.
+        #[arg(long)]
+        skip_build: bool,
+
+        #[command(flatten)]
+        build: BuildOptions,
+    },
+
+    /// Build the XDE kernel driver and produce an illumos package.
+    Package {
+        #[command(flatten)]
+        build: BuildOptions,
+
+        /// Skips building opteadm and XDE.
+        #[arg(long)]
+        skip_build: bool,
+    },
+}
+
+#[derive(Debug, Args)]
+struct BuildOptions {
+    /// Disable building/packaging debug bits for both `opteadm`
+    /// and the XDE module.
+    #[arg(long)]
+    release_only: bool,
+}
+
+fn main() -> anyhow::Result<()> {
+    let cmd = Xtask::parse();
+    // TODO: gate some of these to illumos only.
+    match cmd {
+        Xtask::Build(b) => cmd_build(b.release_only),
+        Xtask::Install { from_package, skip_build, build } => {
+            if !skip_build {
+                cmd_build(!from_package || build.release_only)?;
+            }
+
+            if !elevate(
+                "install xde kernel module",
+                if skip_build { &[] } else { &["--skip-build"] },
+            )? {
+                return Ok(());
+            }
+
+            if from_package {
+                cmd_package(build.release_only)?;
+            } else {
+                raw_install()?;
+            }
+
+            Ok(())
+        }
+        Xtask::Package { build, skip_build } => {
+            if !skip_build {
+                cmd_build(build.release_only)?;
+            }
+
+            cmd_package(build.release_only)
+        }
+    }
+}
+
+fn elevate(operation: &str, extra_args: &[&str]) -> Result<bool> {
+    let curr_user_run = Command::new("whoami").output()?;
+    if !curr_user_run.status.success() {
+        let as_utf = std::str::from_utf8(&curr_user_run.stderr);
+        anyhow::bail!("Failed to get current user: {:?}", as_utf);
+    }
+
+    match std::str::from_utf8(&curr_user_run.stdout) {
+        Ok("root\n") => Ok(true),
+        Ok(_) => {
+            print!("Command requires admin privileges to {operation}. Continue? [yY] ");
+            std::io::stdout().flush()?;
+
+            let mut resp = String::new();
+            std::io::stdin().read_line(&mut resp)?;
+            match resp.as_str() {
+                "y\n" | "Y\n" => {
+                    let my_args = std::env::args();
+                    let mut elevated = Command::new("pfexec")
+                        .args(my_args)
+                        .args(extra_args)
+                        .spawn()?;
+                    let exit_code = elevated.wait()?;
+                    std::process::exit(exit_code.code().unwrap_or(1));
+                }
+                _ => {
+                    println!("Exiting...")
+                }
+            }
+
+            Ok(false)
+        }
+        Err(_) => anyhow::bail!("`whoami` did not return a valid UTF user."),
+    }
+}
+
+fn cmd_build(release_only: bool) -> Result<()> {
+    let modes = if release_only { &[true][..] } else { &[true, false] };
+
+    for release_mode in modes {
+        BuildTarget::OpteAdm.build(*release_mode)?;
+        BuildTarget::Xde.build(*release_mode)?;
+    }
+
+    Ok(())
+}
+
+fn cmd_package(_release_only: bool) -> Result<()> {
+    let meta = cargo_meta();
+
+    // XXX: should this be RIIR'd?
+    Command::new("bash")
+        .arg("build.sh")
+        .current_dir(meta.workspace_root.join("pkg"))
+        .output_nocapture()?;
+
+    Ok(())
+}
+
+fn raw_install() -> Result<()> {
+    let meta = cargo_meta();
+
+    // NOTE: we don't need to actually check this one, it'll return a
+    // failure code even if we don't care about it.
+    Command::new("rem_drv").arg("xde").output()?;
+
+    let mut kmod_dir = meta.target_directory.clone();
+    kmod_dir.extend(&[KMOD_TARGET, "release", "xde"]);
+
+    let mut opteadm_dir = meta.target_directory.clone();
+    opteadm_dir.extend(&["release", "opteadm"]);
+
+    std::fs::copy(kmod_dir, "/kernel/drv/amd64/xde")?;
+    std::fs::copy(opteadm_dir, "/opt/oxide/opte/bin/opteadm")?;
+
+    // Probably shouldn't make a symlink here.
+    // std::os::unix::fs::symlink(original, link)
+
+    Ok(())
+}
+
+enum BuildTarget {
+    OpteAdm,
+    Xde,
+}
+
+fn build_cargo_bin(
+    target: &[&str],
+    release: bool,
+    cwd: Option<&str>,
+    current_cargo: bool,
+) -> Result<()> {
+    let meta = cargo_meta();
+
+    let mut dir = meta.workspace_root.clone();
+    if let Some(cwd) = cwd {
+        dir.push(cwd);
+    }
+
+    let mut command = if current_cargo {
+        let cargo =
+            std::env::var("CARGO").unwrap_or_else(|_| String::from("cargo"));
+        Command::new(&cargo)
+    } else {
+        Command::new("cargo")
+    };
+
+    command.arg("build");
+    command.args(target);
+    if release {
+        command.arg("--release");
+    }
+
+    let mut dir = meta.workspace_root.clone().into_std_path_buf();
+    if let Some(cwd) = cwd {
+        dir.push(cwd);
+    }
+
+    // XDE + XDE-link need to use nightly.
+    if !current_cargo {
+        command.env_remove("RUSTUP_TOOLCHAIN");
+    }
+
+    command.current_dir(dir);
+
+    command.output_nocapture().context(format!(
+        "failed to build {:?}",
+        if target.is_empty() {
+            cwd.unwrap_or("<unnamed>")
+        } else {
+            target[target.len() - 1]
+        }
+    ))
+}
+
+impl BuildTarget {
+    fn build(&self, debug: bool) -> Result<()> {
+        match self {
+            Self::OpteAdm => {
+                build_cargo_bin(&["--bin", "opteadm"], !debug, None, true)
+            }
+            Self::Xde => {
+                let meta = cargo_meta();
+                build_cargo_bin(&[], !debug, Some("xde"), false)?;
+
+                let (folder, out_name) = if debug {
+                    ("debug", "xde.dbg")
+                } else {
+                    ("release", "xde")
+                };
+                let target_dir = meta
+                    .target_directory
+                    .join(format!("{KMOD_TARGET}/{folder}"));
+
+                Command::new("ld")
+                    .args([
+                        "-ztype=kmod",
+                        r#"-N"drv/mac""#,
+                        r#"-N"drv/ip""#,
+                        r#"-N"misc/mac""#,
+                        r#"-N"misc/dls""#,
+                        r#"-N"misc/dld""#,
+                        "-z",
+                        "allextract",
+                        &format!("{target_dir}/xde.a"),
+                        "-o",
+                        &format!("{target_dir}/{out_name}"),
+                    ])
+                    .output_nocapture()
+                    .context("failed to link XDE kernel module")?;
+
+                build_cargo_bin(&[], !debug, Some("xde/xde-link"), false)?;
+
+                // verify no panicking in the devfsadm plugin?
+                let nm_output = Command::new("nm")
+                    .arg(meta.target_directory.join(format!(
+                        "i686-unknown-illumos/{folder}/libxde_link.so"
+                    )))
+                    .output()?;
+
+                if nm_output.status.success() {
+                    if std::str::from_utf8(&nm_output.stdout)?
+                        .contains("panicking")
+                    {
+                        anyhow::bail!("ERROR: devfsadm plugin may panic!")
+                    } else {
+                        Ok(())
+                    }
+                } else {
+                    anyhow::bail!("failed to run `nm`")
+                }
+            }
+        }
+    }
+}
+
+trait CommandNoCapture {
+    fn output_nocapture(&mut self) -> Result<()>;
+}
+
+impl CommandNoCapture for Command {
+    fn output_nocapture(&mut self) -> Result<()> {
+        let status = self
+            .spawn()
+            .context("failed to spawn child cargo invocation")?
+            .wait()
+            .context("failed to await child cargo invocation")?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            anyhow::bail!("failed to run (status {status})")
+        }
+    }
+}
+
+// fn cmd_build() -> Result<> {
+//     BuildTarget::OpteAdm.build()
+// }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -239,7 +239,7 @@ fn cmd_package(
         if release_only {
             cmd.env("RELEASE_ONLY", "1");
         }
-            
+
         cmd.arg("build.sh")
             .current_dir(meta.workspace_root.join(&pkg_dir))
             .output_nocapture()?;
@@ -375,11 +375,10 @@ impl BuildTarget {
                 Command::new("ld")
                     .args([
                         "-ztype=kmod",
-                        "-Ndrv/mac",
+                        "-Ndrv/dld",
                         "-Ndrv/ip",
-                        "-Nmisc/mac",
                         "-Nmisc/dls",
-                        "-Nmisc/dld",
+                        "-Nmisc/mac",
                         "-z",
                         "allextract",
                         &format!("{target_dir}/xde.a"),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -26,9 +26,10 @@ const LINK_TARGET: &str = "i686-unknown-illumos";
 /// Development functions for OPTE.
 #[derive(Debug, Parser)]
 enum Xtask {
+    /// Build the XDE kernel module.
     Build(BuildOptions),
 
-    /// Build and install the XDE kernel driver.
+    /// Build and install the XDE kernel module.
     Install {
         /// Install from an illumos package file rather than by copying
         /// the drivers into place.
@@ -49,7 +50,7 @@ enum Xtask {
         build: BuildOptions,
     },
 
-    /// Build the XDE kernel driver and produce an illumos package.
+    /// Build the XDE kernel module and produce an illumos package.
     Package {
         #[command(flatten)]
         build: BuildOptions,
@@ -231,17 +232,19 @@ fn cmd_package(
     let pkg_dir = meta.workspace_root.join("pkg");
 
     if do_package {
-        // XXX: should this be RIIR'd?
+        // XXX: I'm happy today for this to remain as a bash script,
+        //      given that it would be very verbose to xtask-ify.
         Command::new("bash")
             .arg("build.sh")
+            .env("RELEASE_ONLY", "1")
             .current_dir(meta.workspace_root.join(&pkg_dir))
             .output_nocapture()?;
     }
 
     // Find a matching p5p.
     // XXX: I appreciate we could simplify this by depending on
-    // opteadm as a lib, but then we have to work to make
-    // some subset of it compile on non-illumos platforms.
+    //      opteadm as a lib, but then we have to work to make
+    //      some subset of it compile on non-illumos platforms.
     let dir_entries = std::fs::read_dir(pkg_dir.join("packages/repo"))?;
     for entry in dir_entries {
         let entry = entry?;


### PR DESCRIPTION
This PR adds some `cargo xtask`s to build and install XDE and opteadm on a given host -- `cargo xtask {build, install, package}`. These include flags for `pkg`-based installation as well as a brute-force method which simply copies our artifacts into the right place.

I've also bumped the nightly toolchain used by XDE since it's been some time since we've done so, and added `cargo xtask fmt` to automatically format using the correct nightly toolchain.

Closes #413 and closes #366.