### PR TITLE
Handle `mblk_t` packet chains

### DIFF
--- a/crates/illumos-sys-hdrs/src/kernel.rs
+++ b/crates/illumos-sys-hdrs/src/kernel.rs
@@ -508,6 +508,7 @@ extern "C" {
 
     pub fn freeb(mp: *mut mblk_t);
     pub fn freemsg(mp: *mut mblk_t);
+    pub fn freemsgchain(mp: *mut mblk_t);
 
     pub fn gethrtime() -> hrtime_t;
 

--- a/lib/opte/src/engine/packet.rs
+++ b/lib/opte/src/engine/packet.rs
@@ -465,7 +465,7 @@ impl PacketChain {
             let tail_p = list.tail.as_ptr();
             unsafe {
                 (*tail_p).b_next = pkt_p;
-                (*pkt_p).b_prev = list_p;
+                (*pkt_p).b_prev = tail_p;
                 // pkt_p->b_next is already null.
             }
             list.tail = pkt;

--- a/lib/opte/src/engine/packet.rs
+++ b/lib/opte/src/engine/packet.rs
@@ -3929,6 +3929,10 @@ mod test {
         let chain_inner = chain.inner.as_ref().unwrap();
         assert_eq!(chain_inner.head.as_ptr(), els[1]);
         assert_eq!(chain_inner.tail.as_ptr(), els[2]);
+        unsafe {
+            assert!((*els[1]).b_prev.is_null());
+            assert!((*els[2]).b_next.is_null());
+        }
     }
 
     #[test]

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -2080,7 +2080,7 @@ unsafe extern "C" fn xde_rx(
 ) {
     __dtrace_probe_rx(mp_chain as uintptr_t);
 
-    // Safety: This arg comes from `Arc::as_ptr()` on the `MacClientHandle`
+    // Safety: This arg comes from `Arc::from_ptr()` on the `MacClientHandle`
     // corresponding to the underlay port we're receiving on. Being
     // here in the callback means the `MacPromiscHandle` hasn't been
     // dropped yet and thus our `MacClientHandle` is also still valid.


### PR DESCRIPTION
This PR adds a `PacketChain` type which takes ownership of an `mblk_t` and then serves out owned `Packet<Initialized>` entitites for the rest of the stack to use.

This doesn't fundamentally change how we're structuring Packets internally, which still compute/allocate a Vec of `b_cont` entries. At the same time, we're still serving packets to our chosen destination MAC clients one by one. We will probably want to do some work here to better support reconstructing chains to hand off, where we can.

Closes #237.