### PR TITLE
add ability for omicron to observe v2p mappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
@@ -207,9 +207,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd97381a8cc6493395a5afc4c691c1084b3768db713b73aa215217aa245d153"
+checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
 dependencies = [
  "jobserver",
  "libc",
@@ -292,7 +292,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -453,7 +453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad291aa74992b9b7a7e88c38acbbf6ad7e107f1d90ee8775b7bc1fc3394f485c"
 dependencies = [
  "quote",
- "syn 2.0.58",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -477,7 +477,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.58",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -488,7 +488,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -511,7 +511,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -539,7 +539,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -619,9 +619,9 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
 name = "embedded-io"
@@ -669,7 +669,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -734,7 +734,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -921,9 +921,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+checksum = "685a7d121ee3f65ae4fddd72b25a04bb36b6af81bc0828f7d5434c0fe60fa3a2"
 dependencies = [
  "libc",
 ]
@@ -942,7 +942,7 @@ name = "kstat-macro"
 version = "0.1.0"
 dependencies = [
  "quote",
- "syn 2.0.58",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -1385,7 +1385,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -1521,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "a56dea16b0a29e94408b9aa5e2940a4eedbd128a1ba20e8f7ae60fd3d465af0e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1738,7 +1738,7 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -1767,7 +1767,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -1799,7 +1799,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.58",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -1970,9 +1970,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2032,7 +2032,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -2057,9 +2057,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -2078,9 +2078,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2123,7 +2123,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -2168,7 +2168,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.5",
+ "winnow 0.6.6",
 ]
 
 [[package]]
@@ -2190,7 +2190,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -2252,7 +2252,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_tokenstream",
- "syn 2.0.58",
+ "syn 2.0.59",
  "usdt-impl",
 ]
 
@@ -2270,7 +2270,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.58",
+ "syn 2.0.59",
  "thiserror",
  "thread-id",
  "version_check",
@@ -2286,7 +2286,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_tokenstream",
- "syn 2.0.58",
+ "syn 2.0.59",
  "usdt-impl",
 ]
 
@@ -2339,7 +2339,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.59",
  "wasm-bindgen-shared",
 ]
 
@@ -2361,7 +2361,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.59",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2428,7 +2428,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -2448,17 +2448,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -2469,9 +2470,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2481,9 +2482,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2493,9 +2494,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2505,9 +2512,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2517,9 +2524,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2529,9 +2536,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2541,9 +2548,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
@@ -2556,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+checksum = "f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352"
 dependencies = [
  "memchr",
 ]
@@ -2624,7 +2631,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.59",
 ]
 
 [[package]]

--- a/bin/opteadm/src/bin/opteadm.rs
+++ b/bin/opteadm/src/bin/opteadm.rs
@@ -25,6 +25,7 @@ use opteadm::COMMIT_COUNT;
 use oxide_vpc::api::AddRouterEntryReq;
 use oxide_vpc::api::Address;
 use oxide_vpc::api::ClearVirt2BoundaryReq;
+use oxide_vpc::api::ClearVirt2PhysReq;
 use oxide_vpc::api::DhcpCfg;
 use oxide_vpc::api::ExternalIpCfg;
 use oxide_vpc::api::Filters as FirewallFilters;
