### PR TITLE
Use TabWriter for `opteadm` output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,7 @@ dependencies = [
  "anyhow",
  "cfg-if",
  "clap",
+ "itertools",
  "libc",
  "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys)",
  "opte",
@@ -867,6 +868,7 @@ dependencies = [
  "oxide-vpc",
  "postcard",
  "serde",
+ "tabwriter",
  "thiserror",
 ]
 
@@ -883,6 +885,7 @@ dependencies = [
  "poptrie",
  "serde",
  "smoltcp",
+ "tabwriter",
  "usdt",
  "zerocopy",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,7 @@ dependencies = [
  "postcard",
  "serde",
  "smoltcp",
+ "tabwriter",
  "usdt",
  "version_check",
  "zerocopy",
@@ -1390,6 +1391,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabwriter"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a327282c4f64f6dc37e3bba4c2b6842cc3a992f204fa58d917696a89f691e5f6"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1574,6 +1584,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "usdt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,6 @@ dependencies = [
  "anyhow",
  "cfg-if",
  "clap",
- "itertools",
  "libc",
  "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys)",
  "opte",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ slog-envlogger = "2.2"
 slog-term = "2.9"
 smoltcp = { version = "0.11", default-features = false }
 syn = "2"
+tabwriter = { version = "1", features = ["ansi_formatting"] }
 thiserror = "1.0"
 usdt = "0.5"
 version_check = "0.9"

--- a/bin/opteadm/Cargo.toml
+++ b/bin/opteadm/Cargo.toml
@@ -17,10 +17,12 @@ oxide-vpc = { workspace = true, features = ["api", "engine", "std"] }
 anyhow.workspace = true
 cfg-if.workspace = true
 clap.workspace = true
+itertools.workspace = true
 libc.workspace = true
 libnet.workspace = true
 postcard.workspace = true
 serde.workspace = true
+tabwriter.workspace = true
 thiserror.workspace = true
 
 [build-dependencies]

--- a/bin/opteadm/Cargo.toml
+++ b/bin/opteadm/Cargo.toml
@@ -17,7 +17,6 @@ oxide-vpc = { workspace = true, features = ["api", "engine", "std"] }
 anyhow.workspace = true
 cfg-if.workspace = true
 clap.workspace = true
-itertools.workspace = true
 libc.workspace = true
 libnet.workspace = true
 postcard.workspace = true

--- a/bin/opteadm/src/bin/opteadm.rs
+++ b/bin/opteadm/src/bin/opteadm.rs
@@ -520,7 +520,9 @@ fn main() -> anyhow::Result<()> {
         }
 
         Command::DumpLayer { port, name } => {
-            print_layer(&hdl.get_layer_by_name(&port, &name)?)?;
+            let resp = &hdl.get_layer_by_name(&port, &name)?;
+            print!("Port {port} - ");
+            print_layer(&resp)?;
         }
 
         Command::ClearUft { port } => {

--- a/bin/opteadm/src/bin/opteadm.rs
+++ b/bin/opteadm/src/bin/opteadm.rs
@@ -50,7 +50,9 @@ use oxide_vpc::engine::overlay::BOUNDARY_SERVICES_VNI;
 use oxide_vpc::engine::print::print_v2b;
 use oxide_vpc::engine::print::print_v2p;
 use std::io;
+use std::io::Write;
 use std::str::FromStr;
+use tabwriter::TabWriter;
 
 /// Administer the Oxide Packet Transformation Engine (OPTE)
 #[derive(Debug, Parser)]
@@ -422,11 +424,10 @@ fn opte_pkg_version() -> String {
     format!("{MAJOR_VERSION}.{API_VERSION}.{COMMIT_COUNT}")
 }
 
-// XXX: These are growing unwieldy to the point we might want an actual table
-//      pretty-printer for opte outputs.
-fn print_port_header() {
-    println!(
-        "{:<32} {:<24} {:<16} {:<16} {:<16} {:<40} {:<40} {:<40} {:<8}",
+fn print_port_header(t: &mut impl Write) -> std::io::Result<()> {
+    writeln!(
+        t,
+        "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
         "LINK",
         "MAC ADDRESS",
         "IPv4 ADDRESS",
@@ -436,13 +437,21 @@ fn print_port_header() {
         "EXTERNAL IPv6",
         "FLOATING IPv6",
         "STATE"
-    );
+    )
 }
 
-fn print_port(pi: PortInfo) {
-    let none = String::from("None");
-    println!(
-        "{:<32} {:<24} {:<16} {:<16} {:<16} {:<40} {:<40} {:<40} {:<8}",
+fn print_port(t: &mut impl Write, pi: PortInfo) -> std::io::Result<()> {
+    let none = "None".to_string();
+    let n_rows = pi
+        .floating_ip4_addrs
+        .as_ref()
+        .map(|v| v.len())
+        .unwrap_or(1)
+        .max(pi.floating_ip6_addrs.as_ref().map(|v| v.len()).unwrap_or(1));
+
+    writeln!(
+        t,
+        "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
         pi.name,
         pi.mac_addr.to_string(),
         pi.ip4_addr.map(|x| x.to_string()).unwrap_or_else(|| none.clone()),
@@ -450,25 +459,46 @@ fn print_port(pi: PortInfo) {
             .map(|x| x.to_string())
             .unwrap_or_else(|| none.clone()),
         pi.floating_ip4_addrs
-            .map(|vec| vec
-                .into_iter()
-                .map(|x| x.to_string())
-                .collect::<Vec<String>>()
-                .join(","))
+            .as_ref()
+            .and_then(|vec| vec.first())
+            .map(|x| x.to_string())
             .unwrap_or_else(|| none.clone()),
         pi.ip6_addr.map(|x| x.to_string()).unwrap_or_else(|| none.clone()),
         pi.ephemeral_ip6_addr
             .map(|x| x.to_string())
             .unwrap_or_else(|| none.clone()),
         pi.floating_ip6_addrs
-            .map(|vec| vec
-                .into_iter()
-                .map(|x| x.to_string())
-                .collect::<Vec<String>>()
-                .join(","))
+            .as_ref()
+            .and_then(|vec| vec.first())
+            .map(|x| x.to_string())
             .unwrap_or_else(|| none.clone()),
         pi.state,
-    );
+    )?;
+
+    for i in 1..n_rows {
+        writeln!(
+            t,
+            "\t\t\t\t{}\t\t\t{}\t",
+            pi.floating_ip4_addrs
+                .as_ref()
+                .and_then(|vec| vec.get(i))
+                .map(|x| x.to_string())
+                .unwrap_or_else(String::new),
+            pi.floating_ip6_addrs
+                .as_ref()
+                .and_then(|vec| vec.get(i))
+                .map(|x| x.to_string())
+                .unwrap_or_else(String::new),
+        )?;
+    }
+
+    if n_rows > 1 {
+        // This is required over a plain \n to preserve column alignment
+        // between all ports.
+        writeln!(t, "\t\t\t\t\t\t\t\t",)?;
+    }
+
+    Ok(())
 }
 
 fn main() -> anyhow::Result<()> {
@@ -477,18 +507,20 @@ fn main() -> anyhow::Result<()> {
 
     match cmd {
         Command::ListPorts => {
-            print_port_header();
+            let mut t = TabWriter::new(std::io::stdout());
+            print_port_header(&mut t)?;
             for p in hdl.list_ports()?.ports {
-                print_port(p);
+                print_port(&mut t, p)?;
             }
+            t.flush()?;
         }
 
         Command::ListLayers { port } => {
-            print_list_layers(&hdl.list_layers(&port)?);
+            print_list_layers(&hdl.list_layers(&port)?)?;
         }
 
         Command::DumpLayer { port, name } => {
-            print_layer(&hdl.get_layer_by_name(&port, &name)?);
+            print_layer(&hdl.get_layer_by_name(&port, &name)?)?;
         }
 
         Command::ClearUft { port } => {
@@ -501,20 +533,20 @@ fn main() -> anyhow::Result<()> {
         }
 
         Command::DumpUft { port } => {
-            print_uft(&hdl.dump_uft(&port)?);
+            print_uft(&hdl.dump_uft(&port)?)?;
         }
 
         Command::DumpTcpFlows { port } => {
-            print_tcp_flows(&hdl.dump_tcp_flows(&port)?);
+            print_tcp_flows(&hdl.dump_tcp_flows(&port)?)?;
         }
 
         Command::DumpV2P => {
-            print_v2p(&hdl.dump_v2p()?);
+            print_v2p(&hdl.dump_v2p()?)?;
         }
 
         Command::DumpV2B => {
             let hdl = opteadm::OpteAdm::open(OpteAdm::XDE_CTL)?;
-            print_v2b(&hdl.dump_v2b()?);
+            print_v2b(&hdl.dump_v2b()?)?;
         }
 
         Command::AddFwRule { port, direction, filters, action, priority } => {

--- a/lib/opte/Cargo.toml
+++ b/lib/opte/Cargo.toml
@@ -14,7 +14,7 @@ kernel = ["illumos-sys-hdrs/kernel"]
 # This feature indicates that OPTE is being built with std. This is
 # mostly useful to consumers of the API, providing convenient methods
 # for working with the API types in a std context.
-std = ["opte-api/std"]
+std = ["dep:tabwriter", "opte-api/std"]
 #
 # Used for declaring methods which are useful for integration testing.
 #
@@ -33,6 +33,7 @@ heapless = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
 postcard.workspace = true
 serde.workspace = true
+tabwriter = { workspace = true, optional = true }
 usdt = { workspace = true, optional = true }
 zerocopy = { workspace = true, optional = true }
 

--- a/lib/opte/src/engine/print.rs
+++ b/lib/opte/src/engine/print.rs
@@ -26,7 +26,15 @@ use tabwriter::TabWriter;
 
 /// Print a [`DumpLayerResp`].
 pub fn print_layer(resp: &DumpLayerResp) -> std::io::Result<()> {
-    let mut t = TabWriter::new(std::io::stdout());
+    print_layer_into(&mut std::io::stdout(), resp)
+}
+
+/// Print a [`DumpLayerResp`].
+pub fn print_layer_into(
+    writer: &mut impl Write,
+    resp: &DumpLayerResp,
+) -> std::io::Result<()> {
+    let mut t = TabWriter::new(writer);
 
     writeln!(t, "Layer {}", resp.name)?;
     write_hrb(&mut t)?;
@@ -70,7 +78,15 @@ pub fn print_layer(resp: &DumpLayerResp) -> std::io::Result<()> {
 
 /// Print a [`ListLayersResp`].
 pub fn print_list_layers(resp: &ListLayersResp) -> std::io::Result<()> {
-    let mut t = TabWriter::new(std::io::stdout());
+    print_list_layers_into(&mut std::io::stdout(), resp)
+}
+
+/// Print a [`ListLayersResp`] into a given writer.
+pub fn print_list_layers_into(
+    writer: &mut impl Write,
+    resp: &ListLayersResp,
+) -> std::io::Result<()> {
+    let mut t = TabWriter::new(writer);
     writeln!(t, "NAME\tRULES IN\tRULES OUT\tDEF IN\tDEF OUT\tFLOWS",)?;
 
     for desc in &resp.layers {
@@ -90,7 +106,15 @@ pub fn print_list_layers(resp: &ListLayersResp) -> std::io::Result<()> {
 
 /// Print a [`DumpUftResp`].
 pub fn print_uft(uft: &DumpUftResp) -> std::io::Result<()> {
-    let mut t = TabWriter::new(std::io::stdout());
+    print_uft_into(&mut std::io::stdout(), uft)
+}
+
+/// Print a [`DumpUftResp`] into a given writer.
+pub fn print_uft_into(
+    writer: &mut impl Write,
+    uft: &DumpUftResp,
+) -> std::io::Result<()> {
+    let mut t = TabWriter::new(writer);
 
     writeln!(t, "UFT Inbound: {}/{}", uft.in_num_flows, uft.in_limit)?;
     write_hr(&mut t)?;
@@ -221,7 +245,15 @@ pub fn print_uft_flow(
 
 /// Print a [`DumpTcpFlowsResp`].
 pub fn print_tcp_flows(flows: &DumpTcpFlowsResp) -> std::io::Result<()> {
-    let mut t = TabWriter::new(std::io::stdout());
+    print_tcp_flows_into(&mut std::io::stdout(), flows)
+}
+
+/// Print a [`DumpTcpFlowsResp`] into a given writer.
+pub fn print_tcp_flows_into(
+    writer: &mut impl Write,
+    flows: &DumpTcpFlowsResp,
+) -> std::io::Result<()> {
+    let mut t = TabWriter::new(writer);
 
     writeln!(t, "FLOW\tSTATE\tHITS\tSEGS IN\tSEGS OUT\tBYTES IN\tBYTES OUT")?;
     for (flow_id, entry) in &flows.flows {

--- a/lib/opte/src/engine/print.rs
+++ b/lib/opte/src/engine/print.rs
@@ -25,56 +25,53 @@ use std::string::ToString;
 use tabwriter::TabWriter;
 
 /// Print a [`DumpLayerResp`].
-pub fn print_layer(resp: &DumpLayerResp) {
+pub fn print_layer(resp: &DumpLayerResp) -> std::io::Result<()> {
     let mut t = TabWriter::new(std::io::stdout());
 
-    writeln!(t, "Layer {}", resp.name);
-    print_hrb(&mut t);
-    writeln!(t, "Inbound Flows");
-    print_hr(&mut t);
-    print_lft_flow_header(&mut t);
+    writeln!(t, "Layer {}", resp.name)?;
+    write_hrb(&mut t)?;
+    writeln!(t, "Inbound Flows")?;
+    write_hr(&mut t)?;
+    print_lft_flow_header(&mut t)?;
     for (flow_id, flow_state) in &resp.ft_in {
-        print_lft_flow(&mut t, flow_id, flow_state);
+        print_lft_flow(&mut t, flow_id, flow_state)?;
     }
-    t.flush();
+    t.flush()?;
 
-    writeln!(t, "\nOutbound Flows");
-    print_hr(&mut t);
-    print_lft_flow_header(&mut t);
+    writeln!(t, "\nOutbound Flows")?;
+    write_hr(&mut t)?;
+    print_lft_flow_header(&mut t)?;
     for (flow_id, flow_state) in &resp.ft_out {
-        print_lft_flow(&mut t, flow_id, flow_state);
+        print_lft_flow(&mut t, flow_id, flow_state)?;
     }
-    t.flush();
+    t.flush()?;
 
-    writeln!(t, "\nInbound Rules");
-    print_hr(&mut t);
-    print_rule_header(&mut t);
+    writeln!(t, "\nInbound Rules")?;
+    write_hr(&mut t)?;
+    print_rule_header(&mut t)?;
     for rte in &resp.rules_in {
-        print_rule(&mut t, rte.id, rte.hits, &rte.rule);
+        print_rule(&mut t, rte.id, rte.hits, &rte.rule)?;
     }
-    print_def_rule(&mut t, resp.default_in_hits, &resp.default_in);
-    t.flush();
+    print_def_rule(&mut t, resp.default_in_hits, &resp.default_in)?;
+    t.flush()?;
 
-    writeln!(t, "\nOutbound Rules");
-    print_hr(&mut t);
-    print_rule_header(&mut t);
+    writeln!(t, "\nOutbound Rules")?;
+    write_hr(&mut t)?;
+    print_rule_header(&mut t)?;
     for rte in &resp.rules_out {
-        print_rule(&mut t, rte.id, rte.hits, &rte.rule);
+        print_rule(&mut t, rte.id, rte.hits, &rte.rule)?;
     }
-    print_def_rule(&mut t, resp.default_out_hits, &resp.default_out);
-    t.flush();
+    print_def_rule(&mut t, resp.default_out_hits, &resp.default_out)?;
+    t.flush()?;
 
-    writeln!(t);
-    t.flush();
+    writeln!(t)?;
+    t.flush()
 }
 
 /// Print a [`ListLayersResp`].
-pub fn print_list_layers(resp: &ListLayersResp) {
+pub fn print_list_layers(resp: &ListLayersResp) -> std::io::Result<()> {
     let mut t = TabWriter::new(std::io::stdout());
-    writeln!(
-        t,
-        "NAME\tRULES IN\tRULES OUT\tDEF IN\tDEF OUT\tFLOWS",
-    );
+    writeln!(t, "NAME\tRULES IN\tRULES OUT\tDEF IN\tDEF OUT\tFLOWS",)?;
 
     for desc in &resp.layers {
         writeln!(
@@ -86,47 +83,53 @@ pub fn print_list_layers(resp: &ListLayersResp) {
             desc.default_in,
             desc.default_out,
             desc.flows,
-        );
+        )?;
     }
-    t.flush();
+    t.flush()
 }
 
 /// Print a [`DumpUftResp`].
-pub fn print_uft(uft: &DumpUftResp) {
+pub fn print_uft(uft: &DumpUftResp) -> std::io::Result<()> {
     let mut t = TabWriter::new(std::io::stdout());
 
-    writeln!(t, "UFT Inbound: {}/{}", uft.in_num_flows, uft.in_limit);
-    print_hr(&mut t);
-    print_uft_flow_header(&mut t);
+    writeln!(t, "UFT Inbound: {}/{}", uft.in_num_flows, uft.in_limit)?;
+    write_hr(&mut t)?;
+    print_uft_flow_header(&mut t)?;
     for (flow_id, flow_state) in &uft.in_flows {
-        print_uft_flow(&mut t, flow_id, flow_state);
+        print_uft_flow(&mut t, flow_id, flow_state)?;
     }
-    t.flush();
+    t.flush()?;
 
-    writeln!(t);
-    writeln!(t, "UFT Outbound: {}/{}", uft.out_num_flows, uft.out_limit);
-    print_hr(&mut t);
-    print_uft_flow_header(&mut t);
+    writeln!(t)?;
+    writeln!(t, "UFT Outbound: {}/{}", uft.out_num_flows, uft.out_limit)?;
+    write_hr(&mut t)?;
+    print_uft_flow_header(&mut t)?;
     for (flow_id, flow_state) in &uft.out_flows {
-        print_uft_flow(&mut t, flow_id, flow_state);
+        print_uft_flow(&mut t, flow_id, flow_state)?;
     }
-    t.flush();
+    t.flush()
 }
 
 /// Print the header for the [`print_rule()`] output.
-pub fn print_rule_header(t: &mut impl Write) {
-    writeln!(
-        t,
-        "ID\tPRI\tHITS\tPREDICATES\tACTION"
-    );
+pub fn print_rule_header(t: &mut impl Write) -> std::io::Result<()> {
+    writeln!(t, "ID\tPRI\tHITS\tPREDICATES\tACTION")
 }
 
-pub fn print_def_rule(t: &mut impl Write, hits: u64, action: &str) {
-    writeln!(t, "DEF\t--\t{hits}\t--\t{action:?}");
+pub fn print_def_rule(
+    t: &mut impl Write,
+    hits: u64,
+    action: &str,
+) -> std::io::Result<()> {
+    writeln!(t, "DEF\t--\t{hits}\t--\t{action:?}")
 }
 
 /// Print a [`RuleDump`].
-pub fn print_rule(t: &mut impl Write, id: u64, hits: u64, rule: &RuleDump) {
+pub fn print_rule(
+    t: &mut impl Write,
+    id: u64,
+    hits: u64,
+    rule: &RuleDump,
+) -> std::io::Result<()> {
     let mut preds = rule
         .predicates
         .iter()
@@ -144,11 +147,11 @@ pub fn print_rule(t: &mut impl Write, id: u64, hits: u64, rule: &RuleDump) {
         t,
         "{id}\t{}\t{hits}\t{first_pred}\t{:<?}",
         rule.priority, rule.action
-    );
+    )?;
 
     let mut multi_preds = false;
     while let Some(pred) = preds.pop_front() {
-        writeln!(t, "\t\t\t{pred}");
+        writeln!(t, "\t\t\t{pred}\t")?;
         multi_preds = true;
     }
 
@@ -156,20 +159,23 @@ pub fn print_rule(t: &mut impl Write, id: u64, hits: u64, rule: &RuleDump) {
     // separation so it's easier to discern where one rule ends and
     // another begins.
     if multi_preds {
-        writeln!(t);
+        writeln!(t, "\t\t\t\t")?;
     }
+
+    Ok(())
 }
 
 /// Print the header for the [`print_lft_flow()`] output.
-pub fn print_lft_flow_header(t: &mut impl Write) {
-    writeln!(
-        t,
-        "PROTO\tSRC IP\tSPORT\tDST IP\tDPORT\tHITS\tACTION"
-    );
+pub fn print_lft_flow_header(t: &mut impl Write) -> std::io::Result<()> {
+    writeln!(t, "PROTO\tSRC IP\tSPORT\tDST IP\tDPORT\tHITS\tACTION")
 }
 
 /// Print information about a layer flow.
-pub fn print_lft_flow(t: &mut impl Write, flow_id: &InnerFlowId, flow_entry: &ActionDescEntryDump) {
+pub fn print_lft_flow(
+    t: &mut impl Write,
+    flow_id: &InnerFlowId,
+    flow_entry: &ActionDescEntryDump,
+) -> std::io::Result<()> {
     // For those types with custom Display implementations we need to
     // first format in into a String before passing it to println in
     // order for the format specification to be honored.
@@ -183,19 +189,20 @@ pub fn print_lft_flow(t: &mut impl Write, flow_id: &InnerFlowId, flow_entry: &Ac
         flow_id.dst_port,
         flow_entry.hits,
         flow_entry.summary,
-    );
+    )
 }
 
 /// Print the header for the [`print_uft_flow()`] output.
-pub fn print_uft_flow_header(t: &mut impl Write) {
-    writeln!(
-        t,
-        "PROTO\tSRC IP\tSPORT\tDST IP\tDPORT\tHITS\tXFORMS"
-    );
+pub fn print_uft_flow_header(t: &mut impl Write) -> std::io::Result<()> {
+    writeln!(t, "PROTO\tSRC IP\tSPORT\tDST IP\tDPORT\tHITS\tXFORMS")
 }
 
 /// Print information about a UFT entry.
-pub fn print_uft_flow(t: &mut impl Write, flow_id: &InnerFlowId, flow_entry: &UftEntryDump) {
+pub fn print_uft_flow(
+    t: &mut impl Write,
+    flow_id: &InnerFlowId,
+    flow_entry: &UftEntryDump,
+) -> std::io::Result<()> {
     // For those types with custom Display implementations we need to
     // first format in into a String before passing it to println in
     // order for the format specification to be honored.
@@ -209,22 +216,26 @@ pub fn print_uft_flow(t: &mut impl Write, flow_id: &InnerFlowId, flow_entry: &Uf
         flow_id.dst_port,
         flow_entry.hits,
         flow_entry.summary,
-    );
+    )
 }
 
 /// Print a [`DumpTcpFlowsResp`].
-pub fn print_tcp_flows(flows: &DumpTcpFlowsResp) {
+pub fn print_tcp_flows(flows: &DumpTcpFlowsResp) -> std::io::Result<()> {
     let mut t = TabWriter::new(std::io::stdout());
 
-    writeln!(t, "FLOW\tSTATE\tHITS\tSEGS IN\tSEGS OUT\tBYTES IN\tBYTES OUT");
+    writeln!(t, "FLOW\tSTATE\tHITS\tSEGS IN\tSEGS OUT\tBYTES IN\tBYTES OUT")?;
     for (flow_id, entry) in &flows.flows {
-        print_tcp_flow(&mut t, flow_id, entry);
+        print_tcp_flow(&mut t, flow_id, entry)?;
     }
 
-    t.flush();
+    t.flush()
 }
 
-fn print_tcp_flow(t: &mut impl Write, id: &InnerFlowId, entry: &TcpFlowEntryDump) {
+fn print_tcp_flow(
+    t: &mut impl Write,
+    id: &InnerFlowId,
+    entry: &TcpFlowEntryDump,
+) -> std::io::Result<()> {
     writeln!(
         t,
         "{id}\t{}\t{}\t{}\t{}\t{}\t{}",
@@ -234,15 +245,25 @@ fn print_tcp_flow(t: &mut impl Write, id: &InnerFlowId, entry: &TcpFlowEntryDump
         entry.segs_out,
         entry.bytes_in,
         entry.bytes_out,
-    );
+    )
 }
 
-/// Print horizontal rule in bold.
-pub fn print_hrb(t: &mut impl Write) {
-    writeln!(t, "{:=<70}", "=");
+/// Output a horizontal rule in bold to the given writer.
+pub fn write_hrb(t: &mut impl Write) -> std::io::Result<()> {
+    writeln!(t, "{:=<70}", "=")
 }
 
-/// Print horizontal rule.
-pub fn print_hr(t: &mut impl Write) {
-    writeln!(t, "{:-<70}", "-");
+/// Print a horizontal rule in bold.
+pub fn print_hrb() {
+    println!("{:=<70}", "=");
+}
+
+/// Output a horizontal rule in bold to the given writer.
+pub fn write_hr(t: &mut impl Write) -> std::io::Result<()> {
+    writeln!(t, "{:-<70}", "-")
+}
+
+/// Print a horizontal rule.
+pub fn print_hr() {
+    println!("{:-<70}", "-");
 }

--- a/lib/oxide-vpc/Cargo.toml
+++ b/lib/oxide-vpc/Cargo.toml
@@ -16,7 +16,7 @@ default = ["api", "std"]
 api = ["opte/api"]
 engine = ["api", "opte/engine"]
 kernel = ["opte/kernel"]
-std = ["opte/std"]
+std = ["dep:tabwriter","opte/std"]
 #
 # XXX: This is a hack in order for integration tests to make use of
 # test-only methods.
@@ -35,6 +35,7 @@ opte.workspace = true
 
 serde.workspace = true
 smoltcp.workspace = true
+tabwriter = { workspace = true, optional = true }
 zerocopy.workspace = true
 poptrie.workspace = true
 cfg-if.workspace = true

--- a/lib/oxide-vpc/src/engine/print.rs
+++ b/lib/oxide-vpc/src/engine/print.rs
@@ -28,7 +28,15 @@ fn print_v2p_header(t: &mut impl Write) -> std::io::Result<()> {
 
 /// Print a [`DumpVirt2PhysResp`].
 pub fn print_v2p(resp: &DumpVirt2PhysResp) -> std::io::Result<()> {
-    let mut t = TabWriter::new(std::io::stdout());
+    print_v2p_into(&mut std::io::stdout(), resp)
+}
+
+/// Print a [`DumpVirt2PhysResp`] into a given writer.
+pub fn print_v2p_into(
+    writer: &mut impl Write,
+    resp: &DumpVirt2PhysResp,
+) -> std::io::Result<()> {
+    let mut t = TabWriter::new(writer);
     writeln!(t, "Virtual to Physical Mappings")?;
     write_hrb(&mut t)?;
     for vpc in &resp.mappings {
@@ -69,7 +77,15 @@ fn print_v2b_entry(
 
 /// Print a [`DumpVirt2BoundaryResp`].
 pub fn print_v2b(resp: &DumpVirt2BoundaryResp) -> std::io::Result<()> {
-    let mut t = TabWriter::new(std::io::stdout());
+    print_v2b_into(&mut std::io::stdout(), resp)
+}
+
+/// Print a [`DumpVirt2BoundaryResp`] into a given writer.
+pub fn print_v2b_into(
+    writer: &mut impl Write,
+    resp: &DumpVirt2BoundaryResp,
+) -> std::io::Result<()> {
+    let mut t = TabWriter::new(writer);
     writeln!(t, "Virtual to Boundary Mappings")?;
     write_hrb(&mut t)?;
     writeln!(t, "\nIPv4 mappings")?;

--- a/lib/oxide-vpc/src/engine/print.rs
+++ b/lib/oxide-vpc/src/engine/print.rs
@@ -18,88 +18,105 @@ use alloc::string::ToString;
 use opte::api::IpCidr;
 use opte::engine::geneve::Vni;
 use opte::engine::print::*;
+use std::io::Write;
+use tabwriter::TabWriter;
 
 /// Print the header for the [`print_v2p()`] output.
-fn print_v2p_header() {
-    println!("{:<24} {:<17} UNDERLAY IP", "VPC IP", "VPC MAC ADDR");
+fn print_v2p_header(t: &mut impl Write) -> std::io::Result<()> {
+    writeln!(t, "VPC_IP\tVPC MAC ADDR\tUNDERLAY IP")
 }
 
 /// Print a [`DumpVirt2PhysResp`].
-pub fn print_v2p(resp: &DumpVirt2PhysResp) {
-    println!("Virtual to Physical Mappings");
-    print_hrb();
+pub fn print_v2p(resp: &DumpVirt2PhysResp) -> std::io::Result<()> {
+    let mut t = TabWriter::new(std::io::stdout());
+    writeln!(t, "Virtual to Physical Mappings")?;
+    write_hrb(&mut t)?;
     for vpc in &resp.mappings {
-        println!();
-        println!("VPC {}", vpc.vni);
-        print_hr();
-        println!();
-        println!("IPv4 mappings");
-        print_hr();
-        print_v2p_header();
+        writeln!(t, "\nVPC {}", vpc.vni)?;
+        write_hr(&mut t)?;
+        writeln!(t, "\nIPv4 mappings")?;
+        write_hr(&mut t)?;
+        print_v2p_header(&mut t)?;
         for pair in &vpc.ip4 {
-            print_v2p_ip4(pair);
+            print_v2p_ip4(&mut t, pair)?;
         }
+        t.flush()?;
 
-        println!();
-        println!("IPv6 mappings");
-        print_hr();
-        print_v2p_header();
+        writeln!(t, "\nIPv6 mappings")?;
+        write_hr(&mut t)?;
+        print_v2p_header(&mut t)?;
         for pair in &vpc.ip6 {
-            print_v2p_ip6(pair);
+            print_v2p_ip6(&mut t, pair)?;
         }
+        t.flush()?;
     }
+    t.flush()
 }
 
 /// Print the header for the [`print_v2p()`] output.
-fn print_v2b_header() {
-    println!("{:<24} {:<17} VNI", "TUNNELED PREFIX", "BOUNDARY IP");
+fn print_v2b_header(t: &mut impl Write) -> std::io::Result<()> {
+    writeln!(t, "TUNNELED PREFIX\tBOUNDARY IP\tVNI")
 }
 
-fn print_v2b_entry(prefix: IpCidr, boundary: Ipv6Addr, vni: Vni) {
-    println!("{:<24} {:<17} {}", prefix.to_string(), boundary.to_string(), vni);
+fn print_v2b_entry(
+    t: &mut impl Write,
+    prefix: IpCidr,
+    boundary: Ipv6Addr,
+    vni: Vni,
+) -> std::io::Result<()> {
+    writeln!(t, "{}\t{}\t{vni}", prefix.to_string(), boundary.to_string())
 }
 
 /// Print a [`DumpVirt2BoundaryResp`].
-pub fn print_v2b(resp: &DumpVirt2BoundaryResp) {
-    println!("Virtual to Boundary Mappings");
-    print_hrb();
-    println!();
-    println!("IPv4 mappings");
-    print_hr();
-    print_v2b_header();
+pub fn print_v2b(resp: &DumpVirt2BoundaryResp) -> std::io::Result<()> {
+    let mut t = TabWriter::new(std::io::stdout());
+    writeln!(t, "Virtual to Boundary Mappings")?;
+    write_hrb(&mut t)?;
+    writeln!(t, "\nIPv4 mappings")?;
+    write_hr(&mut t)?;
+    print_v2b_header(&mut t)?;
     for x in &resp.mappings.ip4 {
         for tep in &x.1 {
-            print_v2b_entry(x.0.into(), tep.ip, tep.vni);
+            print_v2b_entry(&mut t, x.0.into(), tep.ip, tep.vni)?;
         }
     }
-    println!();
-    println!("IPv6 mappings");
-    print_hr();
-    print_v2b_header();
+    t.flush()?;
+
+    writeln!(t, "\nIPv6 mappings")?;
+    write_hr(&mut t)?;
+    print_v2b_header(&mut t)?;
     for x in &resp.mappings.ip6 {
         for tep in &x.1 {
-            print_v2b_entry(x.0.into(), tep.ip, tep.vni);
+            print_v2b_entry(&mut t, x.0.into(), tep.ip, tep.vni)?;
         }
     }
-    println!();
+    writeln!(t)?;
+
+    t.flush()
 }
 
-fn print_v2p_ip4((src, phys): &(Ipv4Addr, GuestPhysAddr)) {
-    let eth = format!("{}", phys.ether);
-    println!(
-        "{:<24} {:<17} {}",
+fn print_v2p_ip4(
+    t: &mut impl Write,
+    (src, phys): &(Ipv4Addr, GuestPhysAddr),
+) -> std::io::Result<()> {
+    writeln!(
+        t,
+        "{}\t{}\t{}",
         std::net::Ipv4Addr::from(src.bytes()),
-        eth,
+        phys.ether,
         std::net::Ipv6Addr::from(phys.ip.bytes()),
-    );
+    )
 }
 
-fn print_v2p_ip6((src, phys): &(Ipv6Addr, GuestPhysAddr)) {
-    let eth = format!("{}", phys.ether);
-    println!(
-        "{:<24} {:<17} {}",
+fn print_v2p_ip6(
+    t: &mut impl Write,
+    (src, phys): &(Ipv6Addr, GuestPhysAddr),
+) -> std::io::Result<()> {
+    writeln!(
+        t,
+        "{}\t{}\t{}",
         std::net::Ipv6Addr::from(src.bytes()),
-        eth,
+        phys.ether,
         std::net::Ipv6Addr::from(phys.ip.bytes()),
-    );
+    )
 }

--- a/lib/oxide-vpc/tests/common/mod.rs
+++ b/lib/oxide-vpc/tests/common/mod.rs
@@ -1081,7 +1081,7 @@ fn _encap(
 macro_rules! chk {
     ($pav:expr, $check:expr) => {
         if !$check {
-            print_port(&$pav.port, &$pav.vpc_map);
+            print_port(&$pav.port, &$pav.vpc_map).unwrap();
             panic!("assertion failed: {}", stringify!($check));
         }
     };

--- a/lib/oxide-vpc/tests/common/port_state.rs
+++ b/lib/oxide-vpc/tests/common/port_state.rs
@@ -20,7 +20,7 @@ pub fn print_port(port: &Port<VpcNetwork>, vpc_map: &VpcMappings) {
     // ================================================================
     // Print VPC mappings.
     // ================================================================
-    print_v2p(&vpc_map.dump());
+    print_v2p(&vpc_map.dump()).unwrap();
     println!();
 
     println!(
@@ -34,11 +34,10 @@ pub fn print_port(port: &Port<VpcNetwork>, vpc_map: &VpcMappings) {
     // ================================================================
     // Print overall layer information.
     // ================================================================
-    println!();
-    println!("Layers");
+    println!("\nLayers");
     print_hr();
     let list_layers = port.list_layers();
-    print_list_layers(&list_layers);
+    print_list_layers(&list_layers).unwrap();
 
     // ================================================================
     // Print UFT.
@@ -46,17 +45,16 @@ pub fn print_port(port: &Port<VpcNetwork>, vpc_map: &VpcMappings) {
     println!();
     // Only some states will report a UFT.
     if let Ok(uft) = port.dump_uft() {
-        print_uft(&uft);
+        print_uft(&uft).unwrap();
     }
 
     // ================================================================
     // Print TCP flows.
     // ================================================================
     if port.state() == PortState::Running {
-        println!();
-        println!("TCP Flows (keyed on outbound)");
+        println!("\nTCP Flows (keyed on outbound)");
         print_hr();
-        print_tcp_flows(&port.dump_tcp_flows().unwrap());
+        print_tcp_flows(&port.dump_tcp_flows().unwrap()).unwrap();
     }
 
     // ================================================================
@@ -64,17 +62,14 @@ pub fn print_port(port: &Port<VpcNetwork>, vpc_map: &VpcMappings) {
     // ================================================================
     println!();
     for layer in &list_layers.layers {
-        print_layer(&port.dump_layer(&layer.name).unwrap());
-        println!();
-        println!("{:#?}", port.layer_stats_snap(&layer.name).unwrap());
-        println!();
+        print_layer(&port.dump_layer(&layer.name).unwrap()).unwrap();
+        println!("\n{:#?}\n", port.layer_stats_snap(&layer.name).unwrap());
     }
 
     // ================================================================
     // Print the PortStats.
     // ================================================================
-    println!();
-    println!("Port Stats");
+    println!("\nPort Stats");
     print_hr();
     println!("{:#?}", port.stats_snap());
 

--- a/lib/oxide-vpc/tests/integration_tests.rs
+++ b/lib/oxide-vpc/tests/integration_tests.rs
@@ -1129,7 +1129,6 @@ fn check_external_ip_inbound_behaviour(
             ];
             incr!(port, rules[(if firewall_flow_exists { 2 } else { 0 })..]);
         }
-        print_port(&port.port, &port.vpc_map);
 
         let private_ip: IpAddr = match ext_ip {
             IpAddr::Ip4(_) => {
@@ -1174,14 +1173,12 @@ fn check_external_ip_inbound_behaviour(
             flow_port,
         );
         let res = port.port.process(Out, &mut pkt2, ActionMeta::new());
-        print_port(&port.port, &port.vpc_map);
 
         if old_ip_gone {
             // Failure mode here is different (assuming we have at least one
             // external IP). The packet must fail to send via the old IP,
             // invalidate the entry, and then choose the new external IP.
             assert!(matches!(res, Ok(Modified)), "bad result: {:?}", res);
-            print_port(&port.port, &port.vpc_map);
             update!(
                 port,
                 [
@@ -1890,7 +1887,6 @@ fn arp_gateway() {
     bytes.extend_from_slice(eth_hdr.as_bytes());
     bytes.extend_from_slice(ArpEthIpv4Raw::from(&arp).as_bytes());
     let mut pkt = Packet::copy(&bytes).parse(Out, VpcParser::new()).unwrap();
-    print_port(&g1.port, &g1.vpc_map);
 
     let res = g1.port.process(Out, &mut pkt, ActionMeta::new());
     match res {


### PR DESCRIPTION
This PR changes the formatting on opteadm to be constructed using TabWriter, which should provide a small improvement over the (many) hand-coded padding lengths in today's output strings.

For additional tweaks I've also added the current port name to the output of `opteadm dump-layer`, which should make it somewhat easier to track down the right layers when looking at integration test output on omicron. Multiple external IPs in `list-ports` are now also split over newlines, matching the style of multi-predicate layer rules.