### PR TITLE
fix mutability of ioctl argument

### DIFF
--- a/lib/opte-ioctl/src/lib.rs
+++ b/lib/opte-ioctl/src/lib.rs
@@ -257,7 +257,7 @@ where
     const MAX_ITERATIONS: u8 = 3;
     for _ in 0..MAX_ITERATIONS {
         let ret = unsafe {
-            libc::ioctl(dev, XDE_IOC_OPTE_CMD as libc::c_int, &rioctl)
+            libc::ioctl(dev, XDE_IOC_OPTE_CMD as libc::c_int, &mut rioctl)
         };
 
         // The ioctl(2) failed for a reason other than the response


### PR DESCRIPTION
Something in Rust 1.78.0 changed (not sure what, maybe the upgrade to LLVM 18?) which reliably triggers this assert:

https://github.com/oxidecomputer/opte/blob/7ee353a470ea59529ee1b34729681da887aa88ce/lib/opte-ioctl/src/lib.rs#L293-L294

while sled-agent is coming up in a deployment. ([buildomat deploy job logs](https://buildomat.eng.oxide.computer/wg/0/details/01HXDKSYDNP1YXFRVFP2ZRSNDA/9lEm5MXpBdPO8UQZHmGRfgQPkGAXQzPGRkrXYSTgqWvK4EJO/01HXDKT6YYQTE3PX5X88ZMPGW0))

Correctly using a mutable reference for `rioctl` in the `libc::ioctl` call fixes this issue. It's unclear to me whether this is a case of Rust/LLVM deciding it can optimize out the assertion predicate because `rioctl` wasn't marked as mutating between declaration and then.