### PR TITLE
Prevent modunload once underlay has been set

### DIFF
--- a/bin/opteadm/src/bin/opteadm.rs
+++ b/bin/opteadm/src/bin/opteadm.rs
@@ -197,6 +197,9 @@ enum Command {
     /// Set up xde underlay devices
     SetXdeUnderlay { u1: String, u2: String },
 
+    /// Clear xde underlay devices
+    ClearXdeUnderlay,
+
     /// Set a virtual-to-physical mapping
     SetV2P { vpc_ip: IpAddr, vpc_mac: MacAddr, underlay_ip: Ipv6Addr, vni: Vni },
 
@@ -643,6 +646,10 @@ fn main() -> anyhow::Result<()> {
 
         Command::SetXdeUnderlay { u1, u2 } => {
             let _ = hdl.set_xde_underlay(&u1, &u2)?;
+        }
+
+        Command::ClearXdeUnderlay => {
+            let _ = hdl.clear_xde_underlay()?;
         }
 
         Command::RmFwRule { port, direction, id } => {

--- a/bin/opteadm/src/lib.rs
+++ b/bin/opteadm/src/lib.rs
@@ -6,6 +6,7 @@
 
 //! OPTE driver administration library
 
+use opte::api::ClearXdeUnderlayReq;
 use opte::api::NoResp;
 use opte::api::OpteCmd;
 use opte::api::SetXdeUnderlayReq;
@@ -89,6 +90,13 @@ impl OpteAdm {
     ) -> Result<NoResp, Error> {
         let req = SetXdeUnderlayReq { u1: u1.into(), u2: u2.into() };
         let cmd = OpteCmd::SetXdeUnderlay;
+        run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req))
+    }
+
+    /// Clear xde underlay devices
+    pub fn clear_xde_underlay(&self) -> Result<NoResp, Error> {
+        let req = ClearXdeUnderlayReq { _unused: 0 };
+        let cmd = OpteCmd::ClearXdeUnderlay;
         run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req))
     }
 

--- a/crates/opte-api/src/cmd.rs
+++ b/crates/opte-api/src/cmd.rs
@@ -39,6 +39,7 @@ pub enum OpteCmd {
     CreateXde = 70,          // create a new xde device
     DeleteXde = 71,          // delete an xde device
     SetXdeUnderlay = 72,     // set xde underlay devices
+    ClearXdeUnderlay = 73,   // clear xde underlay devices
     SetExternalIps = 80,     // set xde external IPs for a port
 }
 
@@ -66,6 +67,7 @@ impl TryFrom<c_int> for OpteCmd {
             70 => Ok(Self::CreateXde),
             71 => Ok(Self::DeleteXde),
             72 => Ok(Self::SetXdeUnderlay),
+            73 => Ok(Self::ClearXdeUnderlay),
             80 => Ok(Self::SetExternalIps),
             _ => Err(()),
         }

--- a/crates/opte-api/src/lib.rs
+++ b/crates/opte-api/src/lib.rs
@@ -47,7 +47,7 @@ pub use ulp::*;
 ///
 /// We rely on CI and the check-api-version.sh script to verify that
 /// this number is incremented anytime the oxide-api code changes.
-pub const API_VERSION: u64 = 28;
+pub const API_VERSION: u64 = 29;
 
 /// Major version of the OPTE package.
 pub const MAJOR_VERSION: u64 = 0;
@@ -86,4 +86,10 @@ impl Display for Direction {
 pub struct SetXdeUnderlayReq {
     pub u1: String,
     pub u2: String,
+}
+
+/// Clear the underlay devices used by the xde kernel module
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ClearXdeUnderlayReq {
+    pub _unused: u64,
 }

--- a/lib/opte-ioctl/src/lib.rs
+++ b/lib/opte-ioctl/src/lib.rs
@@ -4,6 +4,7 @@
 
 // Copyright 2022 Oxide Computer Company
 
+use opte::api::ClearXdeUnderlayReq;
 use opte::api::CmdOk;
 use opte::api::NoResp;
 use opte::api::OpteCmd;
@@ -168,6 +169,13 @@ impl OpteHdl {
     ) -> Result<NoResp, Error> {
         let req = SetXdeUnderlayReq { u1: u1.into(), u2: u2.into() };
         let cmd = OpteCmd::SetXdeUnderlay;
+        run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req))
+    }
+
+    /// Clear xde underlay devices.
+    pub fn clear_xde_underlay(&self) -> Result<NoResp, Error> {
+        let req = ClearXdeUnderlayReq { _unused: 0 };
+        let cmd = OpteCmd::ClearXdeUnderlay;
         run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req))
     }
 

--- a/xde-tests/src/lib.rs
+++ b/xde-tests/src/lib.rs
@@ -206,6 +206,12 @@ impl Drop for Xde {
     /// When this object is dropped, remove the xde kernel module from the
     /// underlying system.
     fn drop(&mut self) {
+        // The module can no longer be successfully removed until the underlay
+        // has been cleared. This may not have been done, so this is fallible.
+        if let Ok(adm) = OpteAdm::open(OpteAdm::XDE_CTL) {
+            let _ = adm.clear_xde_underlay();
+        }
+
         let mut cmd = Command::new("pfexec");
         cmd.args(["rem_drv", "xde"]);
         if let Err(e) = cmd.output() {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -276,8 +276,14 @@ fn cmd_package(
 fn raw_install() -> Result<()> {
     let meta = cargo_meta();
 
-    // NOTE: we don't need to actually check this one, it'll return a
-    // failure code even if we don't care about it.
+    // NOTE: we don't need to actually check either command, they'll
+    // return a failure code even if we don't care about it.
+    // Opteadm may not even be installed/accessible, so also allow it to
+    // fail to run at all.
+    let _ = Command::new("/opt/oxide/opte/bin/opteadm")
+        .arg("clear-xde-underlay")
+        .output();
+
     Command::new("rem_drv").arg("xde").output()?;
 
     let mut conf_path = meta.workspace_root.clone();


### PR DESCRIPTION
This PR moves the underlay teardown logic from xde_detach into a new ioctl (and opteadm command) to unset the XDE underlay. Detach will now fail so long as the underlay is set -- this successfully prevents `modunload` from knocking us down after this state has been set.

The semantics are more or less what you'd expect:
* Clearing the underlay will fail if there exists a port.
* Clearing the underlay will fail if there is no underlay.
* Driver detach now requires that you `opteadm clear-xde-underlay`.