### PR TITLE
Fix Geneve size in `integration_tests::common::encap`

### DIFF
--- a/lib/opte/src/engine/geneve.rs
+++ b/lib/opte/src/engine/geneve.rs
@@ -14,6 +14,8 @@ use super::headers::PushAction;
 use super::headers::RawHeader;
 use super::packet::PacketReadMut;
 use super::packet::ReadErr;
+use super::udp::UdpHdr;
+use super::udp::UdpMeta;
 use core::mem;
 pub use opte_api::Vni;
 use serde::Deserialize;
@@ -41,8 +43,6 @@ pub const GENEVE_OPT_CLASS_OXIDE: u16 = 0x0129;
 pub struct GeneveMeta {
     pub entropy: u16,
     pub vni: Vni,
-    pub len: u16,
-
     pub oxide_external_pkt: bool,
 }
 
@@ -87,9 +87,10 @@ impl ModifyAction<GeneveMeta> for GeneveMod {
 }
 
 impl GeneveMeta {
+    /// Emit only the inner Geneve header.
     #[inline]
-    pub fn emit(&self, dst: &mut [u8]) {
-        debug_assert_eq!(dst.len(), self.hdr_len());
+    pub fn emit_inner(&self, dst: &mut [u8]) {
+        debug_assert_eq!(dst.len(), self.hdr_len_inner());
         let (base, remainder) = dst.split_at_mut(GeneveHdrRaw::SIZE);
         let mut raw = GeneveHdrRaw::new_mut(base).unwrap();
         raw.write(GeneveHdrRaw::from(self));
@@ -101,12 +102,41 @@ impl GeneveMeta {
         };
     }
 
+    /// Emit a full Geneve encapsulation for an inner packet, including
+    /// UDP.
+    ///
+    /// `total_len` should be precomputed as `self.hdr_len() + body.len()`.
+    #[inline]
+    pub fn emit(&self, total_len: u16, dst: &mut [u8]) {
+        let (udp_buf, geneve_buf) = dst.split_at_mut(UdpHdr::SIZE);
+        let udp = UdpMeta {
+            src: self.entropy,
+            dst: GENEVE_PORT,
+            len: total_len,
+            csum: [0; 2],
+        };
+        udp.emit(udp_buf);
+
+        self.emit_inner(geneve_buf);
+    }
+
+    /// Return the length of headers needed to fully Geneve-encapsulate
+    /// a packet, including UDP.
+    #[inline]
     pub fn hdr_len(&self) -> usize {
+        UdpHdr::SIZE + self.hdr_len_inner()
+    }
+
+    /// Return the length of only the Geneve header.
+    #[inline]
+    pub fn hdr_len_inner(&self) -> usize {
         GeneveHdr::BASE_SIZE + self.options_len()
     }
 
+    /// Return the required length (in bytes) needed to store
+    /// all Geneve options attached to this packet.
     pub fn options_len(&self) -> usize {
-        // XXX: This is a very special-cased just to enable testing.
+        // XXX: This is very special-cased just to enable testing.
         if self.oxide_external_pkt {
             GeneveOptHdrRaw::SIZE
         } else {
@@ -115,14 +145,18 @@ impl GeneveMeta {
     }
 }
 
+impl<'a> From<(&UdpHdr<'a>, &GeneveHdr<'a>)> for GeneveMeta {
+    fn from((udp, geneve): (&UdpHdr<'a>, &GeneveHdr<'a>)) -> Self {
+        let mut out = Self::from(geneve);
+        out.entropy = udp.src_port();
+        out
+    }
+}
+
 impl<'a> From<&GeneveHdr<'a>> for GeneveMeta {
     fn from(geneve: &GeneveHdr<'a>) -> Self {
-        let mut out = Self {
-            vni: geneve.vni(),
-            entropy: geneve.entropy(),
-            len: geneve.len() as u16,
-            ..Default::default()
-        };
+        let mut out =
+            Self { vni: geneve.vni(), entropy: 0, ..Default::default() };
 
         if let Some(ref opts) = geneve.opts {
             // XXX: Prevent duplication by making Meta generation fallible
@@ -151,14 +185,6 @@ impl<'a> GeneveHdr<'a> {
         usize::from(self.bytes.options_len() * 4) + Self::BASE_SIZE
     }
 
-    pub fn entropy(&self) -> u16 {
-        u16::from_be_bytes(self.bytes.src_port)
-    }
-
-    pub fn len(&self) -> usize {
-        usize::from(u16::from_be_bytes(self.bytes.length))
-    }
-
     pub fn parse<'b, R>(rdr: &'b mut R) -> Result<Self, GeneveHdrError>
     where
         R: PacketReadMut<'a>,
@@ -180,19 +206,6 @@ impl<'a> GeneveHdr<'a> {
         };
 
         Ok(Self { bytes, opts })
-    }
-
-    /// Set the length, in bytes.
-    ///
-    /// The UDP length field includes both header and payload.
-    pub fn set_len(&mut self, len: u16) {
-        self.bytes.length = len.to_be_bytes();
-    }
-
-    pub fn unify(&mut self, meta: &GeneveMeta) {
-        self.bytes.src_port = meta.entropy.to_be_bytes();
-        self.bytes.dst_port = GENEVE_PORT.to_be_bytes();
-        self.bytes.vni = meta.vni.bytes();
     }
 
     /// Return the VNI.
@@ -230,10 +243,6 @@ impl From<ReadErr> for GeneveHdrError {
 #[repr(C)]
 #[derive(Clone, Debug, FromBytes, AsBytes, FromZeroes, Unaligned)]
 pub struct GeneveHdrRaw {
-    src_port: [u8; 2],
-    dst_port: [u8; 2],
-    length: [u8; 2],
-    csum: [u8; 2],
     ver_opt_len: u8,
     flags: u8,
     proto: [u8; 2],
@@ -272,10 +281,6 @@ impl<'a> RawHeader<'a> for GeneveHdrRaw {
 impl Default for GeneveHdrRaw {
     fn default() -> Self {
         Self {
-            src_port: [0; 2],
-            dst_port: [0; 2],
-            length: [0; 2],
-            csum: [0; 2],
             ver_opt_len: 0x0,
             flags: 0x0,
             proto: ETHER_TYPE_ETHER.to_be_bytes(),
@@ -288,10 +293,6 @@ impl Default for GeneveHdrRaw {
 impl From<&GeneveMeta> for GeneveHdrRaw {
     fn from(meta: &GeneveMeta) -> Self {
         Self {
-            src_port: meta.entropy.to_be_bytes(),
-            dst_port: GENEVE_PORT.to_be_bytes(),
-            length: meta.len.to_be_bytes(),
-            csum: [0; 2],
             ver_opt_len: (meta.options_len() >> GENEVE_OPT_LEN_SCALE_SHIFT)
                 as u8,
             flags: 0x0,
@@ -486,7 +487,6 @@ mod test {
         let geneve = GeneveMeta {
             entropy: 7777,
             vni: Vni::new(1234u32).unwrap(),
-            len: GeneveHdr::BASE_SIZE as u16,
 
             ..Default::default()
         };
@@ -494,8 +494,10 @@ mod test {
         let len = geneve.hdr_len();
         let mut pkt = Packet::alloc_and_expand(len);
         let mut wtr = pkt.seg0_wtr();
-        // geneve.emit(&mut wtr).unwrap();
-        geneve.emit(wtr.slice_mut(len).unwrap());
+        geneve.emit(
+            geneve.hdr_len().try_into().unwrap(),
+            wtr.slice_mut(len).unwrap(),
+        );
         assert_eq!(len, pkt.len());
         #[rustfmt::skip]
         let expected_bytes = vec![
@@ -524,15 +526,16 @@ mod test {
         let geneve = GeneveMeta {
             entropy: 7777,
             vni: Vni::new(1234u32).unwrap(),
-            len: (GeneveHdr::BASE_SIZE + GeneveOptHdrRaw::SIZE) as u16,
             oxide_external_pkt: true,
         };
 
         let len = geneve.hdr_len();
         let mut pkt = Packet::alloc_and_expand(len);
         let mut wtr = pkt.seg0_wtr();
-        // geneve.emit(&mut wtr).unwrap();
-        geneve.emit(wtr.slice_mut(len).unwrap());
+        geneve.emit(
+            geneve.hdr_len().try_into().unwrap(),
+            wtr.slice_mut(len).unwrap(),
+        );
         assert_eq!(len, pkt.len());
         #[rustfmt::skip]
         let expected_bytes = vec![
@@ -594,11 +597,12 @@ mod test {
         ];
         let mut pkt = Packet::copy(&buf);
         let mut reader = pkt.get_rdr_mut();
+        let udp = UdpHdr::parse(&mut reader).unwrap();
         let header = GeneveHdr::parse(&mut reader).unwrap();
 
         // Previously, the `Ipv6Meta::total_len` method double-counted the
         // extension header length. Assert we don't do that here.
-        let meta = GeneveMeta::from(&header);
+        let meta = GeneveMeta::from((&udp, &header));
         assert_eq!(
             meta.entropy,
             u16::from_be_bytes(buf[0..2].try_into().unwrap())
@@ -639,6 +643,7 @@ mod test {
         ];
         let mut pkt = Packet::copy(&buf);
         let mut reader = pkt.get_rdr_mut();
+        UdpHdr::parse(&mut reader).unwrap();
         assert!(matches!(
             GeneveHdr::parse(&mut reader),
             Err(GeneveHdrError::BadLength { .. }),
@@ -676,6 +681,7 @@ mod test {
         ];
         let mut pkt = Packet::copy(&buf);
         let mut reader = pkt.get_rdr_mut();
+        UdpHdr::parse(&mut reader).unwrap();
         assert!(matches!(
             GeneveHdr::parse(&mut reader),
             Err(GeneveHdrError::UnknownCriticalOption {
@@ -734,11 +740,12 @@ mod test {
         ];
         let mut pkt = Packet::copy(&buf);
         let mut reader = pkt.get_rdr_mut();
+        let udp = UdpHdr::parse(&mut reader).unwrap();
         let header = GeneveHdr::parse(&mut reader).unwrap();
 
         // Previously, the `Ipv6Meta::total_len` method double-counted the
         // extension header length. Assert we don't do that here.
-        let meta = GeneveMeta::from(&header);
+        let meta = GeneveMeta::from((&udp, &header));
         assert_eq!(
             meta.entropy,
             u16::from_be_bytes(buf[0..2].try_into().unwrap())

--- a/lib/opte/src/engine/packet.rs
+++ b/lib/opte/src/engine/packet.rs
@@ -774,7 +774,7 @@ impl Packet<Initialized> {
                 let meta = GeneveMeta::from((&udp_hdr, &geneve));
                 Ok((HdrInfo { meta, offset }, geneve))
             }
-            port => return Err(ParseError::UnexpectedDestPort(port)),
+            port => Err(ParseError::UnexpectedDestPort(port)),
         }
     }
 

--- a/lib/opte/src/engine/port.rs
+++ b/lib/opte/src/engine/port.rs
@@ -1300,6 +1300,7 @@ impl<N: NetworkImpl> Port<N> {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 enum TcpMaybeClosed {
     Closed { ufid_inbound: Option<InnerFlowId> },

--- a/lib/oxide-vpc/tests/common/mod.rs
+++ b/lib/oxide-vpc/tests/common/mod.rs
@@ -49,7 +49,6 @@ pub use opte::engine::port::ProcessResult::*;
 pub use opte::engine::tcp::TcpFlags;
 pub use opte::engine::tcp::TcpHdr;
 pub use opte::engine::tcp::TcpMeta;
-pub use opte::engine::udp::UdpHdr;
 pub use opte::engine::GenericUlp;
 pub use opte::ExecCtx;
 pub use oxide_vpc::api::AddFwRuleReq;
@@ -986,7 +985,7 @@ fn _encap(
     let geneve = GeneveMeta {
         entropy: 99,
         vni: dst.vni,
-        len: (UdpHdr::SIZE + GeneveHdr::BASE_SIZE + opt_len + inner_len) as u16,
+        len: (GeneveHdr::BASE_SIZE + opt_len + inner_len) as u16,
         oxide_external_pkt: external_snat,
     };
 

--- a/lib/oxide-vpc/tests/common/mod.rs
+++ b/lib/oxide-vpc/tests/common/mod.rs
@@ -49,6 +49,7 @@ pub use opte::engine::port::ProcessResult::*;
 pub use opte::engine::tcp::TcpFlags;
 pub use opte::engine::tcp::TcpHdr;
 pub use opte::engine::tcp::TcpMeta;
+use opte::engine::udp::UdpHdr;
 pub use opte::engine::GenericUlp;
 pub use opte::ExecCtx;
 pub use oxide_vpc::api::AddFwRuleReq;
@@ -969,6 +970,8 @@ fn _encap(
     dst: TestIpPhys,
     external_snat: bool,
 ) -> Packet<Parsed> {
+    let old_pkt = inner_pkt.all_bytes();
+
     let inner_ip_len = inner_pkt.hdr_offsets().inner.ip.map(|off| off.hdr_len);
 
     let inner_ulp_len =
@@ -985,14 +988,19 @@ fn _encap(
     let geneve = GeneveMeta {
         entropy: 99,
         vni: dst.vni,
-        len: (GeneveHdr::BASE_SIZE + opt_len + inner_len) as u16,
         oxide_external_pkt: external_snat,
     };
+
+    let pay_len: u16 = (inner_len + geneve.hdr_len()).try_into().unwrap();
+    assert_eq!(
+        pay_len as usize,
+        inner_len + UdpHdr::SIZE + GeneveHdr::BASE_SIZE + opt_len
+    );
 
     let ip = Ipv6Meta {
         src: src.ip,
         dst: dst.ip,
-        pay_len: geneve.len,
+        pay_len,
         proto: Protocol::UDP,
         next_hdr: IpProtocol::Udp,
         ..Default::default()
@@ -1006,8 +1014,8 @@ fn _encap(
     let mut wtr = pkt.seg0_wtr();
     eth.emit(wtr.slice_mut(EtherHdr::SIZE).unwrap());
     ip.emit(wtr.slice_mut(ip.hdr_len()).unwrap());
-    geneve.emit(wtr.slice_mut(geneve.hdr_len()).unwrap());
-    wtr.write(&inner_pkt.all_bytes()).unwrap();
+    geneve.emit(pay_len, wtr.slice_mut(geneve.hdr_len()).unwrap());
+    wtr.write(&old_pkt).unwrap();
     let pkt = pkt.parse(In, VpcParser::new()).unwrap();
     let off = pkt.hdr_offsets();
     let mut pos = 0;
@@ -1070,6 +1078,9 @@ fn _encap(
             HdrOffset { pkt_pos: pos, seg_idx: 0, seg_pos: pos, hdr_len },
         );
     }
+
+    let new_pkt = pkt.all_bytes();
+    assert_eq!(&new_pkt[new_pkt.len() - old_pkt.len()..], &old_pkt);
 
     pkt
 }

--- a/lib/oxide-vpc/tests/integration_tests.rs
+++ b/lib/oxide-vpc/tests/integration_tests.rs
@@ -75,8 +75,7 @@ const IP6_SZ: usize = EtherHdr::SIZE + Ipv6Hdr::BASE_SIZE;
 const TCP4_SZ: usize = IP4_SZ + TcpHdr::BASE_SIZE;
 const TCP6_SZ: usize = IP6_SZ + TcpHdr::BASE_SIZE;
 
-// The GeneveHdr includes the UDP header.
-const VPC_ENCAP_SZ: usize = IP6_SZ + GeneveHdr::BASE_SIZE;
+const VPC_ENCAP_SZ: usize = IP6_SZ + UdpHdr::SIZE + GeneveHdr::BASE_SIZE;
 
 // If we are running `cargo test`, then make sure to
 // register the USDT probes before running any tests.
@@ -529,6 +528,7 @@ fn guest_to_guest() {
         ]
     );
 
+
     assert_eq!(pkt1.body_offset(), VPC_ENCAP_SZ + TCP4_SZ + HTTP_SYN_OPTS_LEN);
     assert_eq!(pkt1.body_seg(), 1);
     let ulp_csum_after = pkt1.meta().inner.ulp.unwrap().csum();
@@ -861,6 +861,7 @@ fn guest_to_internet_ipv6() {
             "stats.port.out_modified, stats.port.out_uft_miss",
         ]
     );
+
     assert_eq!(pkt1.body_offset(), VPC_ENCAP_SZ + TCP6_SZ + HTTP_SYN_OPTS_LEN);
     assert_eq!(pkt1.body_seg(), 1);
     let meta = pkt1.meta();

--- a/lib/oxide-vpc/tests/integration_tests.rs
+++ b/lib/oxide-vpc/tests/integration_tests.rs
@@ -47,6 +47,7 @@ use opte::engine::packet::Parsed;
 use opte::engine::port::ProcessError;
 use opte::engine::tcp::TcpState;
 use opte::engine::tcp::TIME_WAIT_EXPIRE_SECS;
+use opte::engine::udp::UdpHdr;
 use opte::engine::udp::UdpMeta;
 use opte::engine::Direction;
 use oxide_vpc::api::ExternalIpCfg;

--- a/lib/oxide-vpc/tests/integration_tests.rs
+++ b/lib/oxide-vpc/tests/integration_tests.rs
@@ -528,7 +528,6 @@ fn guest_to_guest() {
         ]
     );
 
-
     assert_eq!(pkt1.body_offset(), VPC_ENCAP_SZ + TCP4_SZ + HTTP_SYN_OPTS_LEN);
     assert_eq!(pkt1.body_seg(), 1);
     let ulp_csum_after = pkt1.meta().inner.ulp.unwrap().csum();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.76.0"
 profile = "default"


### PR DESCRIPTION
The `encap` method has, for its lifetime, been adding the length of a UDP header as well as `GeneveHdr::BASE_SIZE` when computing the length of the Geneve packet metadata for encapsulating test packets. However, `GeneveHdr` already includes UDP and its fields, so we were requesting an extra 8 bytes without initialising them. This PR corrects that length computation.

Fixes #454.