### PR TITLE
Cache routes received from `next_hop`

### DIFF
--- a/lib/opte/src/d_error.rs
+++ b/lib/opte/src/d_error.rs
@@ -145,7 +145,7 @@ impl<const L: usize> LabelBlock<L> {
     }
 
     /// Provides access to all stored [`CStr`]s.
-    pub fn entries<'a>(&'a self) -> LabelBlockIter<'a, L> {
+    pub fn entries(&self) -> LabelBlockIter<'_, L> {
         LabelBlockIter { pos: 0, inner: self }
     }
 

--- a/lib/opte/src/engine/rule.rs
+++ b/lib/opte/src/engine/rule.rs
@@ -834,7 +834,7 @@ impl<'a> Rule<Finalized> {
         #[cfg(debug_assertions)]
         {
             if let Some(preds) = &self.state.preds {
-                if preds.hdr_preds.len() == 0 && preds.data_preds.len() == 0 {
+                if preds.hdr_preds.is_empty() && preds.data_preds.is_empty() {
                     panic!(
                         "bug: RulePredicates must have at least one \
                             predicate"

--- a/xde/src/lib.rs
+++ b/xde/src/lib.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 
 // xde - A mac provider for OPTE-based network implementations.
 #![feature(extern_types)]

--- a/xde/src/lib.rs
+++ b/xde/src/lib.rs
@@ -45,6 +45,7 @@ pub mod dls;
 pub mod ip;
 pub mod mac;
 mod mac_sys;
+pub mod route;
 pub mod secpolicy;
 pub mod sys;
 pub mod xde;

--- a/xde/src/route.rs
+++ b/xde/src/route.rs
@@ -1,0 +1,500 @@
+use crate::ip;
+use crate::sys;
+use crate::xde::xde_underlay_port;
+use crate::xde::DropRef;
+use crate::xde::XdeDev;
+use alloc::collections::BTreeMap;
+use alloc::sync::Arc;
+use core::ptr;
+use core::time::Duration;
+use illumos_sys_hdrs::*;
+use opte::ddi::sync::KRwLock;
+use opte::ddi::sync::KRwLockType;
+use opte::ddi::time::Moment;
+use opte::engine::ether::EtherAddr;
+use opte::engine::ip6::Ipv6Addr;
+
+// XXX: completely arbitrary timeout.
+/// The duration a cached route remains valid for.
+const MAX_ROUTE_LIFETIME: Duration = Duration::from_millis(100);
+
+extern "C" {
+    pub fn __dtrace_probe_next__hop(
+        dst: uintptr_t,
+        gw: uintptr_t,
+        gw_ether_src: uintptr_t,
+        gw_ether_dst: uintptr_t,
+        msg: uintptr_t,
+    );
+}
+
+fn next_hop_probe(
+    dst: &Ipv6Addr,
+    gw: Option<&Ipv6Addr>,
+    gw_eth_src: EtherAddr,
+    gw_eth_dst: EtherAddr,
+    msg: &[u8],
+) {
+    let gw_bytes = gw.unwrap_or(&Ipv6Addr::from([0u8; 16])).bytes();
+
+    unsafe {
+        __dtrace_probe_next__hop(
+            dst.bytes().as_ptr() as uintptr_t,
+            gw_bytes.as_ptr() as uintptr_t,
+            gw_eth_src.to_bytes().as_ptr() as uintptr_t,
+            gw_eth_dst.to_bytes().as_ptr() as uintptr_t,
+            msg.as_ptr() as uintptr_t,
+        );
+    }
+}
+
+// The following are wrappers for reference drop functions used in XDE.
+
+fn ire_refrele(ire: *mut ip::ire_t) {
+    unsafe { ip::ire_refrele(ire) }
+}
+
+fn nce_refrele(ire: *mut ip::nce_t) {
+    unsafe { ip::nce_refrele(ire) }
+}
+
+fn netstack_rele(ns: *mut ip::netstack_t) {
+    unsafe { ip::netstack_rele(ns) }
+}
+
+// At this point the core engine of OPTE has delivered a Geneve
+// encapsulated guest Ethernet Frame (also simply referred to as "the
+// packet") to xde to be sent to the specific outer IPv6 destination
+// address. This packet includes the outer Ethernet Frame as well;
+// however, the outer frame's destination and source addresses are set
+// to zero. It is the job of this function to determine what those
+// values should be.
+//
+// Adjacent to xde is the native IPv6 stack along with its routing
+// table. This table is routinely updated to indicate the best path to
+// any given IPv6 destination that may be specified in the outer IP
+// header. As xde is not utilizing the native IPv6 stack to send out
+// the packet, but rather is handing it directly to the mac module, it
+// must somehow query the native routing table to determine which port
+// this packet should egress and fill in the outer frame accordingly.
+// This query is done via a private interface which allows a kernel
+// module outside of IP to query the routing table.
+//
+// This process happens in a sequence of steps described below.
+//
+// 1. With an IPv6 destination in hand we need to determine the next
+//    hop, also known as the gateway, for this address. That is, of
+//    our neighbors (in this case one of the two switches, which are
+//    also acting as routers), who should we forward this packet to in
+//    order for it to arrive at its destination? We get this
+//    information from the routing table, which contains Internet
+//    Routing Entries, or IREs. Specifically, we query the native IPv6
+//    routing table using the kernel function
+//    `ire_ftable_lookup_simple_v6()`. This function returns an
+//    `ire_t`, which includes the member `ire_u`, which contains the
+//    address of the gateway as `ire6_gateway_addr`.
+//
+// 2. We have the gateway IPv6 address; but in the world of the Oxide
+//    Network that is not enough to deliver the packet. In the Oxide
+//    Network the router (switch) is not a member of the host's
+//    network. Instead, we rely on link-local addresses to reach the
+//    switches. The lookup in step (1) gave us that link-local address
+//    of the gateway; now we need to figure out how to reach it. That
+//    requires consulting the routing table a second time: this time
+//    to find the IRE for the gateway's link-local address.
+//
+// 3. The IRE of the link-local address from step (2) allows us to
+//    determine which interface this traffic should traverse.
+//    Specifically it gives us access to the `ill_t` of the gateway's
+//    link-local address. This structure contains the IP Lower Level
+//    information. In particular it contains the `ill_phys_addr`
+//    which gives us the source MAC address for our outer frame.
+//
+// 4. The final piece of information to obtain is the destination MAC
+//    address. We have the link-local address of the switch port we
+//    want to send to. To get the MAC address of this port it must
+//    first be assumed that the host and its connected switches have
+//    performed NDP in order to learn each other's IPv6 addresses and
+//    corresponding MAC addresses. With that information in hand it is
+//    a matter of querying the kernel's Neighbor Cache Entry Table
+//    (NCE) for the mapping that belongs to our gateway's link-local
+//    address. This is done via the `nce_lookup_v6()` kernel function.
+//
+// With those four steps we have obtained the source and destination
+// MAC addresses and the packet can be sent to mac to be delivered to
+// the underlying NIC. However, the careful reader may find themselves
+// confused about how step (1) actually works.
+//
+//   If step (1) always returns a single gateway, then how do we
+//   actually utilize both NICs/switches?
+//
+// This is where a bit of knowledge about routing tables comes into
+// play along with our very own Delay Driven Multipath in-rack routing
+// protocol. You might imagine the IPv6 routing table on an Oxide Sled
+// looking something like this.
+//
+// Destination/Mask             Gateway                 Flags  If
+// ----------------          -------------------------  ----- ---------
+// default                   fe80::<sc1_p5>             UG     cxgbe0
+// default                   fe80::<sc1_p6>             UG     cxgbe1
+// fe80::/10                 fe80::<sc1_p5>             U      cxgbe0
+// fe80::/10                 fe80::<sc1_p6>             U      cxgbe1
+// fd00:<rack1_sled1>::/64   fe80::<sc1_p5>             U      cxgbe0
+// fd00:<rack1_sled1>::/64   fe80::<sc1_p6>             U      cxgbe1
+//
+// Let's say this host (sled1) wants to send a packet to sled2. Our
+// sled1 host lives on network `fd00:<rack1_sled1>::/64` while our
+// sled2 host lives on `fd00:<rack1_seld2>::/64` -- the key point
+// being they are two different networks and thus must be routed to
+// talk to each other. For sled1 to send this packet it will attempt
+// to look up destination `fd00:<rack1_sled2>::7777` (in this case
+// `7777` is the IP of sled2) in the routing table above. The routing
+// table will then perform a longest prefix match against the
+// `Destination` field for all entries: the longest prefix that
+// matches wins and that entry is returned. However, in this case, no
+// destinations match except for the `default` ones. When more than
+// one entry matches it is left to the system to decide which one to
+// return; typically this just means the first one that matches. But
+// not for us! This is where DDM comes into play.
+//
+// Let's reimagine the routing table again, this time with a
+// probability added to each gateway entry.
+//
+// Destination/Mask             Gateway                 Flags  If      P
+// ----------------          -------------------------  ----- ------- ----
+// default                   fe80::<sc1_p5>             UG     cxgbe0  0.70
+// default                   fe80::<sc1_p6>             UG     cxgbe1  0.30
+// fe80::/10                 fe80::<sc1_p5>             U      cxgbe0
+// fe80::/10                 fe80::<sc1_p6>             U      cxgbe1
+// fd00:<rack1_sled1>::/64   fe80::<sc1_p5>             U      cxgbe0
+// fd00:<rack1_sled1>::/64   fe80::<sc1_p6>             U      cxgbe1
+//
+// With these P values added we now have a new option for deciding
+// which IRE to return when faced with two matches: give each a
+// probability of return based on their P value. In this case, for any
+// given gateway IRE lookup, there would be a 70% chance
+// `fe80::<sc1_p5>` is returned and a 30% chance `fe80::<sc1_p6>` is
+// returned.
+//
+// But wait, what determines those P values? That's the job of DDM.
+// The full story of what DDM is and how it works is outside the scope
+// of this already long block comment; but suffice to say it monitors
+// the flow of the network based on precise latency measurements and
+// with that data constantly refines the P values of all the hosts's
+// routing tables to bias new packets towards one path or another.
+#[no_mangle]
+fn next_hop<'a>(
+    key: &RouteKey,
+    ustate: &'a XdeDev,
+) -> Result<Route<'a>, &'a xde_underlay_port> {
+    let RouteKey { dst: ip6_dst, l4_hash: overlay_hash } = key;
+    unsafe {
+        // Use the GZ's routing table.
+        let netstack =
+            DropRef::new(netstack_rele, ip::netstack_find_by_zoneid(0));
+        assert!(!netstack.inner().is_null());
+        let ipst = (*netstack.inner()).netstack_u.nu_s.nu_ip;
+        assert!(!ipst.is_null());
+
+        let addr = ip::in6_addr_t {
+            _S6_un: ip::in6_addr__bindgen_ty_1 { _S6_u8: key.dst.bytes() },
+        };
+        let xmit_hint = overlay_hash.unwrap_or(0);
+        let mut generation_op = 0u32;
+
+        let mut underlay_port = &*ustate.u1;
+
+        // Step (1): Lookup the IRE for the destination. This is going
+        // to return one of the default gateway entries.
+        let ire = DropRef::new(
+            ire_refrele,
+            ip::ire_ftable_lookup_v6(
+                &addr,
+                ptr::null(),
+                ptr::null(),
+                0,
+                ptr::null_mut(),
+                sys::ALL_ZONES,
+                ptr::null(),
+                0,
+                xmit_hint,
+                ipst,
+                &mut generation_op as *mut ip::uint_t,
+            ),
+        );
+
+        // TODO If there is no entry should we return host
+        // unreachable? I'm not sure since really the guest would map
+        // that with its VPC network. That is, if a user saw host
+        // unreachable they would be correct to think that their VPC
+        // routing table is misconfigured, but in reality it would be
+        // an underlay network issue. How do we convey this situation
+        // to the user/operator?
+        if ire.inner().is_null() {
+            // Try without a pinned ill
+            opte::engine::dbg!("no IRE for destination {:?}", ip6_dst);
+            next_hop_probe(
+                ip6_dst,
+                None,
+                EtherAddr::zero(),
+                EtherAddr::zero(),
+                b"no IRE for destination\0",
+            );
+            return Err(underlay_port);
+        }
+        let ill = (*ire.inner()).ire_ill;
+        if ill.is_null() {
+            opte::engine::dbg!("destination ILL is NULL for {:?}", ip6_dst);
+            next_hop_probe(
+                ip6_dst,
+                None,
+                EtherAddr::zero(),
+                EtherAddr::zero(),
+                b"destination ILL is NULL\0",
+            );
+            return Err(underlay_port);
+        }
+
+        // Step (2): Lookup the IRE for the gateway's link-local
+        // address. This is going to return one of the `fe80::/10`
+        // entries.
+        let ireu = (*ire.inner()).ire_u;
+        let gw = ireu.ire6_u.ire6_gateway_addr;
+        let gw_ip6 = Ipv6Addr::from(&ireu.ire6_u.ire6_gateway_addr);
+
+        // NOTE: specifying the ill is important here, because the gateway
+        // address is going to be of the form fe80::<interface-id>. This means a
+        // simple query that does not specify an ill could come back with any
+        // route matching fe80::/10 over any interface. Since all interfaces
+        // that have an IPv6 link-local address assigned have an associated
+        // fe80::/10 route, we must restrict our search to the interface that
+        // actually has a route to the desired (non-link-local) destination.
+        let flags = ip::MATCH_IRE_ILL as i32;
+        let gw_ire = DropRef::new(
+            ire_refrele,
+            ip::ire_ftable_lookup_v6(
+                &gw,
+                ptr::null(),
+                ptr::null(),
+                0,
+                ill,
+                sys::ALL_ZONES,
+                ptr::null(),
+                flags,
+                xmit_hint,
+                ipst,
+                &mut generation_op as *mut ip::uint_t,
+            ),
+        );
+
+        if gw_ire.inner().is_null() {
+            opte::engine::dbg!("no IRE for gateway {:?}", gw_ip6);
+            next_hop_probe(
+                ip6_dst,
+                Some(&gw_ip6),
+                EtherAddr::zero(),
+                EtherAddr::zero(),
+                b"no IRE for gateway\0",
+            );
+            return Err(underlay_port);
+        }
+
+        // Step (3): Determine the source address of the outer frame
+        // from the physical address of the IP Lower Layer object
+        // member or the internet routing entry.
+        let src = (*ill).ill_phys_addr;
+        if src.is_null() {
+            opte::engine::dbg!(
+                "gateway ILL phys addr is NULL for {:?}",
+                gw_ip6
+            );
+            next_hop_probe(
+                ip6_dst,
+                Some(&gw_ip6),
+                EtherAddr::zero(),
+                EtherAddr::zero(),
+                b"gateway ILL phys addr is NULL\0",
+            );
+            return Err(underlay_port);
+        }
+
+        let src: [u8; 6] = alloc::slice::from_raw_parts(src, 6)
+            .try_into()
+            .expect("src mac from pointer");
+
+        // Switch to the 2nd underlay device if we determine the source mac
+        // belongs to that device.
+        if src == ustate.u2.mac {
+            underlay_port = &ustate.u2;
+        }
+
+        let src = EtherAddr::from(src);
+
+        // Step (4): Determine the destination address of the outer
+        // frame by retrieving the NCE entry for the gateway's
+        // link-local address.
+        let nce = DropRef::new(nce_refrele, ip::nce_lookup_v6(ill, &gw));
+        if nce.inner().is_null() {
+            opte::engine::dbg!("no NCE for gateway {:?}", gw_ip6);
+            next_hop_probe(
+                ip6_dst,
+                Some(&gw_ip6),
+                src,
+                EtherAddr::zero(),
+                b"no NCE for gateway\0",
+            );
+            return Err(underlay_port);
+        }
+
+        let nce_common = (*nce.inner()).nce_common;
+        if nce_common.is_null() {
+            opte::engine::dbg!("no NCE common for gateway {:?}", gw_ip6);
+            next_hop_probe(
+                ip6_dst,
+                Some(&gw_ip6),
+                src,
+                EtherAddr::zero(),
+                b"no NCE common for gateway\0",
+            );
+            return Err(underlay_port);
+        }
+
+        let mac = (*nce_common).ncec_lladdr;
+        if mac.is_null() {
+            opte::engine::dbg!("NCE MAC address is NULL {:?}", gw_ip6);
+            next_hop_probe(
+                ip6_dst,
+                Some(&gw_ip6),
+                src,
+                EtherAddr::zero(),
+                b"NCE MAC address if NULL for gateway\0",
+            );
+            return Err(underlay_port);
+        }
+
+        let maclen = (*nce_common).ncec_lladdr_length;
+        assert!(maclen == 6);
+
+        let dst: [u8; 6] = alloc::slice::from_raw_parts(mac, 6)
+            .try_into()
+            .expect("mac from pointer");
+        let dst = EtherAddr::from(dst);
+
+        next_hop_probe(ip6_dst, Some(&gw_ip6), src, dst, b"\0");
+
+        Ok(Route { src, dst, underlay_dev: underlay_port })
+    }
+}
+
+/// A simple caching layer over `next_hop`.
+pub struct RouteCache(Arc<KRwLock<BTreeMap<RouteKey, CachedRoute>>>);
+
+impl Default for RouteCache {
+    fn default() -> Self {
+        let mut lock = KRwLock::new(BTreeMap::new());
+        lock.init(KRwLockType::Driver);
+        Self(lock.into())
+    }
+}
+
+impl RouteCache {
+    pub fn next_hop<'b>(&self, key: RouteKey, xde: &'b XdeDev) -> Route<'b> {
+        let t = Moment::now();
+
+        let maybe_route = {
+            let route_cache = self.0.read();
+            route_cache.get(&key).copied()
+        };
+
+        match maybe_route {
+            Some(route) if route.is_still_valid(t) => {
+                return route.into_route(xde)
+            }
+            _ => {}
+        }
+
+        // Cache miss: intent is to now ask illumos, then insert.
+        let mut route_cache = self.0.write();
+
+        // Someone else may have written while we were taking the lock.
+        // DO NOT waste time if there's a good route.
+        let maybe_route = route_cache.get(&key).copied();
+        match maybe_route {
+            Some(route) if route.is_still_valid(t) => {
+                return route.into_route(xde)
+            }
+            _ => {}
+        }
+
+        // `next_hop` might fail for myriad reasons, but we still
+        // send the packet on an underlay device depending on our
+        // progress. However, we do not want to cache bad mappings.
+        match next_hop(&key, xde) {
+            Ok(route) => {
+                route_cache.insert(key, route.cached(xde, t));
+                route
+            }
+            Err(underlay_dev) => Route {
+                src: EtherAddr::zero(),
+                dst: EtherAddr::zero(),
+                underlay_dev,
+            },
+        }
+    }
+}
+
+/// An underlay routing destination and flow-dependent entropy.
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct RouteKey {
+    pub dst: Ipv6Addr,
+    pub l4_hash: Option<u32>,
+}
+
+/// Cached representation of [`Route`].
+#[derive(Copy, Clone, Debug)]
+pub struct CachedRoute {
+    pub src: EtherAddr,
+    pub dst: EtherAddr,
+    pub underlay_idx: u8,
+    pub timestamp: Moment,
+}
+
+impl CachedRoute {
+    fn is_still_valid(&self, t: Moment) -> bool {
+        t.delta_as_millis(self.timestamp)
+            <= MAX_ROUTE_LIFETIME.as_millis() as u64
+    }
+
+    fn into_route(self, xde: &XdeDev) -> Route<'_> {
+        Route {
+            src: self.src,
+            dst: self.dst,
+            // This is not a pretty construction, and will not work for
+            // a hypothetically higher port count.
+            underlay_dev: if self.underlay_idx == 0 {
+                &xde.u1
+            } else {
+                &xde.u2
+            },
+        }
+    }
+}
+
+/// Output port and L2 information needed to emit a packet over the underlay.
+#[derive(Copy, Clone, Debug)]
+pub struct Route<'a> {
+    pub src: EtherAddr,
+    pub dst: EtherAddr,
+    pub underlay_dev: &'a xde_underlay_port,
+}
+
+impl Route<'_> {
+    fn cached(&self, xde: &XdeDev, timestamp: Moment) -> CachedRoute {
+        // As unfortunate as `into_route`.
+        let port_0: &xde_underlay_port = &xde.u1;
+        let underlay_idx =
+            if core::ptr::addr_eq(self.underlay_dev, port_0) { 0 } else { 1 };
+
+        CachedRoute { src: self.src, dst: self.dst, underlay_idx, timestamp }
+    }
+}

