### PR TITLE
Correctly preserve inbound UFID on outbound TCP close

### DIFF
--- a/lib/opte/src/engine/port.rs
+++ b/lib/opte/src/engine/port.rs
@@ -1622,7 +1622,7 @@ impl<N: NetworkImpl> Port<N> {
                 self.uft_tcp_closed(data, ufid_out, state_ufid.as_ref());
             }
 
-            ufid_in.map(|v| *v).and(state_ufid)
+            ufid_in.copied().or(state_ufid)
         } else {
             None
         };
@@ -2081,8 +2081,7 @@ impl<N: NetworkImpl> Port<N> {
                 Ok(a) => Ok(TcpMaybeClosed::NewState(a)),
                 Err(e) => Err(e),
             },
-            Ok(v) => Ok(v.into()),
-            Err(e) => Err(e),
+            other => other,
         }
     }
 

--- a/lib/opte/src/engine/port.rs
+++ b/lib/opte/src/engine/port.rs
@@ -1307,6 +1307,15 @@ enum TcpMaybeClosed {
     NewState(TcpState),
 }
 
+impl From<TcpMaybeClosed> for TcpState {
+    fn from(value: TcpMaybeClosed) -> Self {
+        match value {
+            TcpMaybeClosed::Closed { .. } => TcpState::Closed,
+            TcpMaybeClosed::NewState(s) => s,
+        }
+    }
+}
+
 // This is a convenience wrapper for keeping the header and body
 // transformations under one structure, allowing them to be passes as
 // one argument.
@@ -1567,7 +1576,7 @@ impl<N: NetworkImpl> Port<N> {
         tcp: &TcpMeta,
         dir: &TcpDirection,
         pkt_len: u64,
-    ) -> result::Result<TcpState, ProcessError> {
+    ) -> result::Result<TcpMaybeClosed, ProcessError> {
         let tcp_flows = data.tcp_flows();
         let (ufid_out, ufid_in) = match *dir {
             TcpDirection::In { ufid_in, ufid_out } => (ufid_out, Some(ufid_in)),
@@ -1598,23 +1607,27 @@ impl<N: NetworkImpl> Port<N> {
             tfes.inbound_ufid = Some(*ufid_in);
         }
 
-        if matches!(
+        let ufid_inbound = if matches!(
             next_state,
             Ok(TcpState::Closed) | Err(TcpFlowStateError::NewFlow { .. })
         ) {
-            let entry = tcp_flows.remove(ufid_out).unwrap();
-
             // Due to order of operations, out_tcp_existing must
             // call uft_tcp_closed separately.
+            let entry = tcp_flows.remove(ufid_out).unwrap();
+            let state_ufid = entry.state().inbound_ufid;
+
             if let PortDataOrSubset::Port(data) = data {
                 // The inbound side of the UFT is based on
                 // the network-side of the flow (pre-processing).
-                let ufid_in = entry.state().inbound_ufid.as_ref();
-                self.uft_tcp_closed(data, ufid_out, ufid_in);
+                self.uft_tcp_closed(data, ufid_out, state_ufid.as_ref());
             }
-        }
 
-        match next_state {
+            ufid_in.map(|v| *v).and(state_ufid)
+        } else {
+            None
+        };
+
+        let next_state = match next_state {
             Ok(a) => Ok(a),
             Err(e @ TcpFlowStateError::UnexpectedSegment { state, .. }) => {
                 self.tcp_err_probe(
@@ -1626,7 +1639,12 @@ impl<N: NetworkImpl> Port<N> {
                 Ok(state)
             }
             Err(e) => Err(ProcessError::TcpFlow(e)),
-        }
+        }?;
+
+        Ok(match next_state {
+            TcpState::Closed => TcpMaybeClosed::Closed { ufid_inbound },
+            a => TcpMaybeClosed::NewState(a),
+        })
     }
 
     // Process the TCP packet for the purposes of connection tracking
@@ -1670,9 +1688,10 @@ impl<N: NetworkImpl> Port<N> {
                     &dir,
                     pkt_len,
                 )?;
-                e
+                e.map(Into::into)
             }
-            other => other,
+            Ok(v) => Ok(v.into()),
+            Err(e) => Err(e),
         }
     }
 
@@ -1715,7 +1734,8 @@ impl<N: NetworkImpl> Port<N> {
                 &dir,
                 pkt_len,
             ),
