### PR TITLE
VPC Subnet Routing

### DIFF
--- a/bench/src/packet.rs
+++ b/bench/src/packet.rs
@@ -295,6 +295,7 @@ impl BenchPacketInstance for UlpProcessInstance {
             &g1.port,
             IpCidr::Ip4("0.0.0.0/0".parse().unwrap()),
             RouterTarget::InternetGateway,
+            RouterClass::System,
         )
         .unwrap();
         incr!(g1, ["epoch", "router.rules.out"]);
@@ -303,6 +304,7 @@ impl BenchPacketInstance for UlpProcessInstance {
             &g1.port,
             IpCidr::Ip6("::/0".parse().unwrap()),
             RouterTarget::InternetGateway,
+            RouterClass::System,
         )
         .unwrap();
         incr!(g1, ["epoch", "router.rules.out"]);

--- a/bin/opteadm/src/bin/opteadm.rs
+++ b/bin/opteadm/src/bin/opteadm.rs
@@ -244,7 +244,7 @@ enum Command {
         external_net: ExternalNetConfig,
     },
 
-    /// Allows a guest to send and receive traffic on a given CIDR block.
+    /// Allows a guest to send or receive traffic on a given CIDR block.
     AllowCidr {
         /// The OPTE port to configure
         #[arg(short)]
@@ -252,6 +252,11 @@ enum Command {
 
         /// The IP block to allow through the gateway.
         prefix: IpCidr,
+
+        /// Control whether traffic on the CIDR should be allowed for
+        /// inbound or outbound traffic.
+        #[arg(long = "dir")]
+        direction: Direction,
     },
 
     /// Prevents a guest from sending/receiving traffic on a given CIDR block.
@@ -262,6 +267,11 @@ enum Command {
 
         /// The IP block to deny at the gateway.
         prefix: IpCidr,
+
+        /// Control whether traffic on the CIDR should be allowed for
+        /// inbound or outbound traffic.
+        #[arg(long = "dir")]
+        direction: Direction,
     },
 }
 
@@ -788,12 +798,14 @@ fn main() -> anyhow::Result<()> {
             }
         }
 
-        Command::AllowCidr { port, prefix } => {
-            hdl.allow_cidr(&port, prefix)?;
+        Command::AllowCidr { port, prefix, direction } => {
+            hdl.allow_cidr(&port, prefix, direction)?;
         }
 
-        Command::RemoveCidr { port, prefix } => {
-            if let RemoveCidrResp::NotFound = hdl.remove_cidr(&port, prefix)? {
+        Command::RemoveCidr { port, prefix, direction } => {
+            if let RemoveCidrResp::NotFound =
+                hdl.remove_cidr(&port, prefix, direction)?
+            {
                 anyhow::bail!(
                     "could not remove cidr {prefix} from gateway -- not found"
                 );

--- a/bin/opteadm/src/bin/opteadm.rs
+++ b/bin/opteadm/src/bin/opteadm.rs
@@ -26,6 +26,7 @@ use oxide_vpc::api::AddRouterEntryReq;
 use oxide_vpc::api::Address;
 use oxide_vpc::api::ClearVirt2BoundaryReq;
 use oxide_vpc::api::DelRouterEntryReq;
+use oxide_vpc::api::DelRouterEntryResp;
 use oxide_vpc::api::DhcpCfg;
 use oxide_vpc::api::ExternalIpCfg;
 use oxide_vpc::api::Filters as FirewallFilters;
@@ -711,7 +712,11 @@ fn main() -> anyhow::Result<()> {
         } => {
             let req =
                 DelRouterEntryReq { port_name: port, dest, target, class };
-            hdl.del_router_entry(&req)?;
+            if let DelRouterEntryResp::NotFound = hdl.del_router_entry(&req)? {
+                anyhow::bail!(
+                    "could not delete entry -- no matching rule found"
+                );
+            }
         }
 
         Command::SetExternalIps { port, external_net } => {

--- a/bin/opteadm/src/lib.rs
+++ b/bin/opteadm/src/lib.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 //! OPTE driver administration library
 
@@ -16,6 +16,7 @@ use oxide_vpc::api::AddFwRuleReq;
 use oxide_vpc::api::AddRouterEntryReq;
 use oxide_vpc::api::ClearVirt2BoundaryReq;
 use oxide_vpc::api::CreateXdeReq;
+use oxide_vpc::api::DelRouterEntryReq;
 use oxide_vpc::api::DeleteXdeReq;
 use oxide_vpc::api::DhcpCfg;
 use oxide_vpc::api::FirewallRule;
@@ -256,6 +257,14 @@ impl OpteAdm {
         req: &AddRouterEntryReq,
     ) -> Result<NoResp, Error> {
         let cmd = OpteCmd::AddRouterEntry;
+        run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req))
+    }
+
+    pub fn del_router_entry(
+        &self,
+        req: &DelRouterEntryReq,
+    ) -> Result<NoResp, Error> {
+        let cmd = OpteCmd::DelRouterEntry;
         run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req))
     }
 

--- a/bin/opteadm/src/lib.rs
+++ b/bin/opteadm/src/lib.rs
@@ -6,6 +6,7 @@
 
 //! OPTE driver administration library
 
+use opte::api::IpCidr;
 use opte::api::NoResp;
 use opte::api::OpteCmd;
 use opte::api::SetXdeUnderlayReq;
@@ -14,6 +15,7 @@ use opte_ioctl::run_cmd_ioctl;
 use opte_ioctl::Error;
 use oxide_vpc::api::AddFwRuleReq;
 use oxide_vpc::api::AddRouterEntryReq;
+use oxide_vpc::api::AllowCidrReq;
 use oxide_vpc::api::ClearVirt2BoundaryReq;
 use oxide_vpc::api::CreateXdeReq;
 use oxide_vpc::api::DelRouterEntryReq;
@@ -23,6 +25,8 @@ use oxide_vpc::api::DhcpCfg;
 use oxide_vpc::api::FirewallRule;
 use oxide_vpc::api::ListPortsResp;
 use oxide_vpc::api::RemFwRuleReq;
+use oxide_vpc::api::RemoveCidrReq;
+use oxide_vpc::api::RemoveCidrResp;
 use oxide_vpc::api::SetExternalIpsReq;
 use oxide_vpc::api::SetFwRulesReq;
 use oxide_vpc::api::SetVirt2BoundaryReq;
@@ -275,5 +279,31 @@ impl OpteAdm {
     ) -> Result<NoResp, Error> {
         let cmd = OpteCmd::SetExternalIps;
         run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req))
+    }
+
+    pub fn allow_cidr(
+        &self,
+        port_name: &str,
+        cidr: IpCidr,
+    ) -> Result<NoResp, Error> {
+        let cmd = OpteCmd::AllowCidr;
+        run_cmd_ioctl(
+            self.device.as_raw_fd(),
+            cmd,
+            Some(&AllowCidrReq { cidr, port_name: port_name.into() }),
+        )
+    }
+
+    pub fn remove_cidr(
+        &self,
+        port_name: &str,
+        cidr: IpCidr,
+    ) -> Result<RemoveCidrResp, Error> {
+        let cmd = OpteCmd::RemoveCidr;
+        run_cmd_ioctl(
+            self.device.as_raw_fd(),
+            cmd,
+            Some(&RemoveCidrReq { cidr, port_name: port_name.into() }),
+        )
     }
 }

--- a/bin/opteadm/src/lib.rs
+++ b/bin/opteadm/src/lib.rs
@@ -17,6 +17,7 @@ use oxide_vpc::api::AddRouterEntryReq;
 use oxide_vpc::api::ClearVirt2BoundaryReq;
 use oxide_vpc::api::CreateXdeReq;
 use oxide_vpc::api::DelRouterEntryReq;