@@ -199,6 +200,14 @@ enum Command {
 
     /// Set a virtual-to-physical mapping
     SetV2P { vpc_ip: IpAddr, vpc_mac: MacAddr, underlay_ip: Ipv6Addr, vni: Vni },
+
+    /// Clear a virtual-to-physical mapping
+    ClearV2P {
+        vpc_ip: IpAddr,
+        vpc_mac: MacAddr,
+        underlay_ip: Ipv6Addr,
+        vni: Vni,
+    },
 
     /// Set a virtual-to-boundary mapping
     SetV2B { prefix: IpCidr, tunnel_endpoint: Vec<Ipv6Addr> },
@@ -654,6 +663,12 @@ fn main() -> anyhow::Result<()> {
             let phys = PhysNet { ether: vpc_mac, ip: underlay_ip, vni };
             let req = SetVirt2PhysReq { vip: vpc_ip, phys };
             hdl.set_v2p(&req)?;
+        }
+
+        Command::ClearV2P { vpc_ip, vpc_mac, underlay_ip, vni } => {
+            let phys = PhysNet { ether: vpc_mac, ip: underlay_ip, vni };
+            let req = ClearVirt2PhysReq { vip: vpc_ip, phys };
+            hdl.clear_v2p(&req)?;
         }
 
         Command::SetV2B { prefix, tunnel_endpoint } => {

--- a/bin/opteadm/src/lib.rs
+++ b/bin/opteadm/src/lib.rs
@@ -18,6 +18,10 @@ use oxide_vpc::api::ClearVirt2BoundaryReq;
 use oxide_vpc::api::CreateXdeReq;
 use oxide_vpc::api::DeleteXdeReq;
 use oxide_vpc::api::DhcpCfg;
+use oxide_vpc::api::DumpVirt2BoundaryReq;
+use oxide_vpc::api::DumpVirt2BoundaryResp;
+use oxide_vpc::api::DumpVirt2PhysReq;
+use oxide_vpc::api::DumpVirt2PhysResp;
 use oxide_vpc::api::FirewallRule;
 use oxide_vpc::api::ListPortsResp;
 use oxide_vpc::api::RemFwRuleReq;
@@ -26,7 +30,6 @@ use oxide_vpc::api::SetFwRulesReq;
 use oxide_vpc::api::SetVirt2BoundaryReq;
 use oxide_vpc::api::SetVirt2PhysReq;
 use oxide_vpc::api::VpcCfg;
-use oxide_vpc::engine::overlay;
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::os::unix::io::AsRawFd;
@@ -219,12 +222,12 @@ impl OpteAdm {
     }
 
     /// Dump the Virtual-to-Physical mappings.
-    pub fn dump_v2p(&self) -> Result<overlay::DumpVirt2PhysResp, Error> {
+    pub fn dump_v2p(&self) -> Result<DumpVirt2PhysResp, Error> {
         let cmd = OpteCmd::DumpVirt2Phys;
         run_cmd_ioctl(
             self.device.as_raw_fd(),
             cmd,
-            Some(&overlay::DumpVirt2PhysReq { unused: 99 }),
+            Some(&DumpVirt2PhysReq { unused: 99 }),
         )
     }
 
@@ -242,12 +245,12 @@ impl OpteAdm {
     }
 
     /// Dump the Virtual-to-Boundary mappings.
-    pub fn dump_v2b(&self) -> Result<overlay::DumpVirt2BoundaryResp, Error> {
+    pub fn dump_v2b(&self) -> Result<DumpVirt2BoundaryResp, Error> {
         let cmd = OpteCmd::DumpVirt2Boundary;
         run_cmd_ioctl(
             self.device.as_raw_fd(),
             cmd,
-            Some(&overlay::DumpVirt2BoundaryReq { unused: 99 }),
+            Some(&DumpVirt2BoundaryReq { unused: 99 }),
         )
     }
 

--- a/bin/opteadm/src/lib.rs
+++ b/bin/opteadm/src/lib.rs
@@ -15,6 +15,7 @@ use opte_ioctl::Error;
 use oxide_vpc::api::AddFwRuleReq;
 use oxide_vpc::api::AddRouterEntryReq;
 use oxide_vpc::api::ClearVirt2BoundaryReq;
+use oxide_vpc::api::ClearVirt2PhysReq;
 use oxide_vpc::api::CreateXdeReq;
 use oxide_vpc::api::DeleteXdeReq;
 use oxide_vpc::api::DhcpCfg;
@@ -218,6 +219,11 @@ impl OpteAdm {
 
     pub fn set_v2p(&self, req: &SetVirt2PhysReq) -> Result<NoResp, Error> {
         let cmd = OpteCmd::SetVirt2Phys;
+        run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req))
+    }
+
+    pub fn clear_v2p(&self, req: &ClearVirt2PhysReq) -> Result<NoResp, Error> {
+        let cmd = OpteCmd::ClearVirt2Phys;
         run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req))
     }
 

--- a/crates/opte-api/src/cmd.rs
+++ b/crates/opte-api/src/cmd.rs
@@ -35,6 +35,7 @@ pub enum OpteCmd {
     SetVirt2Boundary = 52,   // set a v2b mapping
     ClearVirt2Boundary = 53, // clear a v2b mapping
     DumpVirt2Boundary = 54,  // dump the v2b mappings
+    ClearVirt2Phys = 55,     // clear a v2p mapping
     AddRouterEntry = 60,     // add a router entry for IP dest
     CreateXde = 70,          // create a new xde device
     DeleteXde = 71,          // delete an xde device
@@ -62,6 +63,7 @@ impl TryFrom<c_int> for OpteCmd {
             52 => Ok(Self::SetVirt2Boundary),
             53 => Ok(Self::ClearVirt2Boundary),
             54 => Ok(Self::DumpVirt2Boundary),
+            55 => Ok(Self::ClearVirt2Phys),
             60 => Ok(Self::AddRouterEntry),
             70 => Ok(Self::CreateXde),
             71 => Ok(Self::DeleteXde),

--- a/crates/opte-api/src/lib.rs
+++ b/crates/opte-api/src/lib.rs
@@ -47,7 +47,7 @@ pub use ulp::*;
 ///
 /// We rely on CI and the check-api-version.sh script to verify that
 /// this number is incremented anytime the oxide-api code changes.
-pub const API_VERSION: u64 = 28;
+pub const API_VERSION: u64 = 29;
 
 /// Major version of the OPTE package.
 pub const MAJOR_VERSION: u64 = 0;

--- a/lib/opte-ioctl/src/lib.rs
+++ b/lib/opte-ioctl/src/lib.rs
@@ -23,6 +23,7 @@ use oxide_vpc::api::SetFwRulesReq;
 use oxide_vpc::api::SetVirt2BoundaryReq;
 use oxide_vpc::api::SetVirt2PhysReq;
 use oxide_vpc::api::VpcCfg;
+use oxide_vpc::engine::overlay::DumpVirt2PhysResp;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::fs::File;
@@ -140,6 +141,11 @@ impl OpteHdl {
         Ok(OpteHdl {
             device: OpenOptions::new().read(true).write(true).open(what)?,
         })
+    }
+
+    pub fn list_v2p(&self) -> Result<DumpVirt2PhysResp, Error> {
+        let cmd = OpteCmd::DumpVirt2Phys;
+        run_cmd_ioctl(self.device.as_raw_fd(), cmd, None::<&()>)
     }
 
     pub fn set_v2p(&self, req: &SetVirt2PhysReq) -> Result<NoResp, Error> {

--- a/lib/opte-ioctl/src/lib.rs
+++ b/lib/opte-ioctl/src/lib.rs
@@ -14,6 +14,7 @@ use opte::api::API_VERSION;
 use opte::api::XDE_IOC_OPTE_CMD;
 use oxide_vpc::api::AddRouterEntryReq;
 use oxide_vpc::api::ClearVirt2BoundaryReq;
+use oxide_vpc::api::ClearVirt2PhysReq;
 use oxide_vpc::api::CreateXdeReq;
 use oxide_vpc::api::DeleteXdeReq;
 use oxide_vpc::api::DhcpCfg;
@@ -154,6 +155,11 @@ impl OpteHdl {
 
     pub fn set_v2p(&self, req: &SetVirt2PhysReq) -> Result<NoResp, Error> {
         let cmd = OpteCmd::SetVirt2Phys;
+        run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req))
+    }
+
+    pub fn clear_v2p(&self, req: &ClearVirt2PhysReq) -> Result<NoResp, Error> {
+        let cmd = OpteCmd::ClearVirt2Phys;
         run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req))
     }
 

--- a/lib/opte-ioctl/src/lib.rs
+++ b/lib/opte-ioctl/src/lib.rs
@@ -17,13 +17,13 @@ use oxide_vpc::api::ClearVirt2BoundaryReq;
 use oxide_vpc::api::CreateXdeReq;
 use oxide_vpc::api::DeleteXdeReq;
 use oxide_vpc::api::DhcpCfg;
+use oxide_vpc::api::DumpVirt2PhysResp;
 use oxide_vpc::api::ListPortsResp;
 use oxide_vpc::api::SetExternalIpsReq;
 use oxide_vpc::api::SetFwRulesReq;
 use oxide_vpc::api::SetVirt2BoundaryReq;
 use oxide_vpc::api::SetVirt2PhysReq;
 use oxide_vpc::api::VpcCfg;
-use oxide_vpc::engine::overlay::DumpVirt2PhysResp;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::fs::File;
@@ -143,7 +143,7 @@ impl OpteHdl {
         })
     }
 