-            other => other,
+            Ok(v) => Ok(v.into()),
+            Err(e) => Err(e),
         }
     }
 
@@ -2023,14 +2043,6 @@ impl<N: NetworkImpl> Port<N> {
             &TcpDirection::Out { ufid_out },
             pkt_len,
         )
-        .map(|tcp_state| match tcp_state {
-            TcpState::Closed => TcpMaybeClosed::Closed {
-                ufid_inbound: tcp_flows
-                    .remove(ufid_out)
-                    .and_then(|v| v.state().inbound_ufid),
-            },
-            other => TcpMaybeClosed::NewState(other),
-        })
     }
 
     // Process the TCP packet for the purposes of connection tracking
@@ -2045,7 +2057,7 @@ impl<N: NetworkImpl> Port<N> {
         let tcp = pmeta.inner_tcp().unwrap();
         let dir = TcpDirection::Out { ufid_out };
 
-        let tcp_state = match self.update_tcp_entry(
+        match self.update_tcp_entry(
             PortDataOrSubset::Port(data),
             tcp,
             &dir,
@@ -2054,24 +2066,23 @@ impl<N: NetworkImpl> Port<N> {
             Err(
                 ProcessError::TcpFlow(TcpFlowStateError::NewFlow { .. })
                 | ProcessError::MissingFlow(_),
-            ) => self.create_new_tcp_entry(
+            ) => match self.create_new_tcp_entry(
                 &mut data.tcp_flows,
                 tcp,
                 &dir,
                 pkt_len,
-            ),
-            other => other,
-        }?;
-
-        Ok(match tcp_state {
-            TcpState::Closed => TcpMaybeClosed::Closed {
-                ufid_inbound: data
-                    .tcp_flows
-                    .remove(ufid_out)
-                    .and_then(|v| v.state().inbound_ufid),
+            ) {
+                // Note: don't need to remove on this case, as create_new_tcp_entry
+                // will only insert to the map if state != Closed.
+                Ok(TcpState::Closed) => {
+                    Ok(TcpMaybeClosed::Closed { ufid_inbound: None })
+                }
+                Ok(a) => Ok(TcpMaybeClosed::NewState(a)),
+                Err(e) => Err(e),
             },
-            other => TcpMaybeClosed::NewState(other),
-        })
+            Ok(v) => Ok(v.into()),
+            Err(e) => Err(e),
+        }
     }
 
     fn process_out_miss(

--- a/lib/opte/src/engine/port.rs
+++ b/lib/opte/src/engine/port.rs
@@ -1984,6 +1984,7 @@ impl<N: NetworkImpl> Port<N> {
                                 e,
                                 pkt,
                             );
+                            data.uft_in.remove(pkt.flow());
                             return Ok(ProcessResult::Drop {
                                 reason: DropReason::TcpErr,
                             });
@@ -2263,6 +2264,7 @@ impl<N: NetworkImpl> Port<N> {
                                 e,
                                 pkt,
                             );
+                            data.uft_out.remove(pkt.flow());
                             return Ok(ProcessResult::Drop {
                                 reason: DropReason::TcpErr,
                             });


### PR DESCRIPTION
Outbound TCP packets which transitioned the state machine to `Closed` were
double-removing the TCP flow entries allocated to them. This is not bad on its
own due to the table lock. However, the inbound UFID was being always being
reported as `None` in this case. Ultimately, we need both UFIDs to remove
both UFT entries.

The inbound UFID used to invalidate both UFT entries was being computed from a
second remove in e.g. `process_out_tcp_existing`. Naturally this returned `None`,
as the TCP flow entry has already been removed. This resulted in the inbound UFID
always being `None` -- a later call to `update_tcp_entry` thus removes only the
outbound UFT entry and leaves a dangling inbound UFT entry.

This dangling entry prevents new inbound TCP flows on the same 5-tuple for a time
of 1 minute (i.e., until the UFT entry expires).

This fix plumbs the inbound UFID down correctly and performs the flow entry removal
only once. This ensures that both UFT entries will be torn down when a guest
packet transitions the state to `TcpState::Closed`. Also, any packets dropped
due to a missing TCP flow entry will now remove the existing UFT entry they matched
against.

Fixes https://github.com/oxidecomputer/opte/issues/466.