+use oxide_vpc::api::DelRouterEntryResp;
 use oxide_vpc::api::DeleteXdeReq;
 use oxide_vpc::api::DhcpCfg;
 use oxide_vpc::api::FirewallRule;
@@ -263,7 +264,7 @@ impl OpteAdm {
     pub fn del_router_entry(
         &self,
         req: &DelRouterEntryReq,
-    ) -> Result<NoResp, Error> {
+    ) -> Result<DelRouterEntryResp, Error> {
         let cmd = OpteCmd::DelRouterEntry;
         run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req))
     }

--- a/bin/opteadm/src/lib.rs
+++ b/bin/opteadm/src/lib.rs
@@ -7,6 +7,7 @@
 //! OPTE driver administration library
 
 use opte::api::ClearXdeUnderlayReq;
+use opte::api::Direction;
 use opte::api::IpCidr;
 use opte::api::NoResp;
 use opte::api::OpteCmd;
@@ -302,12 +303,13 @@ impl OpteAdm {
         &self,
         port_name: &str,
         cidr: IpCidr,
+        dir: Direction,
     ) -> Result<NoResp, Error> {
         let cmd = OpteCmd::AllowCidr;
         run_cmd_ioctl(
             self.device.as_raw_fd(),
             cmd,
-            Some(&AllowCidrReq { cidr, port_name: port_name.into() }),
+            Some(&AllowCidrReq { cidr, port_name: port_name.into(), dir }),
         )
     }
 
@@ -315,12 +317,13 @@ impl OpteAdm {
         &self,
         port_name: &str,
         cidr: IpCidr,
+        dir: Direction,
     ) -> Result<RemoveCidrResp, Error> {
         let cmd = OpteCmd::RemoveCidr;
         run_cmd_ioctl(
             self.device.as_raw_fd(),
             cmd,
-            Some(&RemoveCidrReq { cidr, port_name: port_name.into() }),
+            Some(&RemoveCidrReq { cidr, port_name: port_name.into(), dir }),
         )
     }
 }

--- a/crates/opte-api/src/cmd.rs
+++ b/crates/opte-api/src/cmd.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 use super::encap::Vni;
 use super::ip::IpCidr;
@@ -36,6 +36,7 @@ pub enum OpteCmd {
     ClearVirt2Boundary = 53, // clear a v2b mapping
     DumpVirt2Boundary = 54,  // dump the v2b mappings
     AddRouterEntry = 60,     // add a router entry for IP dest
+    DelRouterEntry = 61,     // remove a router entry for IP dest
     CreateXde = 70,          // create a new xde device
     DeleteXde = 71,          // delete an xde device
     SetXdeUnderlay = 72,     // set xde underlay devices
@@ -63,6 +64,7 @@ impl TryFrom<c_int> for OpteCmd {
             53 => Ok(Self::ClearVirt2Boundary),
             54 => Ok(Self::DumpVirt2Boundary),
             60 => Ok(Self::AddRouterEntry),
+            61 => Ok(Self::DelRouterEntry),
             70 => Ok(Self::CreateXde),
             71 => Ok(Self::DeleteXde),
             72 => Ok(Self::SetXdeUnderlay),

--- a/crates/opte-api/src/cmd.rs
+++ b/crates/opte-api/src/cmd.rs
@@ -41,6 +41,8 @@ pub enum OpteCmd {
     DeleteXde = 71,          // delete an xde device
     SetXdeUnderlay = 72,     // set xde underlay devices
     SetExternalIps = 80,     // set xde external IPs for a port
+    AllowCidr = 90,          // allow ip block through gateway tx/rx
+    RemoveCidr = 91,         // deny ip block through gateway tx/rx
 }
 
 impl TryFrom<c_int> for OpteCmd {
@@ -69,6 +71,8 @@ impl TryFrom<c_int> for OpteCmd {
             71 => Ok(Self::DeleteXde),
             72 => Ok(Self::SetXdeUnderlay),
             80 => Ok(Self::SetExternalIps),
+            90 => Ok(Self::AllowCidr),
+            91 => Ok(Self::RemoveCidr),
             _ => Err(()),
         }
     }

--- a/crates/opte-api/src/ip.rs
+++ b/crates/opte-api/src/ip.rs
@@ -844,6 +844,13 @@ impl IpCidr {
             Self::Ip6(ip6) => ip6.prefix_len(),
         }
     }
+
+    pub fn max_prefix_len(&self) -> u8 {
+        match self {
+            Self::Ip4(_) => Ipv4PrefixLen::NETMASK_ALL.val(),
+            Self::Ip6(_) => Ipv6PrefixLen::NETMASK_ALL.val(),
+        }
+    }
 }
 
 impl fmt::Display for IpCidr {

--- a/crates/opte-api/src/lib.rs
+++ b/crates/opte-api/src/lib.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 #![no_std]
 #![deny(unreachable_patterns)]
@@ -47,7 +47,7 @@ pub use ulp::*;
 ///
 /// We rely on CI and the check-api-version.sh script to verify that
 /// this number is incremented anytime the oxide-api code changes.
-pub const API_VERSION: u64 = 28;
+pub const API_VERSION: u64 = 29;
 
 /// Major version of the OPTE package.
 pub const MAJOR_VERSION: u64 = 0;

--- a/lib/opte-ioctl/src/lib.rs
+++ b/lib/opte-ioctl/src/lib.rs
@@ -6,6 +6,7 @@
 
 use opte::api::ClearXdeUnderlayReq;
 use opte::api::CmdOk;
+use opte::api::Direction;
 use opte::api::NoResp;
 use opte::api::OpteCmd;
 use opte::api::OpteCmdIoctl;
@@ -234,12 +235,13 @@ impl OpteHdl {
         &self,
         port_name: &str,
         cidr: IpCidr,
+        dir: Direction,
     ) -> Result<NoResp, Error> {
         let cmd = OpteCmd::AllowCidr;
         run_cmd_ioctl(
             self.device.as_raw_fd(),
             cmd,
-            Some(&AllowCidrReq { cidr, port_name: port_name.into() }),
+            Some(&AllowCidrReq { cidr, port_name: port_name.into(), dir }),
         )
     }
 
@@ -247,12 +249,13 @@ impl OpteHdl {
         &self,
         port_name: &str,
         cidr: IpCidr,
+        dir: Direction,
     ) -> Result<RemoveCidrResp, Error> {
         let cmd = OpteCmd::RemoveCidr;
         run_cmd_ioctl(
             self.device.as_raw_fd(),
             cmd,
-            Some(&RemoveCidrReq { cidr, port_name: port_name.into() }),
+            Some(&RemoveCidrReq { cidr, port_name: port_name.into(), dir }),
         )
     }
 }

--- a/lib/opte-ioctl/src/lib.rs
+++ b/lib/opte-ioctl/src/lib.rs
@@ -13,13 +13,17 @@ use opte::api::SetXdeUnderlayReq;
 use opte::api::API_VERSION;
 use opte::api::XDE_IOC_OPTE_CMD;
 use oxide_vpc::api::AddRouterEntryReq;
+use oxide_vpc::api::AllowCidrReq;
 use oxide_vpc::api::ClearVirt2BoundaryReq;
 use oxide_vpc::api::CreateXdeReq;
 use oxide_vpc::api::DelRouterEntryReq;
 use oxide_vpc::api::DelRouterEntryResp;
 use oxide_vpc::api::DeleteXdeReq;
 use oxide_vpc::api::DhcpCfg;
+use oxide_vpc::api::IpCidr;
 use oxide_vpc::api::ListPortsResp;
