### PR TITLE
Fix opte#469 for VPC-external flows

### DIFF
--- a/lib/opte/src/engine/port.rs
+++ b/lib/opte/src/engine/port.rs
@@ -1880,7 +1880,7 @@ impl<N: NetworkImpl> Port<N> {
 
         // Use the compiled UFT entry if one exists. Otherwise
         // fallback to layer processing.
-        match data.uft_in.get_mut(pkt.flow()) {
+        match data.uft_in.get_mut(ufid_in) {
             Some(entry) if entry.state().epoch == epoch => {
                 // TODO At the moment I'm holding the UFT locks not
                 // just for lookup, but for the entire duration of
@@ -1939,7 +1939,7 @@ impl<N: NetworkImpl> Port<N> {
                             // but we have regenerated the TCP entry to be less disruptive
                             // than a drop. Remove the UFT entry on the same proviso since the
                             // next packet to use it will regenerate it.
-                            data.uft_in.remove(ufid_in);
+                            self.uft_invalidate(data, None, Some(ufid_in), epoch);
                             return Ok(ProcessResult::Modified);
                         }
                         Err(ProcessError::TcpFlow(

--- a/lib/opte/src/engine/port.rs
+++ b/lib/opte/src/engine/port.rs
@@ -1934,11 +1934,12 @@ impl<N: NetworkImpl> Port<N> {
                                 e,
                                 pkt,
                             );
-
                             // If we have a UFT but no TCP flow ID, there is likely a bug
                             // and we are now out of sync. As above we can't reprocess,
                             // but we have regenerated the TCP entry to be less disruptive
-                            // than a drop.
+                            // than a drop. Remove the UFT entry on the same proviso since the
+                            // next packet to use it will regenerate it.
+                            data.uft_in.remove(ufid_in);
                             return Ok(ProcessResult::Modified);
                         }
                         Err(ProcessError::TcpFlow(

--- a/lib/opte/src/engine/port.rs
+++ b/lib/opte/src/engine/port.rs
@@ -1939,7 +1939,12 @@ impl<N: NetworkImpl> Port<N> {
                             // but we have regenerated the TCP entry to be less disruptive
                             // than a drop. Remove the UFT entry on the same proviso since the
                             // next packet to use it will regenerate it.
-                            self.uft_invalidate(data, None, Some(ufid_in), epoch);
+                            self.uft_invalidate(
+                                data,
+                                None,
+                                Some(ufid_in),
+                                epoch,
+                            );
                             return Ok(ProcessResult::Modified);
                         }
                         Err(ProcessError::TcpFlow(
@@ -1984,7 +1989,7 @@ impl<N: NetworkImpl> Port<N> {
             // entries and proceed to rule processing.
             Some(entry) => {
                 let epoch = entry.state().epoch;
-                let ufid_in = Some(pkt.flow());
+                let ufid_in = Some(ufid_in);
                 let ufid_out = entry.state().pair;
                 self.uft_invalidate(data, ufid_out.as_ref(), ufid_in, epoch);
             }

--- a/lib/oxide-vpc/tests/integration_tests.rs
+++ b/lib/oxide-vpc/tests/integration_tests.rs
@@ -3577,7 +3577,7 @@ fn early_tcp_invalidation() {
         g1,
         [
             "incr:stats.port.in_modified, stats.port.in_uft_hit",
-            "set:uft.in=1, uft.out=0",
+            "set:uft.in=0, uft.out=0",
         ]
     );
     assert_eq!(TcpState::Listen, g1.port.tcp_state(&flow).unwrap());
@@ -3850,7 +3850,7 @@ fn tcp_inbound() {
         g1,
         [
             "incr:stats.port.in_modified, stats.port.in_uft_hit",
-            "set:uft.in=1, uft.out=0",
+            "set:uft.in=0, uft.out=0",
         ]
     );
     assert_eq!(None, g1.port.tcp_state(&flow));


### PR DESCRIPTION
Removing an inbound UFT entry in response to a TCP closure requires
that we remove it using its pre-transform flow ID, rather than
`pkt.flow()`. This is what `TcpFlowEntryState.inbound_ufid` was intended
to capture. To-date, we have been filling in this optional inbound flow
ID on a TCP flow entry using its post-transformation metadata -- either
`pkt.flow()` or `InnerFlowId::from(pmeta)`. This results in a mismatch:
* The UFT is keyed on pre-transform flow ID, e.g., ephemeral IP + remote
  IP.
* The TCP flow table is always keyed on, e.g., private IP + remote IP.

So nothing is removed from the inbound UFT table when a TCP flow triggers
early UFT invalidation.

We now correctly use the initial `flow_before` on all inbound TCP flows.
Additionally, we create a new TCP flow entry and allow transformed packets
through in the event of a flow table mismatch in case similar bugs recur.