--- a/xde/src/route.rs
+++ b/xde/src/route.rs
@@ -493,7 +493,7 @@ impl Route<'_> {
         // As unfortunate as `into_route`.
         let port_0: &xde_underlay_port = &xde.u1;
         let underlay_idx =
-            if core::ptr::addr_eq(self.underlay_dev, port_0) { 0 } else { 1 };
+            if core::ptr::eq(self.underlay_dev, port_0) { 0 } else { 1 };
 
         CachedRoute { src: self.src, dst: self.dst, underlay_idx, timestamp }
     }

--- a/xde/src/route.rs
+++ b/xde/src/route.rs
@@ -615,7 +615,7 @@ impl RouteCache {
             if v.is_retained(t) {
                 true
             } else {
-                route_delete_probe(map_ptr_int, &k);
+                route_delete_probe(map_ptr_int, k);
                 false
             }
         });

--- a/xde/src/route.rs
+++ b/xde/src/route.rs
@@ -424,7 +424,7 @@ fn next_hop<'a>(
 /// Naturally, bringing this down to O(ns) is desirable. Usually, illumos
 /// holds `ire_t`s per `conn_t`, but we're aiming to be more fine-grained
 /// with DDM -- so we need a tradeoff between 'asking about the best route
-/// per-packet' and 'holding a route until it is expired'. We choose, for noe,
+/// per-packet' and 'holding a route until it is expired'. We choose, for now,
 /// to hold a route for 100ms.
 ///
 /// Note, this uses a `BTreeMap`, but we would prefer the more consistent