+use oxide_vpc::api::RemoveCidrReq;
+use oxide_vpc::api::RemoveCidrResp;
 use oxide_vpc::api::SetExternalIpsReq;
 use oxide_vpc::api::SetFwRulesReq;
 use oxide_vpc::api::SetVirt2BoundaryReq;
@@ -200,6 +204,32 @@ impl OpteHdl {
     ) -> Result<NoResp, Error> {
         let cmd = OpteCmd::SetExternalIps;
         run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req))
+    }
+
+    pub fn allow_cidr(
+        &self,
+        port_name: &str,
+        cidr: IpCidr,
+    ) -> Result<NoResp, Error> {
+        let cmd = OpteCmd::AllowCidr;
+        run_cmd_ioctl(
+            self.device.as_raw_fd(),
+            cmd,
+            Some(&AllowCidrReq { cidr, port_name: port_name.into() }),
+        )
+    }
+
+    pub fn remove_cidr(
+        &self,
+        port_name: &str,
+        cidr: IpCidr,
+    ) -> Result<RemoveCidrResp, Error> {
+        let cmd = OpteCmd::RemoveCidr;
+        run_cmd_ioctl(
+            self.device.as_raw_fd(),
+            cmd,
+            Some(&RemoveCidrReq { cidr, port_name: port_name.into() }),
+        )
     }
 }
 

--- a/lib/opte-ioctl/src/lib.rs
+++ b/lib/opte-ioctl/src/lib.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 use opte::api::CmdOk;
 use opte::api::NoResp;
@@ -15,6 +15,7 @@ use opte::api::XDE_IOC_OPTE_CMD;
 use oxide_vpc::api::AddRouterEntryReq;
 use oxide_vpc::api::ClearVirt2BoundaryReq;
 use oxide_vpc::api::CreateXdeReq;
+use oxide_vpc::api::DelRouterEntryReq;
 use oxide_vpc::api::DeleteXdeReq;
 use oxide_vpc::api::DhcpCfg;
 use oxide_vpc::api::ListPortsResp;
@@ -176,6 +177,14 @@ impl OpteHdl {
         req: &AddRouterEntryReq,
     ) -> Result<NoResp, Error> {
         let cmd = OpteCmd::AddRouterEntry;
+        run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req))
+    }
+
+    pub fn del_router_entry(
+        &self,
+        req: &DelRouterEntryReq,
+    ) -> Result<NoResp, Error> {
+        let cmd = OpteCmd::DelRouterEntry;
         run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req))
     }
 

--- a/lib/opte-ioctl/src/lib.rs
+++ b/lib/opte-ioctl/src/lib.rs
@@ -16,6 +16,7 @@ use oxide_vpc::api::AddRouterEntryReq;
 use oxide_vpc::api::ClearVirt2BoundaryReq;
 use oxide_vpc::api::CreateXdeReq;
 use oxide_vpc::api::DelRouterEntryReq;
+use oxide_vpc::api::DelRouterEntryResp;
 use oxide_vpc::api::DeleteXdeReq;
 use oxide_vpc::api::DhcpCfg;
 use oxide_vpc::api::ListPortsResp;
@@ -183,7 +184,7 @@ impl OpteHdl {
     pub fn del_router_entry(
         &self,
         req: &DelRouterEntryReq,
-    ) -> Result<NoResp, Error> {
+    ) -> Result<DelRouterEntryResp, Error> {
         let cmd = OpteCmd::DelRouterEntry;
         run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req))
     }

--- a/lib/opte-test-utils/src/lib.rs
+++ b/lib/opte-test-utils/src/lib.rs
@@ -63,6 +63,7 @@ pub use oxide_vpc::api::IpCfg;
 pub use oxide_vpc::api::Ipv4Cfg;
 pub use oxide_vpc::api::Ipv6Cfg;
 pub use oxide_vpc::api::PhysNet;
+pub use oxide_vpc::api::RouterClass;
 pub use oxide_vpc::api::RouterTarget;
 pub use oxide_vpc::api::SNat4Cfg;
 pub use oxide_vpc::api::SNat6Cfg;
@@ -333,6 +334,7 @@ pub fn oxide_net_setup2(
         &port,
         IpCidr::Ip4(cfg.ipv4().vpc_subnet),
         RouterTarget::VpcSubnet(IpCidr::Ip4(cfg.ipv4().vpc_subnet)),
+        RouterClass::System,
     )
     .unwrap();
 

--- a/lib/opte/src/engine/port.rs
+++ b/lib/opte/src/engine/port.rs
@@ -710,7 +710,7 @@ macro_rules! check_state {
 
 impl<N: NetworkImpl> Port<N> {
     /// Return the [`NetworkImpl`] associated with this port.
-    pub fn network(&self) -> &dyn NetworkImpl<Parser = N::Parser> {
+    pub fn network(&self) -> &N {
         &self.net
     }
 

--- a/lib/oxide-vpc/src/api.rs
+++ b/lib/oxide-vpc/src/api.rs
@@ -939,20 +939,22 @@ impl Display for Ports {
     }
 }
 
-/// Add an entry to the gateway allowing a port to send and receive
+/// Add an entry to the gateway allowing a port to send or receive
 /// traffic on a CIDR other than its private IP.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AllowCidrReq {
     pub port_name: String,
     pub cidr: IpCidr,
+    pub dir: Direction,
 }
 
-/// Remove entries from the gateway allowing a port to send and receive
+/// Remove entries from the gateway allowing a port to send or receive
 /// traffic on a specific CIDR other than its private IP.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoveCidrReq {
     pub port_name: String,
     pub cidr: IpCidr,
+    pub dir: Direction,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/lib/oxide-vpc/src/api.rs
+++ b/lib/oxide-vpc/src/api.rs
@@ -959,7 +959,7 @@ pub struct RemoveCidrReq {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum RemoveCidrResp {
-    Ok,
+    Ok(IpCidr),
     NotFound,
 }
 

--- a/lib/oxide-vpc/src/api.rs
+++ b/lib/oxide-vpc/src/api.rs
@@ -556,6 +556,8 @@ pub enum DelRouterEntryResp {
     NotFound,
 }
 
+impl opte::api::cmd::CmdOk for DelRouterEntryResp {}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SetExternalIpsReq {
     pub port_name: String,

--- a/lib/oxide-vpc/src/api.rs
+++ b/lib/oxide-vpc/src/api.rs
@@ -542,6 +542,8 @@ pub struct AddRouterEntryReq {
     pub class: RouterClass,
 }
 
+/// Remove an entry to the router. Addresses may be either IPv4 or IPv6, though the
+/// destination and target must match in protocol version.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DelRouterEntryReq {
     pub port_name: String,
@@ -889,6 +891,30 @@ impl Display for Ports {
         }
     }
 }
+
+/// Add an entry to the gateway allowing a port to send and receive
+/// traffic on a CIDR other than its private IP.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AllowCidrReq {
+    pub port_name: String,
+    pub cidr: IpCidr,
+}
+
+/// Remove entries from the gateway allowing a port to send and receive
+/// traffic on a specific CIDR other than its private IP.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RemoveCidrReq {
+    pub port_name: String,
+    pub cidr: IpCidr,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum RemoveCidrResp {
+    Ok,
+    NotFound,
+}
+
+impl opte::api::cmd::CmdOk for RemoveCidrResp {}
 
 #[cfg(test)]
 pub mod tests {

--- a/lib/oxide-vpc/src/engine/gateway/mod.rs
+++ b/lib/oxide-vpc/src/engine/gateway/mod.rs
@@ -42,6 +42,7 @@
 
 use crate::api::DhcpCfg;
 use crate::api::MacAddr;
+use crate::api::RemoveCidrResp;
 use crate::cfg::Ipv4Cfg;
 use crate::cfg::Ipv6Cfg;
 use crate::cfg::VpcCfg;
@@ -54,6 +55,8 @@ use core::fmt;
 use core::fmt::Display;
 use core::marker::PhantomData;
 use opte::api::Direction;
+use opte::api::IpCidr;
+use opte::api::NoResp;
 use opte::api::OpteError;
 use opte::engine::ether::EtherMod;
 use opte::engine::headers::HeaderAction;
@@ -63,6 +66,7 @@ use opte::engine::layer::LayerActions;
 use opte::engine::packet::InnerFlowId;
 use opte::engine::packet::PacketMeta;
 use opte::engine::port::meta::ActionMeta;
+use opte::engine::port::Port;
 use opte::engine::port::PortBuilder;
 use opte::engine::port::Pos;
 use opte::engine::predicate::DataPredicate;
@@ -72,12 +76,15 @@ use opte::engine::predicate::Ipv6AddrMatch;
 use opte::engine::predicate::Predicate;
 use opte::engine::rule::Action;
 use opte::engine::rule::AllowOrDeny;
+use opte::engine::rule::Finalized;
 use opte::engine::rule::GenHtResult;
 use opte::engine::rule::HdrTransform;
 use opte::engine::rule::MetaAction;
 use opte::engine::rule::ModMetaResult;
 use opte::engine::rule::Rule;
 use opte::engine::rule::StaticAction;
+
+use super::VpcNetwork;
 
 pub mod arp;
 pub mod dhcp;
@@ -274,4 +281,88 @@ impl Display for VpcMeta {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "vpc-meta")
     }