-    pub fn list_v2p(&self) -> Result<DumpVirt2PhysResp, Error> {
+    pub fn dump_v2p(&self) -> Result<DumpVirt2PhysResp, Error> {
         let cmd = OpteCmd::DumpVirt2Phys;
         run_cmd_ioctl(self.device.as_raw_fd(), cmd, None::<&()>)
     }

--- a/lib/opte-ioctl/src/lib.rs
+++ b/lib/opte-ioctl/src/lib.rs
@@ -17,6 +17,7 @@ use oxide_vpc::api::ClearVirt2BoundaryReq;
 use oxide_vpc::api::CreateXdeReq;
 use oxide_vpc::api::DeleteXdeReq;
 use oxide_vpc::api::DhcpCfg;
+use oxide_vpc::api::DumpVirt2PhysReq;
 use oxide_vpc::api::DumpVirt2PhysResp;
 use oxide_vpc::api::ListPortsResp;
 use oxide_vpc::api::SetExternalIpsReq;
@@ -143,9 +144,12 @@ impl OpteHdl {
         })
     }
 
-    pub fn dump_v2p(&self) -> Result<DumpVirt2PhysResp, Error> {
+    pub fn dump_v2p(
+        &self,
+        req: &DumpVirt2PhysReq,
+    ) -> Result<DumpVirt2PhysResp, Error> {
         let cmd = OpteCmd::DumpVirt2Phys;
-        run_cmd_ioctl(self.device.as_raw_fd(), cmd, None::<&()>)
+        run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req))
     }
 
     pub fn set_v2p(&self, req: &SetVirt2PhysReq) -> Result<NoResp, Error> {

--- a/lib/oxide-vpc/src/api.rs
+++ b/lib/oxide-vpc/src/api.rs
@@ -4,6 +4,7 @@
 
 // Copyright 2023 Oxide Computer Company
 
+use alloc::collections::BTreeSet;
 use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec::Vec;
@@ -476,6 +477,45 @@ pub struct ListPortsResp {
 }
 
 impl opte::api::cmd::CmdOk for ListPortsResp {}
+
+#[repr(C)]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DumpVirt2PhysReq {
+    pub unused: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct VpcMapResp {
+    pub vni: Vni,
+    pub ip4: Vec<(Ipv4Addr, GuestPhysAddr)>,
+    pub ip6: Vec<(Ipv6Addr, GuestPhysAddr)>,
+}
+
+#[repr(C)]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DumpVirt2BoundaryReq {
+    pub unused: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DumpVirt2PhysResp {
+    pub mappings: Vec<VpcMapResp>,
+}
+
+impl CmdOk for DumpVirt2PhysResp {}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct V2bMapResp {
+    pub ip4: Vec<(Ipv4Cidr, BTreeSet<TunnelEndpoint>)>,
+    pub ip6: Vec<(Ipv6Cidr, BTreeSet<TunnelEndpoint>)>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DumpVirt2BoundaryResp {
+    pub mappings: V2bMapResp,
+}
+
+impl CmdOk for DumpVirt2BoundaryResp {}
 
 /// Set mapping from VPC IP to physical network destination.
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/lib/oxide-vpc/src/api.rs
+++ b/lib/oxide-vpc/src/api.rs
@@ -524,6 +524,13 @@ pub struct SetVirt2PhysReq {
     pub phys: PhysNet,
 }
 
+/// Clear a mapping from VPC IP to physical network destination.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ClearVirt2PhysReq {
+    pub vip: IpAddr,
+    pub phys: PhysNet,
+}
+
 /// Set a mapping from a VPC IP to boundary tunnel endpoint destination.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SetVirt2BoundaryReq {

--- a/lib/oxide-vpc/src/engine/overlay.rs
+++ b/lib/oxide-vpc/src/engine/overlay.rs
@@ -8,9 +8,13 @@
 //!
 //! This implements the Oxide Network VPC Overlay.
 use super::router::RouterTargetInternal;
+use crate::api::DumpVirt2BoundaryResp;
+use crate::api::DumpVirt2PhysResp;
 use crate::api::GuestPhysAddr;
 use crate::api::PhysNet;
 use crate::api::TunnelEndpoint;
+use crate::api::V2bMapResp;
+use crate::api::VpcMapResp;
 use crate::cfg::VpcCfg;
 use alloc::collections::btree_map::BTreeMap;
 use alloc::collections::BTreeSet;
@@ -19,7 +23,6 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt;
 use core::marker::PhantomData;
-use opte::api::CmdOk;
 use opte::api::Direction;
 use opte::api::Ipv4Addr;
 use opte::api::Ipv4Cidr;
@@ -67,8 +70,6 @@ use opte::engine::rule::ResourceEntry;
 use opte::engine::rule::Rule;
 use opte::engine::rule::StaticAction;
 use poptrie::Poptrie;
-use serde::Deserialize;
-use serde::Serialize;
 
 pub const OVERLAY_LAYER_NAME: &str = "overlay";
 
@@ -786,42 +787,3 @@ impl MappingResource for Virt2Phys {
         }
     }
 }
