### PR TITLE
Expose choice of zone brand on kbench remote/server

### DIFF
--- a/bench/Gimlet.adoc
+++ b/bench/Gimlet.adoc
@@ -5,38 +5,19 @@ Today, SN9/SN14 are set up in this configuration.
 
 == Image construction
 When https://github.com/oxidecomputer/helios[building a helios image], we need to include some extra packages and pull in the latest (host-installed) version of OPTE.
-The below patch adds these packages behind a conditional flag:
-
-[source, diff]
-----
-diff --git a/image/templates/gimlet/ramdisk-01-os.json b/image/templates/gimlet/ramdisk-01-os.json
-index a063784..c81974f 100644
---- a/image/templates/gimlet/ramdisk-01-os.json
-+++ b/image/templates/gimlet/ramdisk-01-os.json
-@@ -105,6 +105,14 @@
-             "/driver/developer/amd/zen"
-         ] },
-
-+        { "t": "pkg_install", "with": "netperf", "pkgs": [
-+            "/network/test/iperf",
-+            "/driver/network/opte",
-+            "/system/zones/brand/sparse",
-+            "/system/library/demangle",
-+            "/ooce/developer/flamegraph"
-+        ] },
-+
-         { "t": "pkg_install", "with": "compliance", "pkgs": [
-             "/driver/developer/amd/zen",
-             "/developer/debug/humility"
-----
-
 After following instructions to setup Helios and build illumos, a Helios image suitable for running `kbench` can then be built using the command:
 
 [source, bash]
 ----
-./helios-build experiment-image -F netperf -B -N netperf
+./helios-build experiment-image \
+  -F extra_packages+=/network/test/iperf \
+  -F extra_packages+=/system/library/demangle \
+  -F extra_packages+=/ooce/developer/flamegraph \
+  -F optever=0.31.264 \
+  -B -N netperf
 ----
 
+The version of opte installed here is unimportant, as we will often be using local unpublished binaries and modules for testing.
 This image may then be installed onto your bench gimlet(s) as standard.
 
 == Running kbench on a bench gimlet

--- a/bench/Gimlet.adoc
+++ b/bench/Gimlet.adoc
@@ -1,0 +1,87 @@
+= Running OPTE Benchmarks on a Gimlet (pair)
+
+The kernel module benchmarks can be run on a pair of lab gimlets connected over their `cxgbe` interfaces.
+Today, SN9/SN14 are set up in this configuration.
+
+== Image construction
+When https://github.com/oxidecomputer/helios[building a helios image], we need to include some extra packages and pull in the latest (host-installed) version of OPTE.
+The below patch adds these packages behind a conditional flag:
+
+[source, diff]
+----
+diff --git a/image/templates/gimlet/ramdisk-01-os.json b/image/templates/gimlet/ramdisk-01-os.json
+index a063784..c81974f 100644
+--- a/image/templates/gimlet/ramdisk-01-os.json
++++ b/image/templates/gimlet/ramdisk-01-os.json
+@@ -105,6 +105,14 @@
+             "/driver/developer/amd/zen"
+         ] },
+
++        { "t": "pkg_install", "with": "netperf", "pkgs": [
++            "/network/test/iperf",
++            "/driver/network/opte",
++            "/system/zones/brand/sparse",
++            "/system/library/demangle",
++            "/ooce/developer/flamegraph"
++        ] },
++
+         { "t": "pkg_install", "with": "compliance", "pkgs": [
+             "/driver/developer/amd/zen",
+             "/developer/debug/humility"
+----
+
+After following instructions to setup Helios and build illumos, a Helios image suitable for running `kbench` can then be built using the command:
+
+[source, bash]
+----
+./helios-build experiment-image -F netperf -B -p helios-dev="https://pkg.oxide.computer/helios/2/dev/" -N netperf
+----
+
+This image may then be installed onto your bench gimlet(s) as standard.
+
+== Running kbench on a bench gimlet
+
+Bench gimlets will not have cargo or rust installed, so typically we will need to locally compile these artifacts on a Helios/illumos machine and transfer these artifacts onto the gimlet ramdisk:
+
+ - the `xde` kernel module -- `target/x86_64-unknown-unknown/release/xde`
+ - `opteadm` -- `target/release/opteadm`
+ - the `kbench` binary.
+
+All three artifacts require a consistent API version.
+
+The first two are stored in a static location, however see link:README.adoc#in-situ-measurement[the README entry on in-situ measurement] to acquire the current path for the third entry.
+This `cargo bench ... --message-format json-render-diagnostics` invocation will return a path such as:
+
+[source,json]
+----
+[
+  "/develop/gits/opte/target/release/deps/xde-5f922c3588d78a41"
+]
+----
+
+=== Installing and running artifacts
+
+Assuming all components have been `rsync`/`scp`'d into `/tmp`, we run on both machines:
+
+[source, bash]
+----
+cd /tmp
+rem_drv xde
+cp xde /kernel/drv/amd64/
+----
+
+On SN9:
+
+[source, bash]
+----
+./kbench server -u cxgbe0 cxgbe1 -b omicron1
+----
+
+On SN14:
+
+[source, bash]
+----
+./kbench remote 172.20.2.109 -u cxgbe0 cxgbe1 -b omicron1
+----
+
+`opteadm` invocations for inspecting state or, e.g., manually configuring the underlay can then be made using `/tmp/opteadm [args]`.

--- a/bench/Gimlet.adoc
+++ b/bench/Gimlet.adoc
@@ -34,7 +34,7 @@ After following instructions to setup Helios and build illumos, a Helios image s
 
 [source, bash]
 ----
-./helios-build experiment-image -F netperf -B -p helios-dev="https://pkg.oxide.computer/helios/2/dev/" -N netperf
+./helios-build experiment-image -F netperf -B -N netperf
 ----
 
 This image may then be installed onto your bench gimlet(s) as standard.

--- a/bench/benches/xde.rs
+++ b/bench/benches/xde.rs
@@ -61,7 +61,7 @@ impl ZoneBrand {
 
 impl std::fmt::Display for ZoneBrand {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{self:?}")
+        write!(f, "{}", self.to_str())
     }
 }
 

--- a/bench/benches/xde.rs
+++ b/bench/benches/xde.rs
@@ -7,6 +7,7 @@
 use anyhow::Result;
 use clap::Parser;
 use clap::Subcommand;
+use clap::ValueEnum;
 use itertools::Itertools;
 use opte_bench::iperf::Output;
 use opte_bench::kbench::measurement::*;
@@ -38,6 +39,32 @@ fn main() -> Result<()> {
     anyhow::bail!("This benchmark must be run on Helios!")
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ZoneBrand {
+    /// A sparse zone built using `pkg` info in the current GZ.
+    Sparse,
+    /// An omicron1-branded zone.
+    ///
+    /// You will need to ensure the baseline has been built to include
+    /// all intended dependencies.
+    Omicron1,
+}
+
+impl ZoneBrand {
+    fn to_str(&self) -> &'static str {
+        match self {
+            ZoneBrand::Sparse => "sparse",
+            ZoneBrand::Omicron1 => "omicron1",
+        }
+    }
+}
+
+impl std::fmt::Display for ZoneBrand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
 #[cfg(target_os = "illumos")]
 fn main() -> Result<()> {
     opte_bench::kbench::elevate()?;
@@ -46,12 +73,12 @@ fn main() -> Result<()> {
 
     match cfg.command {
         Experiment::Remote { iperf_server, opte_create, pause, .. } => {
-            check_deps(true, true)?;
+            check_deps(true, true, Some(opte_create.brand))?;
             over_nic(&opte_create, &iperf_server, pause)?;
             give_ownership()
         }
         Experiment::Local { no_bench, .. } => {
-            check_deps(true, !no_bench)?;
+            check_deps(true, !no_bench, Some(ZoneBrand::Sparse))?;
             if no_bench {
                 zone_to_zone_dummy()?;
             } else {
@@ -60,7 +87,7 @@ fn main() -> Result<()> {
             give_ownership()
         }
         Experiment::Server { opte_create, .. } => {
-            check_deps(false, true)?;
+            check_deps(false, true, Some(opte_create.brand))?;
             host_iperf(&opte_create)
         }
         Experiment::InSitu {
@@ -69,12 +96,12 @@ fn main() -> Result<()> {
             dont_process,
             ..
         } => {
-            check_deps(!dont_process, false)?;
+            check_deps(!dont_process, false, None)?;
             dtrace_only(&experiment_name, capture_mode, dont_process)?;
             give_ownership()
         }
         Experiment::Cleanup { .. } => {
-            check_deps(false, false)?;
+            check_deps(false, false, None)?;
             cleanup_detritus()
         }
     }
@@ -180,6 +207,14 @@ struct OpteCreateParams {
         default_value_t=DEFAULT_PORT,
     )]
     port: u16,
+
+    /// Type of Zone created to host iperf instances.
+    #[arg(
+        short,
+        long,
+        default_value_t=ZoneBrand::Sparse,
+    )]
+    brand: ZoneBrand,
 }
 
 #[derive(Parser)]
@@ -219,7 +254,11 @@ fn ensure_xde() -> Result<()> {
     }
 }
 
-fn check_deps(process_flamegraph: bool, iperf_based: bool) -> Result<()> {
+fn check_deps(
+    process_flamegraph: bool,
+    iperf_based: bool,
+    zone_type: Option<ZoneBrand>,
+) -> Result<()> {
     #[derive(Copy, Clone)]
     enum Dep {
         Program,
@@ -234,10 +273,16 @@ fn check_deps(process_flamegraph: bool, iperf_based: bool) -> Result<()> {
         ]);
     }
     if iperf_based {
-        dep_map.extend_from_slice(&[
-            (Dep::Program, "iperf", "iperf"),
-            (Dep::File, "/usr/lib/brand/sparse", "sparse"),
-        ]);
+        dep_map.extend_from_slice(&[(Dep::Program, "iperf", "iperf")]);
+        dep_map.extend_from_slice(match zone_type {
+            Some(ZoneBrand::Sparse) => {
+                &[(Dep::File, "/usr/lib/brand/sparse", "sparse")]
+            }
+            Some(ZoneBrand::Omicron1) => {
+                &[(Dep::File, "/usr/lib/brand/omicron1", "omicron1")]
+            }
+            _ => &[],
+        });
     }
 
     let mut missing_progs = vec![];
@@ -380,6 +425,7 @@ fn over_nic(params: &OpteCreateParams, host: &str, pause: bool) -> Result<()> {
         (&params.underlay_nics[..2]).try_into().unwrap(),
         xde_tests::ZONE_B_PORT,
         &[xde_tests::ZONE_A_PORT],
+        params.brand.to_str(),
     )?;
     print_banner("Topology built!");
 
@@ -497,6 +543,7 @@ fn host_iperf(params: &OpteCreateParams) -> Result<()> {
         (&params.underlay_nics[..2]).try_into().unwrap(),
         xde_tests::ZONE_A_PORT,
         &[xde_tests::ZONE_B_PORT],
+        params.brand.to_str(),
     )?;
 
     print_banner("topology created, spawning iPerf.\ntype 'exit' to exit.");

--- a/dtrace/opte-count-cycles.d
+++ b/dtrace/opte-count-cycles.d
@@ -1,19 +1,19 @@
 xde_mc_tx:entry {
-	self->ts = vtimestamp;
+	self->tx_ts = vtimestamp;
 }
 
 xde_rx:entry {
-	self->ts = vtimestamp;
+	self->rx_ts = vtimestamp;
 }
 
-xde_mc_tx:return /self->ts/ {
-	@time["tx"] = lquantize((vtimestamp - self->ts), 256, 32768, 256);
-	self->ts = 0;
+xde_mc_tx:return /self->tx_ts/ {
+	@time["tx"] = lquantize((vtimestamp - self->tx_ts), 256, 32768, 256);
+	self->tx_ts = 0;
 }
 
-xde_rx:return /self->ts/ {
-	@time["rx"] = lquantize((vtimestamp - self->ts), 256, 32768, 256);
-	self->ts = 0;
+xde_rx:return /self->rx_ts/ {
+	@time["rx"] = lquantize((vtimestamp - self->rx_ts), 256, 32768, 256);
+	self->rx_ts = 0;
 }
 
 END {

--- a/xde-tests/src/lib.rs
+++ b/xde-tests/src/lib.rs
@@ -49,8 +49,8 @@ impl OpteZone {
     /// Create a new zone with the given name, underlying zfs instance and set
     /// of interfaces. In illumos parlance, the interfaces are data link
     /// devices.
-    fn new(name: &str, zfs: &Zfs, ifx: &[&str]) -> Result<Self> {
-        let zone = Zone::new(name, "sparse", zfs, ifx, &[])?;
+    fn new(name: &str, zfs: &Zfs, ifx: &[&str], brand: &str) -> Result<Self> {
+        let zone = Zone::new(name, brand, zfs, ifx, &[])?;
         Ok(Self { zone })
     }
 
@@ -339,9 +339,9 @@ pub fn two_node_topology() -> Result<Topology> {
 
     // Create a pair of zones to simulate our VM instances.
     println!("start zone a");
-    let a = OpteZone::new("a", &zfs, &[&vopte0.name])?;
+    let a = OpteZone::new("a", &zfs, &[&vopte0.name], "sparse")?;
     println!("start zone b");
-    let b = OpteZone::new("b", &zfs, &[&vopte1.name])?;
+    let b = OpteZone::new("b", &zfs, &[&vopte1.name], "sparse")?;
 
     println!("setup zone a");
     a.setup(&vopte0.name, opte0.ip())?;
@@ -422,6 +422,7 @@ pub fn single_node_over_real_nic(
     underlay: &[String; 2],
     my_info: PortInfo,
     peers: &[PortInfo],
+    brand: &str,
 ) -> Result<Topology> {
     Xde::set_xde_underlay(&underlay[0], &underlay[1])?;
     let xde = Xde {};
@@ -451,7 +452,7 @@ pub fn single_node_over_real_nic(
     let zfs = Arc::new(Zfs::new("opte1node")?);
 
     println!("start zone");
-    let a = OpteZone::new("a", &zfs, &[&vopte.name])?;
+    let a = OpteZone::new("a", &zfs, &[&vopte.name], brand)?;
 
     std::thread::sleep(Duration::from_secs(30));
 


### PR DESCRIPTION
This is a necessity for testing on newly-built bench gimlet images -- even if `sparse` is included, I've been unable to get their zones to come up due to supposed publisher/incorporation lookup issues.

On the other hand, a helios experiment-image built with extra packages like iperf will place all those into the omicron1 baseline where we need them, so this is the simplest fix to run both halves on sn9/14.