+}
+
+fn make_holepunch_rules(
+    guest_mac: MacAddr,
+    gateway_mac: MacAddr,
+    dest: IpCidr,
+    vpc_mappings: Arc<VpcMappings>,
+) -> (Rule<Finalized>, Rule<Finalized>) {
+    let vpc_meta = Arc::new(VpcMeta::new(vpc_mappings));
+
+    let (cidr_in_pred, cidr_out_pred) = match dest {
+        IpCidr::Ip4(v4) => (
+            Predicate::InnerDstIp4(vec![Ipv4AddrMatch::Prefix(v4)]),
+            Predicate::InnerSrcIp4(vec![Ipv4AddrMatch::Prefix(v4)]),
+        ),
+        IpCidr::Ip6(v6) => (
+            Predicate::InnerDstIp6(vec![Ipv6AddrMatch::Prefix(v6)]),
+            Predicate::InnerSrcIp6(vec![Ipv6AddrMatch::Prefix(v6)]),
+        ),
+    };
+
+    let mut cidr_out = Rule::new(1000, Action::Meta(vpc_meta));
+    cidr_out.add_predicate(Predicate::InnerEtherSrc(vec![
+        EtherAddrMatch::Exact(guest_mac),
+    ]));
+    cidr_out.add_predicate(cidr_out_pred);
+
+    let mut cidr_in = Rule::new(
+        1000,
+        Action::Static(Arc::new(RewriteSrcMac { gateway_mac })),
+    );
+    cidr_in.add_predicate(cidr_in_pred);
+    cidr_in.add_predicate(Predicate::InnerEtherDst(vec![
+        EtherAddrMatch::Exact(guest_mac),
+    ]));
+
+    (cidr_in.finalize(), cidr_out.finalize())
+}
+
+/// Allows a guest to send and receive traffic on a CIDR block
+/// other than their private IP.
+pub fn allow_cidr(
+    port: &Port<VpcNetwork>,
+    dest: IpCidr,
+    vpc_mappings: Arc<VpcMappings>,
+) -> Result<NoResp, OpteError> {
+    let (in_rule, out_rule) = make_holepunch_rules(
+        port.mac_addr(),
+        port.network().cfg.gateway_mac,
+        dest,
+        vpc_mappings,
+    );
+    port.add_rule(NAME, Direction::In, in_rule)?;
+    port.add_rule(NAME, Direction::Out, out_rule)?;
+    Ok(NoResp::default())
+}
+
+/// Prevents a guest from sending/receiving traffic on a CIDR block
+/// other than their private IP.
+pub fn remove_cidr(
+    port: &Port<VpcNetwork>,
+    dest: IpCidr,
+    vpc_mappings: Arc<VpcMappings>,
+) -> Result<RemoveCidrResp, OpteError> {
+    let (in_rule, out_rule) = make_holepunch_rules(
+        port.mac_addr(),
+        port.network().cfg.gateway_mac,
+        dest,
+        vpc_mappings,
+    );
+    let maybe_in_id = port.find_rule(NAME, Direction::In, &in_rule)?;
+    let maybe_out_id = port.find_rule(NAME, Direction::Out, &out_rule)?;
+    if let Some(id) = maybe_in_id {
+        port.remove_rule(NAME, Direction::In, id)?;
+    }
+    if let Some(id) = maybe_out_id {
+        port.remove_rule(NAME, Direction::Out, id)?;
+    }
+
+    Ok(if maybe_in_id.is_none() || maybe_out_id.is_none() {
+        RemoveCidrResp::NotFound
+    } else {
+        RemoveCidrResp::Ok
+    })
 }

--- a/lib/oxide-vpc/src/engine/gateway/mod.rs
+++ b/lib/oxide-vpc/src/engine/gateway/mod.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 //! The Oxide VPC Virtual Gateway.
 //!
@@ -42,7 +42,6 @@
 
 use crate::api::DhcpCfg;
 use crate::api::MacAddr;
-use crate::api::RemoveCidrResp;
 use crate::cfg::Ipv4Cfg;
 use crate::cfg::Ipv6Cfg;
 use crate::cfg::VpcCfg;
@@ -55,8 +54,6 @@ use core::fmt;
 use core::fmt::Display;
 use core::marker::PhantomData;
 use opte::api::Direction;
-use opte::api::IpCidr;
-use opte::api::NoResp;
 use opte::api::OpteError;
 use opte::engine::ether::EtherMod;
 use opte::engine::headers::HeaderAction;
@@ -66,7 +63,6 @@ use opte::engine::layer::LayerActions;
 use opte::engine::packet::InnerFlowId;
 use opte::engine::packet::PacketMeta;
 use opte::engine::port::meta::ActionMeta;
-use opte::engine::port::Port;
 use opte::engine::port::PortBuilder;
 use opte::engine::port::Pos;
 use opte::engine::predicate::DataPredicate;
@@ -76,7 +72,6 @@ use opte::engine::predicate::Ipv6AddrMatch;
 use opte::engine::predicate::Predicate;
 use opte::engine::rule::Action;
 use opte::engine::rule::AllowOrDeny;
-use opte::engine::rule::Finalized;
 use opte::engine::rule::GenHtResult;
 use opte::engine::rule::HdrTransform;
 use opte::engine::rule::MetaAction;
@@ -84,13 +79,13 @@ use opte::engine::rule::ModMetaResult;
 use opte::engine::rule::Rule;
 use opte::engine::rule::StaticAction;
 
-use super::VpcNetwork;
-
 pub mod arp;
 pub mod dhcp;
 pub mod dhcpv6;
 pub mod icmp;
 pub mod icmpv6;
+mod transit;
+pub use transit::*;
 
 pub const NAME: &str = "gateway";
 
@@ -281,88 +276,4 @@ impl Display for VpcMeta {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "vpc-meta")
     }