@@ -540,13 +540,13 @@ pub struct CachedRoute {
 
 impl CachedRoute {
     fn is_valid(&self, t: Moment) -> bool {
-        t.delta_as_millis(self.timestamp)
-            <= EXPIRE_ROUTE_LIFETIME.as_millis() as u64
+        u128::from(t.delta_as_millis(self.timestamp))
+            <= EXPIRE_ROUTE_LIFETIME.as_millis()
     }
 
     fn is_retained(&self, t: Moment) -> bool {
-        t.delta_as_millis(self.timestamp)
-            <= REMOVE_ROUTE_LIFETIME.as_millis() as u64
+        u128::from(t.delta_as_millis(self.timestamp))
+            <= REMOVE_ROUTE_LIFETIME.as_millis()
     }
 
     fn into_route(self, xde: &XdeDev) -> Route<'_> {

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -604,7 +604,7 @@ fn expire_periodic(port: &mut Arc<Port<VpcNetwork>>) {
 
 #[no_mangle]
 fn expire_route_cache(routes: &mut RouteCache) {
-    routes.expire_routes()
+    routes.remove_routes()
 }
 
 #[no_mangle]

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -143,13 +143,6 @@ extern "C" {
         dst_port: uintptr_t,
     );
     pub fn __dtrace_probe_hdlr__resp(resp_str: uintptr_t);
-    pub fn __dtrace_probe_next__hop(
-        dst: uintptr_t,
-        gw: uintptr_t,
-        gw_ether_src: uintptr_t,
-        gw_ether_dst: uintptr_t,
-        msg: *const c_char,
-    );
     pub fn __dtrace_probe_rx(mp: uintptr_t);
     pub fn __dtrace_probe_tx(mp: uintptr_t);
 }

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -1523,7 +1523,7 @@ unsafe extern "C" fn xde_mc_tx(
     // by the mch they're being targeted to. E.g., either build a list
     // of chains (u1, u2, port0, port1, ...), or hold tx until another
     // packet breaks the run targeting the same dest.
-    while let Some(pkt) = chain.next() {
+    while let Some(pkt) = chain.pop_front() {
         xde_mc_tx_one(src_dev, pkt);
     }
 
@@ -1825,7 +1825,7 @@ unsafe extern "C" fn xde_rx(
     // by the mch they're being targeted to. E.g., either build a list
     // of chains (port0, port1, ...), or hold tx until another
     // packet breaks the run targeting the same dest.
-    while let Some(pkt) = chain.next() {
+    while let Some(pkt) = chain.pop_front() {
         xde_rx_one(&mch, mrh, pkt);
     }
 }

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -1438,12 +1438,12 @@ struct CachedRoute {
     src: EtherAddr,
     dst: EtherAddr,
     underlay_idx: u8,
-    timestep: Moment,
+    timestamp: Moment,
 }
 
 impl CachedRoute {
     pub fn is_still_valid(&self, t: Moment) -> bool {
-        t.delta_as_millis(self.timestep)
+        t.delta_as_millis(self.timestamp)
             <= MAX_ROUTE_LIFETIME.as_millis() as u64
     }
 }
@@ -1594,7 +1594,7 @@ unsafe extern "C" fn xde_mc_tx(
                 };
                 if recompute {
                     let (src, dst, underlay_dev) =
-                        next_hop(&ip6.dst, src_dev, meta.l4_hash());
+                        next_hop(&ip6.dst, src_dev, my_key.l4_hash);
 
                     // This is terrible.
                     let underlay_idx = if underlay_dev as *const _
@@ -1607,7 +1607,7 @@ unsafe extern "C" fn xde_mc_tx(
 
                     route_cache.insert(
                         my_key,
-                        CachedRoute { src, dst, underlay_idx, timestep: t },
+                        CachedRoute { src, dst, underlay_idx, timestamp: t },
                     );
 
                     (src, dst, underlay_dev)


### PR DESCRIPTION
This PR inserts a caching layer in front of `next_hop` to store routes for a given `(IpAddr6, L4Hash)` for around 100ms, and reorganises routing-related code into `xde::route`. This is a necessary step as today we spend around 21% of `xde_mc_tx` in route lookup on a per-outbound-packet basis. As a consequence, we need install a new `Periodic` to flush expired entries every 1s, as otherwise we can have a large amountof detritus pileup from different L4Hash values.

Currently this is implemented as a per-port cache rather than shared across the driver -- I've done this because it will give us better sharding of concurrent readers/writers at higher port/guest counts. The PR as-is pulls us up from  ~1.74Gbps to 2Gbps on a single link between sn9/14.

I'm seeing similar gain on the `all-perf-in-flight` branch on in-review illumos bits (which includes mac flows + packet chains), where this change brings us from 2.25 Gbps to 2.50 Gbps on this setup.