-
-#[repr(C)]
-#[derive(Debug, Deserialize, Serialize)]
-pub struct DumpVirt2PhysReq {
-    pub unused: u64,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct VpcMapResp {
-    pub vni: Vni,
-    pub ip4: Vec<(Ipv4Addr, GuestPhysAddr)>,
-    pub ip6: Vec<(Ipv6Addr, GuestPhysAddr)>,
-}
-
-#[repr(C)]
-#[derive(Debug, Deserialize, Serialize)]
-pub struct DumpVirt2BoundaryReq {
-    pub unused: u64,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct DumpVirt2PhysResp {
-    pub mappings: Vec<VpcMapResp>,
-}
-
-impl CmdOk for DumpVirt2PhysResp {}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct V2bMapResp {
-    pub ip4: Vec<(Ipv4Cidr, BTreeSet<TunnelEndpoint>)>,
-    pub ip6: Vec<(Ipv6Cidr, BTreeSet<TunnelEndpoint>)>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub struct DumpVirt2BoundaryResp {
-    pub mappings: V2bMapResp,
-}
-
-impl CmdOk for DumpVirt2BoundaryResp {}

--- a/lib/oxide-vpc/src/engine/print.rs
+++ b/lib/oxide-vpc/src/engine/print.rs
@@ -9,11 +9,11 @@
 //! This is mostly just a place to hang printing routines so that they
 //! can be used by both opteadm and integration tests.
 
+use crate::api::DumpVirt2BoundaryResp;
+use crate::api::DumpVirt2PhysResp;
 use crate::api::GuestPhysAddr;
 use crate::api::Ipv4Addr;
 use crate::api::Ipv6Addr;
-use crate::engine::overlay::DumpVirt2BoundaryResp;
-use crate::engine::overlay::DumpVirt2PhysResp;
 use alloc::string::ToString;
 use opte::api::IpCidr;
 use opte::engine::geneve::Vni;

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -72,6 +72,7 @@ use opte::ExecCtx;
 use oxide_vpc::api::AddFwRuleReq;
 use oxide_vpc::api::AddRouterEntryReq;
 use oxide_vpc::api::ClearVirt2BoundaryReq;
+use oxide_vpc::api::ClearVirt2PhysReq;
 use oxide_vpc::api::CreateXdeReq;
 use oxide_vpc::api::DeleteXdeReq;
 use oxide_vpc::api::DhcpCfg;
@@ -563,6 +564,11 @@ unsafe extern "C" fn xde_ioc_opte_cmd(karg: *mut c_void, mode: c_int) -> c_int {
 
         OpteCmd::SetVirt2Phys => {
             let resp = set_v2p_hdlr(&mut env);
+            hdlr_resp(&mut env, resp)
+        }
+
+        OpteCmd::ClearVirt2Phys => {
+            let resp = clear_v2p_hdlr(&mut env);
             hdlr_resp(&mut env, resp)
         }
 
@@ -2198,6 +2204,14 @@ fn set_v2p_hdlr(env: &mut IoctlEnvelope) -> Result<NoResp, OpteError> {
     let req: SetVirt2PhysReq = env.copy_in_req()?;
     let state = get_xde_state();
     state.vpc_map.add(req.vip, req.phys);
+    Ok(NoResp::default())
+}
+
+#[no_mangle]
+fn clear_v2p_hdlr(env: &mut IoctlEnvelope) -> Result<NoResp, OpteError> {
+    let req: ClearVirt2PhysReq = env.copy_in_req()?;
+    let state = get_xde_state();
+    state.vpc_map.del(&req.vip, &req.phys);
     Ok(NoResp::default())
 }
 

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -75,6 +75,10 @@ use oxide_vpc::api::ClearVirt2BoundaryReq;
 use oxide_vpc::api::CreateXdeReq;
 use oxide_vpc::api::DeleteXdeReq;
 use oxide_vpc::api::DhcpCfg;
+use oxide_vpc::api::DumpVirt2BoundaryReq;
+use oxide_vpc::api::DumpVirt2BoundaryResp;
+use oxide_vpc::api::DumpVirt2PhysReq;
+use oxide_vpc::api::DumpVirt2PhysResp;
 use oxide_vpc::api::ListPortsResp;
 use oxide_vpc::api::PhysNet;
 use oxide_vpc::api::PortInfo;
@@ -2200,8 +2204,8 @@ fn set_v2p_hdlr(env: &mut IoctlEnvelope) -> Result<NoResp, OpteError> {
 #[no_mangle]
 fn dump_v2p_hdlr(
     env: &mut IoctlEnvelope,
-) -> Result<overlay::DumpVirt2PhysResp, OpteError> {
-    let _req: overlay::DumpVirt2PhysReq = env.copy_in_req()?;
+) -> Result<DumpVirt2PhysResp, OpteError> {
+    let _req: DumpVirt2PhysReq = env.copy_in_req()?;
     let state = get_xde_state();
     Ok(state.vpc_map.dump())
 }
@@ -2225,8 +2229,8 @@ fn clear_v2b_hdlr(env: &mut IoctlEnvelope) -> Result<NoResp, OpteError> {
 #[no_mangle]
 fn dump_v2b_hdlr(
     env: &mut IoctlEnvelope,
-) -> Result<overlay::DumpVirt2BoundaryResp, OpteError> {
-    let _req: overlay::DumpVirt2BoundaryReq = env.copy_in_req()?;
+) -> Result<DumpVirt2BoundaryResp, OpteError> {
+    let _req: DumpVirt2BoundaryReq = env.copy_in_req()?;
     let state = get_xde_state();
     Ok(state.v2b.dump())
 }


### PR DESCRIPTION
We're adding rpws to Omicron so we can keep the v2p mappings consistent across sled reboots and other unfortunate-but-necessary events. Currently, sled-agent nor omicron has the ability to determine what mappings already exists, so it's difficult to reconcile or detect conflicting mappings.

Related
---
Closes https://github.com/oxidecomputer/opte/issues/332