-}
-
-fn make_holepunch_rules(
-    guest_mac: MacAddr,
-    gateway_mac: MacAddr,
-    dest: IpCidr,
-    vpc_mappings: Arc<VpcMappings>,
-) -> (Rule<Finalized>, Rule<Finalized>) {
-    let vpc_meta = Arc::new(VpcMeta::new(vpc_mappings));
-
-    let (cidr_in_pred, cidr_out_pred) = match dest {
-        IpCidr::Ip4(v4) => (
-            Predicate::InnerDstIp4(vec![Ipv4AddrMatch::Prefix(v4)]),
-            Predicate::InnerSrcIp4(vec![Ipv4AddrMatch::Prefix(v4)]),
-        ),
-        IpCidr::Ip6(v6) => (
-            Predicate::InnerDstIp6(vec![Ipv6AddrMatch::Prefix(v6)]),
-            Predicate::InnerSrcIp6(vec![Ipv6AddrMatch::Prefix(v6)]),
-        ),
-    };
-
-    let mut cidr_out = Rule::new(1000, Action::Meta(vpc_meta));
-    cidr_out.add_predicate(Predicate::InnerEtherSrc(vec![
-        EtherAddrMatch::Exact(guest_mac),
-    ]));
-    cidr_out.add_predicate(cidr_out_pred);
-
-    let mut cidr_in = Rule::new(
-        1000,
-        Action::Static(Arc::new(RewriteSrcMac { gateway_mac })),
-    );
-    cidr_in.add_predicate(cidr_in_pred);
-    cidr_in.add_predicate(Predicate::InnerEtherDst(vec![
-        EtherAddrMatch::Exact(guest_mac),
-    ]));
-
-    (cidr_in.finalize(), cidr_out.finalize())
-}
-
-/// Allows a guest to send and receive traffic on a CIDR block
-/// other than their private IP.
-pub fn allow_cidr(
-    port: &Port<VpcNetwork>,
-    dest: IpCidr,
-    vpc_mappings: Arc<VpcMappings>,
-) -> Result<NoResp, OpteError> {
-    let (in_rule, out_rule) = make_holepunch_rules(
-        port.mac_addr(),
-        port.network().cfg.gateway_mac,
-        dest,
-        vpc_mappings,
-    );
-    port.add_rule(NAME, Direction::In, in_rule)?;
-    port.add_rule(NAME, Direction::Out, out_rule)?;
-    Ok(NoResp::default())
-}
-
-/// Prevents a guest from sending/receiving traffic on a CIDR block
-/// other than their private IP.
-pub fn remove_cidr(
-    port: &Port<VpcNetwork>,
-    dest: IpCidr,
-    vpc_mappings: Arc<VpcMappings>,
-) -> Result<RemoveCidrResp, OpteError> {
-    let (in_rule, out_rule) = make_holepunch_rules(
-        port.mac_addr(),
-        port.network().cfg.gateway_mac,
-        dest,
-        vpc_mappings,
-    );
-    let maybe_in_id = port.find_rule(NAME, Direction::In, &in_rule)?;
-    let maybe_out_id = port.find_rule(NAME, Direction::Out, &out_rule)?;
-    if let Some(id) = maybe_in_id {
-        port.remove_rule(NAME, Direction::In, id)?;
-    }
-    if let Some(id) = maybe_out_id {
-        port.remove_rule(NAME, Direction::Out, id)?;
-    }
-
-    Ok(if maybe_in_id.is_none() || maybe_out_id.is_none() {
-        RemoveCidrResp::NotFound
-    } else {
-        RemoveCidrResp::Ok
-    })
 }

--- a/lib/oxide-vpc/src/engine/gateway/transit.rs
+++ b/lib/oxide-vpc/src/engine/gateway/transit.rs
@@ -1,0 +1,101 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2024 Oxide Computer Company
+
+//! Utility functions to allow a port to permit traffic on an
+//! additional set of CIDR blocks, e.g. to enable transit for
+//! VPC-wide VPN traffic.
+
+use super::*;
+use crate::api::RemoveCidrResp;
+use crate::engine::VpcNetwork;
+use opte::api::IpCidr;
+use opte::api::NoResp;
+use opte::engine::port::Port;
+use opte::engine::rule::Finalized;
+
+fn make_holepunch_rules(
+    guest_mac: MacAddr,
+    gateway_mac: MacAddr,
+    dest: IpCidr,
+    vpc_mappings: Arc<VpcMappings>,
+) -> (Rule<Finalized>, Rule<Finalized>) {
+    let vpc_meta = Arc::new(VpcMeta::new(vpc_mappings));
+
+    let (cidr_in_pred, cidr_out_pred) = match dest {
+        IpCidr::Ip4(v4) => (
+            Predicate::InnerDstIp4(vec![Ipv4AddrMatch::Prefix(v4)]),
+            Predicate::InnerSrcIp4(vec![Ipv4AddrMatch::Prefix(v4)]),
+        ),
+        IpCidr::Ip6(v6) => (
+            Predicate::InnerDstIp6(vec![Ipv6AddrMatch::Prefix(v6)]),
+            Predicate::InnerSrcIp6(vec![Ipv6AddrMatch::Prefix(v6)]),
+        ),
+    };
+
+    let mut cidr_out = Rule::new(1000, Action::Meta(vpc_meta));
+    cidr_out.add_predicate(Predicate::InnerEtherSrc(vec![
+        EtherAddrMatch::Exact(guest_mac),
+    ]));
+    cidr_out.add_predicate(cidr_out_pred);
+
+    let mut cidr_in = Rule::new(
+        1000,
+        Action::Static(Arc::new(RewriteSrcMac { gateway_mac })),
+    );
+    cidr_in.add_predicate(cidr_in_pred);
+    cidr_in.add_predicate(Predicate::InnerEtherDst(vec![
+        EtherAddrMatch::Exact(guest_mac),
+    ]));
+
+    (cidr_in.finalize(), cidr_out.finalize())
+}
+
+/// Allows a guest to send and receive traffic on a CIDR block
+/// other than their private IP.
+pub fn allow_cidr(
+    port: &Port<VpcNetwork>,
+    dest: IpCidr,
+    vpc_mappings: Arc<VpcMappings>,
+) -> Result<NoResp, OpteError> {
+    let (in_rule, out_rule) = make_holepunch_rules(
+        port.mac_addr(),
+        port.network().cfg.gateway_mac,
+        dest,
+        vpc_mappings,
+    );
+    port.add_rule(NAME, Direction::In, in_rule)?;
+    port.add_rule(NAME, Direction::Out, out_rule)?;
+    Ok(NoResp::default())
+}
+
+/// Prevents a guest from sending/receiving traffic on a CIDR block
+/// other than their private IP.
+pub fn remove_cidr(
+    port: &Port<VpcNetwork>,
+    dest: IpCidr,
+    vpc_mappings: Arc<VpcMappings>,
+) -> Result<RemoveCidrResp, OpteError> {
+    let (in_rule, out_rule) = make_holepunch_rules(
+        port.mac_addr(),
+        port.network().cfg.gateway_mac,
+        dest,
+        vpc_mappings,
+    );
+    let maybe_in_id = port.find_rule(NAME, Direction::In, &in_rule)?;
+    let maybe_out_id = port.find_rule(NAME, Direction::Out, &out_rule)?;
+    if let Some(id) = maybe_in_id {
+        port.remove_rule(NAME, Direction::In, id)?;
+    }
+    if let Some(id) = maybe_out_id {
+        port.remove_rule(NAME, Direction::Out, id)?;
+    }
+
+    Ok(if maybe_in_id.is_none() || maybe_out_id.is_none() {
+        RemoveCidrResp::NotFound
+    } else {
+        RemoveCidrResp::Ok
+    })
+}

--- a/lib/oxide-vpc/src/engine/gateway/transit.rs
+++ b/lib/oxide-vpc/src/engine/gateway/transit.rs
@@ -103,6 +103,6 @@ pub fn remove_cidr(
     Ok(if maybe_id.is_none() {
         RemoveCidrResp::NotFound
     } else {
-        RemoveCidrResp::Ok
+        RemoveCidrResp::Ok(dest)
     })
 }

--- a/lib/oxide-vpc/src/engine/gateway/transit.rs
+++ b/lib/oxide-vpc/src/engine/gateway/transit.rs
@@ -16,14 +16,13 @@ use opte::api::NoResp;
 use opte::engine::port::Port;
 use opte::engine::rule::Finalized;
 
-fn make_holepunch_rules(
+fn make_holepunch_rule(
     guest_mac: MacAddr,
     gateway_mac: MacAddr,
     dest: IpCidr,
+    dir: Direction,
     vpc_mappings: Arc<VpcMappings>,
-) -> (Rule<Finalized>, Rule<Finalized>) {
-    let vpc_meta = Arc::new(VpcMeta::new(vpc_mappings));
-
+) -> Rule<Finalized> {
     let (cidr_in_pred, cidr_out_pred) = match dest {
         IpCidr::Ip4(v4) => (
             Predicate::InnerDstIp4(vec![Ipv4AddrMatch::Prefix(v4)]),
@@ -35,39 +34,48 @@ fn make_holepunch_rules(
         ),
     };
 
-    let mut cidr_out = Rule::new(1000, Action::Meta(vpc_meta));
-    cidr_out.add_predicate(Predicate::InnerEtherSrc(vec![
-        EtherAddrMatch::Exact(guest_mac),
-    ]));
-    cidr_out.add_predicate(cidr_out_pred);
+    match dir {
+        Direction::In => {
+            let mut cidr_in = Rule::new(
+                1000,
+                Action::Static(Arc::new(RewriteSrcMac { gateway_mac })),
+            );
+            cidr_in.add_predicate(cidr_in_pred);
+            cidr_in.add_predicate(Predicate::InnerEtherDst(vec![
+                EtherAddrMatch::Exact(guest_mac),
+            ]));
 
-    let mut cidr_in = Rule::new(
-        1000,
-        Action::Static(Arc::new(RewriteSrcMac { gateway_mac })),
-    );
-    cidr_in.add_predicate(cidr_in_pred);
-    cidr_in.add_predicate(Predicate::InnerEtherDst(vec![
-        EtherAddrMatch::Exact(guest_mac),
-    ]));
+            cidr_in.finalize()
+        }
+        Direction::Out => {
+            let vpc_meta = Arc::new(VpcMeta::new(vpc_mappings));
+            let mut cidr_out = Rule::new(1000, Action::Meta(vpc_meta));
+            cidr_out.add_predicate(Predicate::InnerEtherSrc(vec![
+                EtherAddrMatch::Exact(guest_mac),
+            ]));
+            cidr_out.add_predicate(cidr_out_pred);
 
-    (cidr_in.finalize(), cidr_out.finalize())
+            cidr_out.finalize()
+        }
+    }
 }
 
-/// Allows a guest to send and receive traffic on a CIDR block
+/// Allows a guest to send or receive traffic on a CIDR block
 /// other than their private IP.
 pub fn allow_cidr(
     port: &Port<VpcNetwork>,
     dest: IpCidr,
+    dir: Direction,
     vpc_mappings: Arc<VpcMappings>,
 ) -> Result<NoResp, OpteError> {
-    let (in_rule, out_rule) = make_holepunch_rules(
+    let rule = make_holepunch_rule(
         port.mac_addr(),
         port.network().cfg.gateway_mac,
         dest,
+        dir,
         vpc_mappings,
     );
-    port.add_rule(NAME, Direction::In, in_rule)?;
-    port.add_rule(NAME, Direction::Out, out_rule)?;
+    port.add_rule(NAME, dir, rule)?;
     Ok(NoResp::default())
 }
 
@@ -76,24 +84,23 @@ pub fn allow_cidr(
 pub fn remove_cidr(
     port: &Port<VpcNetwork>,
     dest: IpCidr,
+    dir: Direction,
     vpc_mappings: Arc<VpcMappings>,
 ) -> Result<RemoveCidrResp, OpteError> {
-    let (in_rule, out_rule) = make_holepunch_rules(
+    let rule = make_holepunch_rule(
         port.mac_addr(),
         port.network().cfg.gateway_mac,
         dest,
+        dir,
         vpc_mappings,
     );
-    let maybe_in_id = port.find_rule(NAME, Direction::In, &in_rule)?;
-    let maybe_out_id = port.find_rule(NAME, Direction::Out, &out_rule)?;
-    if let Some(id) = maybe_in_id {
-        port.remove_rule(NAME, Direction::In, id)?;
-    }
-    if let Some(id) = maybe_out_id {
-        port.remove_rule(NAME, Direction::Out, id)?;
+
+    let maybe_id = port.find_rule(NAME, dir, &rule)?;
+    if let Some(id) = maybe_id {
+        port.remove_rule(NAME, dir, id)?;
     }
 
-    Ok(if maybe_in_id.is_none() || maybe_out_id.is_none() {
+    Ok(if maybe_id.is_none() {
         RemoveCidrResp::NotFound
     } else {
         RemoveCidrResp::Ok

--- a/lib/oxide-vpc/src/engine/router.rs
+++ b/lib/oxide-vpc/src/engine/router.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2023 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 //! The Oxide Network VPC Router.
 //!
@@ -164,13 +164,8 @@ impl fmt::Display for RouterTargetInternal {
 // |0          |1      |267 = ((128 - 0) << 1 | 1) + 10  |
 // ```
 fn compute_rule_priority(cidr: &IpCidr, class: RouterClass) -> u16 {
-    use opte::api::ip::IpCidr::*;
-    use opte::api::ip::Ipv4PrefixLen;
-    use opte::api::ip::Ipv6PrefixLen;
-    let (max_prefix_len, prefix_len) = match cidr {
-        Ip4(ipv4) => (Ipv4PrefixLen::NETMASK_ALL.val(), ipv4.prefix_len()),
-        Ip6(ipv6) => (Ipv6PrefixLen::NETMASK_ALL.val(), ipv6.prefix_len()),
-    };
+    let max_prefix_len = cidr.max_prefix_len();
+    let prefix_len = cidr.prefix_len();
     let class_prio = match class {
         RouterClass::Custom => 0,
         RouterClass::System => 1,

--- a/lib/oxide-vpc/tests/integration_tests.rs
+++ b/lib/oxide-vpc/tests/integration_tests.rs
@@ -4152,7 +4152,10 @@ fn port_as_router_target() {
     incr!(g1, ["epoch", "router.rules.out"]);
 
     // This also requires that we allow g2 to send/recv on this CIDR.
-    gateway::allow_cidr(&g2.port, cidr, g2.vpc_map.clone()).unwrap();
+    gateway::allow_cidr(&g2.port, cidr, Direction::In, g2.vpc_map.clone())
+        .unwrap();
+    gateway::allow_cidr(&g2.port, cidr, Direction::Out, g2.vpc_map.clone())
+        .unwrap();
     incr!(g2, ["epoch, epoch, gateway.rules.out, gateway.rules.in"]);
 
     let data = b"1234\0";

--- a/lib/oxide-vpc/tests/integration_tests.rs
+++ b/lib/oxide-vpc/tests/integration_tests.rs
@@ -52,6 +52,7 @@ use opte::engine::udp::UdpMeta;
 use opte::engine::Direction;
 use oxide_vpc::api::ExternalIpCfg;
 use oxide_vpc::api::FirewallRule;
+use oxide_vpc::api::RouterClass;
 use oxide_vpc::api::VpcCfg;
 use oxide_vpc::engine::overlay::BOUNDARY_SERVICES_VNI;
 use pcap::*;
@@ -267,6 +268,7 @@ fn port_transition_pause() {
             RouterTarget::VpcSubnet(IpCidr::Ip4(
                 g2_cfg.ipv4_cfg().unwrap().vpc_subnet
             )),
+            RouterClass::System,
         ),
         Err(OpteError::BadState(_))
     ));
@@ -444,6 +446,7 @@ fn guest_to_guest_no_route() {
         &g1.port,
         IpCidr::Ip4(g1_cfg.ipv4().vpc_subnet),
         RouterTarget::VpcSubnet(IpCidr::Ip4(g1_cfg.ipv4().vpc_subnet)),
+        RouterClass::System,
     )
     .unwrap();
     update!(g1, ["incr:epoch", "set:router.rules.out=0"]);
@@ -707,6 +710,7 @@ fn guest_to_internet_ipv4() {
         &g1.port,
         IpCidr::Ip4("0.0.0.0/0".parse().unwrap()),
         RouterTarget::InternetGateway,
+        RouterClass::System,
     )
     .unwrap();
     incr!(g1, ["epoch", "router.rules.out"]);
@@ -830,6 +834,7 @@ fn guest_to_internet_ipv6() {
         &g1.port,
         IpCidr::Ip6("::/0".parse().unwrap()),
         RouterTarget::InternetGateway,
+        RouterClass::System,
     )
     .unwrap();
     incr!(g1, ["epoch", "router.rules.out"]);
@@ -1027,6 +1032,7 @@ fn multi_external_ip_setup(
         &g1.port,
         IpCidr::Ip6("::/0".parse().unwrap()),
         RouterTarget::InternetGateway,
+        RouterClass::System,
     )
     .unwrap();
     incr!(g1, ["epoch", "router.rules.out"]);
@@ -1034,6 +1040,7 @@ fn multi_external_ip_setup(
         &g1.port,
         IpCidr::Ip4("0.0.0.0/0".parse().unwrap()),
         RouterTarget::InternetGateway,
+        RouterClass::System,
     )
     .unwrap();
     incr!(g1, ["epoch", "router.rules.out"]);
@@ -1644,6 +1651,7 @@ fn snat_icmp_shared_echo_rewrite(dst_ip: IpAddr) {
         &g1.port,
         IpCidr::Ip6("::/0".parse().unwrap()),
         RouterTarget::InternetGateway,
+        RouterClass::System,
     )
     .unwrap();
     incr!(g1, ["epoch", "router.rules.out"]);
@@ -1651,6 +1659,7 @@ fn snat_icmp_shared_echo_rewrite(dst_ip: IpAddr) {
         &g1.port,
         IpCidr::Ip4("0.0.0.0/0".parse().unwrap()),
         RouterTarget::InternetGateway,
+        RouterClass::System,
     )
     .unwrap();
     incr!(g1, ["epoch", "router.rules.out"]);
@@ -2523,6 +2532,7 @@ fn outbound_ndp_dropped() {
         &g1.port,
         IpCidr::Ip6(ipv6.vpc_subnet),
         RouterTarget::VpcSubnet(IpCidr::Ip6(ipv6.vpc_subnet)),
+        RouterClass::System,
     )
     .unwrap();
     incr!(g1, ["router.rules.out", "epoch"]);
@@ -2532,6 +2542,7 @@ fn outbound_ndp_dropped() {
         &g1.port,
         IpCidr::Ip6("::/0".parse().unwrap()),
         RouterTarget::InternetGateway,
+        RouterClass::System,
     )
     .unwrap();
     incr!(g1, ["router.rules.out", "epoch"]);
@@ -3034,6 +3045,7 @@ fn uft_lft_invalidation_out() {
         &g1.port,
         IpCidr::Ip4("0.0.0.0/0".parse().unwrap()),
         RouterTarget::InternetGateway,
+        RouterClass::System,
     )
     .unwrap();
     incr!(g1, ["epoch", "router.rules.out"]);
@@ -3120,6 +3132,7 @@ fn uft_lft_invalidation_in() {
         &g1.port,
         IpCidr::Ip4("0.0.0.0/0".parse().unwrap()),
         RouterTarget::InternetGateway,
+        RouterClass::System,
     )
     .unwrap();
     incr!(g1, ["epoch", "router.rules.out"]);
@@ -3441,6 +3454,7 @@ fn tcp_outbound() {
         &g1.port,
         IpCidr::Ip4("0.0.0.0/0".parse().unwrap()),
         RouterTarget::InternetGateway,
+        RouterClass::System,
     )
     .unwrap();
     incr!(g1, ["epoch", "router.rules.out"]);
@@ -3502,6 +3516,7 @@ fn early_tcp_invalidation() {
         &g1.port,
         IpCidr::Ip4("0.0.0.0/0".parse().unwrap()),
         RouterTarget::InternetGateway,
+        RouterClass::System,
     )
     .unwrap();
     incr!(g1, ["epoch", "router.rules.out"]);
@@ -3684,6 +3699,7 @@ fn tcp_inbound() {
         &g1.port,
         IpCidr::Ip4("0.0.0.0/0".parse().unwrap()),
         RouterTarget::InternetGateway,
+        RouterClass::System,
     )
     .unwrap();
     incr!(g1, ["epoch", "router.rules.out"]);
@@ -3949,6 +3965,7 @@ fn no_panic_on_flow_table_full() {
         &g1.port,
         IpCidr::Ip4("0.0.0.0/0".parse().unwrap()),
         RouterTarget::InternetGateway,
+        RouterClass::System,
     )
     .unwrap();
     incr!(g1, ["epoch", "router.rules.out"]);

--- a/xde-tests/src/lib.rs
+++ b/xde-tests/src/lib.rs
@@ -117,6 +117,7 @@ impl OptePort {
             port_name: self.name.clone(),
             dest: IpCidr::Ip4(format!("{}/32", dest).parse().unwrap()),
             target: RouterTarget::Ip(dest.parse().unwrap()),
+            class: oxide_vpc::api::RouterClass::System,
         })?;
         Ok(())
     }

--- a/xde-tests/src/lib.rs
+++ b/xde-tests/src/lib.rs
@@ -23,6 +23,7 @@ use oxide_vpc::api::Ipv6Addr;
 use oxide_vpc::api::MacAddr;
 use oxide_vpc::api::PhysNet;
 use oxide_vpc::api::Ports;
+use oxide_vpc::api::RouterClass;
 use oxide_vpc::api::RouterTarget;
 use oxide_vpc::api::SNat4Cfg;
 use oxide_vpc::api::SetVirt2PhysReq;
@@ -117,7 +118,7 @@ impl OptePort {
             port_name: self.name.clone(),
             dest: IpCidr::Ip4(format!("{}/32", dest).parse().unwrap()),
             target: RouterTarget::Ip(dest.parse().unwrap()),
-            class: oxide_vpc::api::RouterClass::System,
+            class: RouterClass::System,
         })?;
         Ok(())
     }

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -74,6 +74,7 @@ use oxide_vpc::api::AddRouterEntryReq;
 use oxide_vpc::api::ClearVirt2BoundaryReq;
 use oxide_vpc::api::CreateXdeReq;
 use oxide_vpc::api::DelRouterEntryReq;
+use oxide_vpc::api::DelRouterEntryResp;
 use oxide_vpc::api::DeleteXdeReq;
 use oxide_vpc::api::DhcpCfg;
 use oxide_vpc::api::ListPortsResp;
@@ -2154,7 +2155,9 @@ fn add_router_entry_hdlr(env: &mut IoctlEnvelope) -> Result<NoResp, OpteError> {
 }
 
 #[no_mangle]
-fn del_router_entry_hdlr(env: &mut IoctlEnvelope) -> Result<NoResp, OpteError> {
+fn del_router_entry_hdlr(
+    env: &mut IoctlEnvelope,
+) -> Result<DelRouterEntryResp, OpteError> {
     let req: DelRouterEntryReq = env.copy_in_req()?;
     let devs = unsafe { xde_devs.read() };
     let mut iter = devs.iter();

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -73,6 +73,7 @@ use oxide_vpc::api::AddFwRuleReq;
 use oxide_vpc::api::AddRouterEntryReq;
 use oxide_vpc::api::ClearVirt2BoundaryReq;
 use oxide_vpc::api::CreateXdeReq;
+use oxide_vpc::api::DelRouterEntryReq;
 use oxide_vpc::api::DeleteXdeReq;
 use oxide_vpc::api::DhcpCfg;
 use oxide_vpc::api::ListPortsResp;
@@ -579,6 +580,11 @@ unsafe extern "C" fn xde_ioc_opte_cmd(karg: *mut c_void, mode: c_int) -> c_int {
 
         OpteCmd::AddRouterEntry => {
             let resp = add_router_entry_hdlr(&mut env);
+            hdlr_resp(&mut env, resp)
+        }
+
+        OpteCmd::DelRouterEntry => {
+            let resp = del_router_entry_hdlr(&mut env);
             hdlr_resp(&mut env, resp)
         }
 
@@ -2145,6 +2151,19 @@ fn add_router_entry_hdlr(env: &mut IoctlEnvelope) -> Result<NoResp, OpteError> {
     };
 
     router::add_entry(&dev.port, req.dest, req.target)
+}
+
+#[no_mangle]
+fn del_router_entry_hdlr(env: &mut IoctlEnvelope) -> Result<NoResp, OpteError> {
+    let req: DelRouterEntryReq = env.copy_in_req()?;
+    let devs = unsafe { xde_devs.read() };
+    let mut iter = devs.iter();
+    let dev = match iter.find(|x| x.devname == req.port_name) {
+        Some(dev) => dev,
+        None => return Err(OpteError::PortNotFound(req.port_name)),
+    };
+
+    router::del_entry(&dev.port, req.dest, req.target)
 }
 
 #[no_mangle]

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -2494,7 +2494,7 @@ fn allow_cidr_hdlr(env: &mut IoctlEnvelope) -> Result<NoResp, OpteError> {
     };
     let state = get_xde_state();
 
-    gateway::allow_cidr(&dev.port, req.cidr, state.vpc_map.clone())?;
+    gateway::allow_cidr(&dev.port, req.cidr, req.dir, state.vpc_map.clone())?;
     Ok(NoResp::default())
 }
 
@@ -2511,7 +2511,7 @@ fn remove_cidr_hdlr(
     };
     let state = get_xde_state();
 
-    gateway::remove_cidr(&dev.port, req.cidr, state.vpc_map.clone())
+    gateway::remove_cidr(&dev.port, req.cidr, req.dir, state.vpc_map.clone())
 }
 
 #[no_mangle]

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -68,6 +68,7 @@ use opte::engine::port::meta::ActionMeta;
 use opte::engine::port::Port;
 use opte::engine::port::PortBuilder;
 use opte::engine::port::ProcessResult;
+use opte::engine::NetworkImpl;
 use opte::ExecCtx;
 use oxide_vpc::api::AddFwRuleReq;
 use oxide_vpc::api::AddRouterEntryReq;
@@ -81,6 +82,7 @@ use oxide_vpc::api::ListPortsResp;
 use oxide_vpc::api::PhysNet;
 use oxide_vpc::api::PortInfo;
 use oxide_vpc::api::RemFwRuleReq;
+use oxide_vpc::api::RemoveCidrResp;
 use oxide_vpc::api::SetFwRulesReq;
 use oxide_vpc::api::SetVirt2BoundaryReq;
 use oxide_vpc::api::SetVirt2PhysReq;
@@ -596,6 +598,16 @@ unsafe extern "C" fn xde_ioc_opte_cmd(karg: *mut c_void, mode: c_int) -> c_int {
 
         OpteCmd::SetExternalIps => {
             let resp = set_external_ips_hdlr(&mut env);
+            hdlr_resp(&mut env, resp)
+        }
+
+        OpteCmd::AllowCidr => {
+            let resp = allow_cidr_hdlr(&mut env);
+            hdlr_resp(&mut env, resp)
+        }
+
+        OpteCmd::RemoveCidr => {
+            let resp = remove_cidr_hdlr(&mut env);
             hdlr_resp(&mut env, resp)
         }
     }
@@ -2353,6 +2365,37 @@ fn set_external_ips_hdlr(env: &mut IoctlEnvelope) -> Result<NoResp, OpteError> {
 
     nat::set_nat_rules(&dev.vpc_cfg, &dev.port, req)?;
     Ok(NoResp::default())
+}
+
+#[no_mangle]
+fn allow_cidr_hdlr(env: &mut IoctlEnvelope) -> Result<NoResp, OpteError> {
+    let req: oxide_vpc::api::AllowCidrReq = env.copy_in_req()?;
+    let devs = unsafe { xde_devs.read() };
+    let mut iter = devs.iter();
+    let dev = match iter.find(|x| x.devname == req.port_name) {
+        Some(dev) => dev,
+        None => return Err(OpteError::PortNotFound(req.port_name)),
+    };
+    let state = get_xde_state();
+
+    gateway::allow_cidr(&dev.port, req.cidr, state.vpc_map.clone())?;
+    Ok(NoResp::default())
+}
+
+#[no_mangle]
+fn remove_cidr_hdlr(
+    env: &mut IoctlEnvelope,
+) -> Result<RemoveCidrResp, OpteError> {
+    let req: oxide_vpc::api::RemoveCidrReq = env.copy_in_req()?;
+    let devs = unsafe { xde_devs.read() };
+    let mut iter = devs.iter();
+    let dev = match iter.find(|x| x.devname == req.port_name) {
+        Some(dev) => dev,
+        None => return Err(OpteError::PortNotFound(req.port_name)),
+    };
+    let state = get_xde_state();
+
+    gateway::remove_cidr(&dev.port, req.cidr, state.vpc_map.clone())
 }
 
 #[no_mangle]

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -2151,7 +2151,7 @@ fn add_router_entry_hdlr(env: &mut IoctlEnvelope) -> Result<NoResp, OpteError> {
         None => return Err(OpteError::PortNotFound(req.port_name)),
     };
 
-    router::add_entry(&dev.port, req.dest, req.target)
+    router::add_entry(&dev.port, req.dest, req.target, req.class)
 }
 
 #[no_mangle]
@@ -2166,7 +2166,7 @@ fn del_router_entry_hdlr(
         None => return Err(OpteError::PortNotFound(req.port_name)),
     };
 
-    router::del_entry(&dev.port, req.dest, req.target)
+    router::del_entry(&dev.port, req.dest, req.target, req.class)
 }
 
 #[no_mangle]


### PR DESCRIPTION
This PR introduces various features needed in OPTE side for VPC subnet routing:

* Add ioctl for deletion of router rules.
* Support for the 'system' vs 'custom' router distinction, and prioritisation of 'custom' rules of equal prefix length.
* Allow IP spoof-detection to be disabled (and re-enabled) on a per-CIDR basis. This is necassary to enable rules such as `192.168.0.0/16 -> ip(instance_abc)` for software routing or enabling VPN endpoints.

I'm leaving this in draft while the omicron-side pieces are in development.