### PR TITLE
[WIP] Experiments with worker threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,6 +922,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,7 +1222,7 @@ dependencies = [
  "dyn-clone",
  "heapless",
  "illumos-sys-hdrs",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "kstat-macro",
  "opte",
  "opte-api",
@@ -1245,7 +1254,7 @@ dependencies = [
  "clap",
  "criterion",
  "ctor",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "nix",
  "opte",
  "opte-test-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ darling = "0.20"
 dyn-clone = "1.0"
 heapless = "0.8"
 ipnetwork = { version = "0.20", default-features = false }
-itertools = { version = "0.12", default-features = false }
+itertools = { version = "0.13", default-features = false }
 libc = "0.2"
 libnet = { git = "https://github.com/oxidecomputer/netadm-sys" }
 nix = { version = "0.28", features = ["signal", "user"] }

--- a/bench/src/kbench/measurement.rs
+++ b/bench/src/kbench/measurement.rs
@@ -182,8 +182,9 @@ pub fn build_flamegraph(
     }
 
     let terms = [
-        ("xde_rx", rx_name.unwrap_or("rx")),
-        ("xde_mc_tx", tx_name.unwrap_or("tx")),
+        ("xde_rx", rx_name.unwrap_or("in_place")),
+        ("xde_mc_tx", tx_name.unwrap_or("out_place")),
+        ("xde_worker", "process"),
     ];
 
     for (tracked_fn, out_name) in terms {

--- a/crates/illumos-sys-hdrs/src/lib.rs
+++ b/crates/illumos-sys-hdrs/src/lib.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 #![cfg_attr(feature = "kernel", feature(extern_types))]
 #![allow(non_camel_case_types)]
 #![no_std]
@@ -307,6 +307,7 @@ pub type hrtime_t = c_longlong;
 // ======================================================================
 // uts/common/sys/types.h
 // ======================================================================
+pub type clock_t = c_long;
 pub type datalink_id_t = uint32_t;
 pub type dev_t = c_ulong;
 pub type id_t = c_int;

--- a/dtrace/flow.d
+++ b/dtrace/flow.d
@@ -1,0 +1,16 @@
+mac_client_set_flow_cb:entry {
+	printf("entry: mip %p mrh %p mp  %p",
+		arg0, arg1, arg2);
+}
+
+mac_client_set_flow_cb:return {
+	printf("donezo off %p val %p", arg0, arg1);
+}
+
+flow_transport_lport_match:entry {
+	printf("entry: mip %p mrh %p mp %p", arg0, arg1, arg2);
+}
+
+flow_transport_lport_match:return {
+	printf("donezo off %p val %p", arg0, arg1);
+}

--- a/dtrace/opte-count-cycles-oneliner.d
+++ b/dtrace/opte-count-cycles-oneliner.d
@@ -1,0 +1,1 @@
+worker-pkt-start { self->ts = vtimestamp; self->dir = arg0; } worker-pkt-end /self->dir == 1 && self->ts/ { @time["rx"] = lquantize((vtimestamp - self->ts), 256, 32768, 256); self->ts = 0;} worker-pkt-end /self->dir == 2 && self->ts/ {@time["tx"] = lquantize((vtimestamp - self->ts), 256, 32768, 256); self->ts = 0;} END {}

--- a/dtrace/opte-count-cycles-os.d
+++ b/dtrace/opte-count-cycles-os.d
@@ -1,0 +1,1 @@
+xde_rx:entry { self->ts = vtimestamp; self->dir = 1; } xde_mc_tx:entry { self->ts = vtimestamp; self->dir = 2; } xde_rx:return /self->ts/ { @time["rx"] = lquantize((vtimestamp - self->ts), 256, 32768, 256); self->ts = 0;} xde_mc_tx:return /self->ts/ {@time["tx"] = lquantize((vtimestamp - self->ts), 256, 32768, 256); self->ts = 0;} END {}

--- a/dtrace/opte-count-cycles.d
+++ b/dtrace/opte-count-cycles.d
@@ -16,6 +16,42 @@ worker-pkt-end {
 	self->dir = 0;
 }
 
+xde_rx:entry {
+	self->drop_time = vtimestamp;
+}
+
+xde_mc_tx:entry {
+	self->drop_time = vtimestamp;
+}
+
+xde_rx:return /self->dir/ {
+	@time["place_in_inner"] = lquantize((vtimestamp - self->ts), 256, 32768, 256);
+	self->drop_time = 0;
+}
+
+xde_mc_tx:return /self->dir/ {
+	@time["place_out_inner"] = lquantize((vtimestamp - self->ts), 256, 32768, 256);
+	self->drop_time = 0;
+}
+
+xde_rx:return /!self->dir/ {
+	@time["place_in"] = lquantize((vtimestamp - self->ts), 256, 32768, 256);
+	self->drop_time = 0;
+}
+
+xde_mc_tx:return /!self->dir/ {
+	@time["place_out"] = lquantize((vtimestamp - self->ts), 256, 32768, 256);
+	self->drop_time = 0;
+}
+
+xde_rx:return {
+	self->drop_time = 0;
+}
+
+xde_mc_tx:return {
+	self->drop_time = 0;
+}
+
 END {
 
 }

--- a/dtrace/opte-count-cycles.d
+++ b/dtrace/opte-count-cycles.d
@@ -6,12 +6,12 @@ xde_rx:entry {
 	self->ts = vtimestamp;
 }
 
-xde_mc_tx:return /self->ts/ {
+xde_mc_tx_one:return /self->ts/ {
 	@time["tx"] = lquantize((vtimestamp - self->ts), 256, 32768, 256);
 	self->ts = 0;
 }
 
-xde_rx:return /self->ts/ {
+xde_rx_one:return /self->ts/ {
 	@time["rx"] = lquantize((vtimestamp - self->ts), 256, 32768, 256);
 	self->ts = 0;
 }

--- a/dtrace/opte-tcp-flowdrop.d
+++ b/dtrace/opte-tcp-flowdrop.d
@@ -1,0 +1,31 @@
+/*
+ * Track bad packets as they happen.
+ *
+ * dtrace -L ./lib -I . -Cqs ./opte-bad-packet.d
+ */
+#include "common.h"
+
+#define	HDR_FMT		"%-12s %-3s %-18s %s\n"
+#define	LINE_FMT	"%-12s %-3s 0x%-16p %s\n"
+
+BEGIN {
+	printf(HDR_FMT, "PORT", "DIR", "MBLK", "MSG");
+	num = 0;
+}
+
+tcp-err {
+	this->dir = DIR_STR(arg0);
+	this->port = stringof(arg1);
+	this->flow_id = stringof(arg2);
+	this->mblk = arg3;
+	this->msg = stringof(arg4);
+
+	if (num >= 10) {
+		printf(HDR_FMT, "PORT", "DIR", "MBLK", "MSG");
+		num = 0;
+	}
+
+	printf(LINE_FMT, this->port, this->dir, this->mblk, this->msg);
+	stack();
+	num++;
+}

--- a/lib/opte/src/engine/packet.rs
+++ b/lib/opte/src/engine/packet.rs
@@ -8,11 +8,6 @@
 //!
 //! TODO
 //!
-//! * Add a PacketChain type to represent a chain of one or more
-//! indepenndent packets. Also consider having chains that represent
-//! multiple packets for the same flow if it would be advantageous to
-//! do so.
-//!
 //! * Add hardware offload information to [`Packet`].
 //!
 
@@ -49,12 +44,16 @@ use super::ip6::Ipv6HdrError;
 use super::ip6::Ipv6Meta;
 use super::NetworkParser;
 use crate::d_error::DError;
+use crate::ddi::sync::KCondvar;
+use crate::ddi::sync::KMutex;
+use alloc::collections::LinkedList;
 use core::fmt;
 use core::fmt::Display;
 use core::ptr;
 use core::ptr::NonNull;
 use core::result;
 use core::slice;
+use core::sync::atomic::AtomicBool;
 use crc32fast::Hasher;
 use dyn_clone::DynClone;
 use serde::Deserialize;
@@ -423,6 +422,7 @@ impl PacketMeta {
 struct PacketChainInner {
     head: NonNull<mblk_t>,
     tail: NonNull<mblk_t>,
+    len: usize,
 }
 
 /// A chain of network packets.
@@ -460,11 +460,21 @@ impl PacketChain {
 
         // Walk the chain to find the tail, and support faster append.
         let mut tail = head;
+        let mut len = 0;
         while let Some(next_ptr) = NonNull::new((*tail.as_ptr()).b_next) {
+            len += 1;
             tail = next_ptr;
         }
 
-        Ok(Self { inner: Some(PacketChainInner { head, tail }) })
+        Ok(Self { inner: Some(PacketChainInner { head, tail, len }) })
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.as_ref().map(|v| v.len).unwrap_or_default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     /// Removes the next packet from the top of the chain and returns
@@ -527,8 +537,10 @@ impl PacketChain {
                 // pkt_p->b_next is already null.
             }
             list.tail = pkt;
+            list.len += 1;
         } else {
-            self.inner = Some(PacketChainInner { head: pkt, tail: pkt });
+            self.inner =
+                Some(PacketChainInner { head: pkt, tail: pkt, len: 1 });
         }
     }
 
@@ -537,6 +549,31 @@ impl PacketChain {
     /// `mblk_t` segment chain.
     pub fn unwrap_mblk(mut self) -> Option<NonNull<mblk_t>> {
         self.inner.take().map(|v| v.head)
+    }
+
+    /// Append another `PacketChain` to the end of this one.
+    pub fn extend(&mut self, mut other: Self) {
+        match (&mut self.inner, other.inner.take()) {
+            // Append them to us.
+            (Some(my_inner), Some(their_inner)) => {
+                // link our tail with their head.
+                let old_tail_p = my_inner.tail.as_ptr();
+                let their_head_p = their_inner.head.as_ptr();
+                unsafe {
+                    (*old_tail_p).b_next = their_head_p;
+                    (*their_head_p).b_prev = old_tail_p;
+                }
+
+                my_inner.tail = their_inner.tail;
+                my_inner.len += their_inner.len;
+            }
+            // replace with their inner.
+            (None, their_inner @ Some(_)) => {
+                self.inner = their_inner;
+            }
+            // Append an empty list: no-op.
+            (_, None) => {}
+        }
     }
 }
 
@@ -560,6 +597,105 @@ impl Drop for PacketChain {
             }
         }
     }
+}
+
+/// A `PacketChain` plus per-element metadata.
+// using linked list, probably want to swap vecdeques in and out.
+pub struct PacketChainAnd<T> {
+    packets: PacketChain,
+    metadata: LinkedList<T>,
+}
+
+impl<T> Default for PacketChainAnd<T> {
+    fn default() -> Self {
+        Self { packets: PacketChain::empty(), metadata: LinkedList::new() }
+    }
+}
+
+impl<T> Iterator for PacketChainAnd<T> {
+    type Item = (Packet<Initialized>, T);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.packets
+            .pop_front()
+            .and_then(|el| self.metadata.pop_front().map(|meta| (el, meta)))
+    }
+}
+
+/// Not quite an SQueue.
+// TODO: work in signalling/condvar
+pub struct EssQueue<T> {
+    inner: KMutex<PacketChainAnd<T>>,
+    cv: KCondvar,
+    watermark: usize,
+    kill: AtomicBool,
+}
+
+impl<T> EssQueue<T> {
+    pub fn new(watermark: usize) -> Self {
+        Self {
+            inner: KMutex::new(
+                Default::default(),
+                crate::ddi::sync::KMutexType::Driver,
+            ),
+            cv: KCondvar::new(),
+            watermark,
+            kill: false.into(),
+        }
+    }
+
+    // TODO: want in future to maybe have T be derived from the packet (e.g., parsed).
+    pub fn deliver(
+        &self,
+        packets: PacketChain,
+        mut f: impl FnMut() -> T,
+    ) -> Result<(), EssQueueDeliverError> {
+        // pre-prepare list of elements to push at back.
+        let mut els: LinkedList<T> = (0..packets.len()).map(|_| f()).collect();
+
+        let mut workspace = self.inner.lock();
+
+        if workspace.packets.len() > self.watermark {
+            return Err(EssQueueDeliverError::Full);
+        }
+
+        workspace.packets.extend(packets);
+        workspace.metadata.append(&mut els);
+
+        // We can notify with/without the lock, but illumos prefers
+        // we do so with the lock 'for scheduling purposes'.
+        self.cv.notify_one();
+
+        Ok(())
+    }
+
+    // Probably want there to be a timeout here rather than just a kill flag.
+    pub fn receive(&self) -> Result<PacketChainAnd<T>, EssQueueReceiveError> {
+        let mut workspace = self.inner.lock();
+
+        while workspace.packets.is_empty() {
+            if self.kill.load(core::sync::atomic::Ordering::Relaxed) {
+                return Err(EssQueueReceiveError::Dead);
+            }
+
+            workspace = self.cv.wait(workspace);
+        }
+
+        Ok(core::mem::take(&mut workspace))
+    }
+
+    pub fn quiesce(&self) {
+        self.kill.store(true, core::sync::atomic::Ordering::Relaxed);
+        self.cv.notify_all();
+    }
+}
+
+pub enum EssQueueDeliverError {
+    Full,
+}
+
+pub enum EssQueueReceiveError {
+    Dead,
 }
 
 /// A network packet.

--- a/lib/opte/src/engine/packet.rs
+++ b/lib/opte/src/engine/packet.rs
@@ -55,6 +55,7 @@ use core::ptr::NonNull;
 use core::result;
 use core::slice;
 use core::sync::atomic::AtomicBool;
+use core::sync::atomic::AtomicU64;
 use core::sync::atomic::AtomicUsize;
 use crc32fast::Hasher;
 use dyn_clone::DynClone;
@@ -744,8 +745,8 @@ impl<T> EssQueue<T> {
                 pkts.extend(taken);
             }
 
-            let a = self.sleepy.lock();
-            self.cv.wait(a);
+            // let a = self.sleepy.lock();
+            // self.cv.wait(a);
         }
 
         Ok(pkts)

--- a/xde/src/lib.rs
+++ b/xde/src/lib.rs
@@ -47,6 +47,7 @@ mod mac_sys;
 pub mod route;
 pub mod secpolicy;
 pub mod sys;
+pub mod thread;
 pub mod xde;
 
 // On alignment, `kmem_alloc(9F)` has this of offer:

--- a/xde/src/thread.rs
+++ b/xde/src/thread.rs
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2024 Oxide Computer Company
+
+//! Illumos kthread support.
+
+use crate::ip::kthread_t;
+use crate::ip::p0;
+use crate::ip::thread_create;
+use crate::ip::thread_exit;
+use crate::ip::thread_join;
+use crate::ip::TS_RUN;
+use alloc::boxed::Box;
+use core::ffi::c_void;
+use core::ptr;
+use core::ptr::addr_of_mut;
+use core::ptr::NonNull;
+
+unsafe extern "C" fn kthread_body(arg: *mut c_void) {
+    let arg = arg as *mut Box<dyn FnOnce()>;
+    let closure = unsafe { Box::from_raw(arg) };
+
+    closure();
+    // closure used by val, so dropped before thread exit.
+
+    unsafe {
+        thread_exit();
+    }
+}
+
+pub fn spawn<F>(f: F) -> JoinHandle
+where
+    F: FnOnce(), // -> T,
+    F: Send + 'static,
+    // T: Send + 'static,
+{
+    // A bit of an odd dance here -- we need to double box to get a thin
+    // pointer at the `into_raw` side.
+    let boxed = Box::new(f) as Box<dyn FnOnce()>;
+    let arg = Box::into_raw(Box::new(boxed));
+    let handle = unsafe {
+        thread_create(
+            ptr::null_mut(),
+            0, // pulled up to default stack size.
+            // Typedef implies no args, reality implies args. Huh.
+            Some(core::mem::transmute::<_, unsafe extern "C" fn()>(
+                kthread_body as unsafe extern "C" fn(_),
+            )),
+            arg as *mut c_void,
+            0,
+            addr_of_mut!(p0),
+            TS_RUN as i32,
+            60, //minclsyspri
+        )
+    };
+
+    let handle = NonNull::new(handle)
+        .expect("thread_create returned a null ptr, \
+            but is documented as infallible");
+
+    JoinHandle { handle }
+}
+
+pub struct JoinHandle {
+    handle: NonNull<kthread_t>,
+}
+
+impl JoinHandle {
+    pub fn join(self) {
+        unsafe { thread_join((*self.handle.as_ptr()).t_did) }
+    }
+}

--- a/xde/src/thread.rs
+++ b/xde/src/thread.rs
@@ -56,9 +56,10 @@ where
         )
     };
 
-    let handle = NonNull::new(handle)
-        .expect("thread_create returned a null ptr, \
-            but is documented as infallible");
+    let handle = NonNull::new(handle).expect(
+        "thread_create returned a null ptr, \
+            but is documented as infallible",
+    );
 
     JoinHandle { handle }
 }

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -265,7 +265,9 @@ impl XdeState {
         let ectx = Arc::new(ExecCtx { log: Box::new(opte::KernelLog {}) });
 
         // Completely arbitrary watermark lmao.
-        let deliver = Arc::new(EssQueue::new(Some(NonZeroUsize::new(usize::MAX).unwrap())));
+        let deliver = Arc::new(EssQueue::new(Some(
+            NonZeroUsize::new(usize::MAX).unwrap(),
+        )));
         let worker_mailbox = deliver.clone();
 
         let deliver_hdl = Some(spawn(|| xde_worker(worker_mailbox)));
@@ -1569,7 +1571,7 @@ unsafe extern "C" fn xde_mc_tx(
 
     if let Err(_) = get_xde_state()
         .deliver
-        .deliver(chain, || Origin::Port(src_dev.devname.clone()))
+        .deliver(1, chain, || Origin::Port(src_dev.devname.clone()))
     {
         unsafe {
             __dtrace_probe_worker__no__space(Direction::Out as _, n_pkts);
@@ -1962,7 +1964,7 @@ unsafe extern "C" fn xde_rx(
     // Eh... The only reason I can get away with this is because we never
     // Hairpin anything on the underlay, for good reason lmao.
     if let Err(_) =
-        get_xde_state().deliver.deliver(chain, || Origin::Underlay(0))
+        get_xde_state().deliver.deliver(0, chain, || Origin::Underlay(0))
     {
         unsafe {
             __dtrace_probe_worker__no__space(Direction::In as _, n_pkts);

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -28,6 +28,8 @@ use crate::route::RouteCache;
 use crate::route::RouteKey;
 use crate::secpolicy;
 use crate::sys;
+use crate::thread::spawn;
+use crate::thread::JoinHandle;
 use crate::warn;
 use alloc::boxed::Box;
 use alloc::ffi::CString;
@@ -37,6 +39,7 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::ffi::CStr;
 use core::num::NonZeroU32;
+use core::num::NonZeroUsize;
 use core::ptr;
 use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
@@ -64,6 +67,7 @@ use opte::engine::headers::EncapMeta;
 use opte::engine::headers::IpAddr;
 use opte::engine::ioctl::{self as api};
 use opte::engine::ip6::Ipv6Addr;
+use opte::engine::packet::EssQueue;
 use opte::engine::packet::Initialized;
 use opte::engine::packet::InnerFlowId;
 use opte::engine::packet::Packet;
@@ -145,6 +149,14 @@ extern "C" {
     pub fn __dtrace_probe_hdlr__resp(resp_str: uintptr_t);
     pub fn __dtrace_probe_rx(mp: uintptr_t);
     pub fn __dtrace_probe_tx(mp: uintptr_t);
+
+    pub fn __dtrace_probe_worker__start(n_pkts: uintptr_t);
+    pub fn __dtrace_probe_worker__end();
+
+    pub fn __dtrace_probe_worker__pkt__start(dir: uintptr_t);
+    pub fn __dtrace_probe_worker__pkt__end();
+
+    pub fn __dtrace_probe_worker__no__space(dir: uintptr_t, n_pkts: uintptr_t);
 }
 
 fn bad_packet_parse_probe(
@@ -226,6 +238,9 @@ struct XdeState {
     vpc_map: Arc<overlay::VpcMappings>,
     v2b: Arc<overlay::Virt2Boundary>,
     underlay: KMutex<Option<UnderlayState>>,
+
+    deliver: Arc<EssQueue<Origin>>,
+    deliver_hdl: Option<JoinHandle>,
 }
 
 struct UnderlayState {
@@ -248,11 +263,21 @@ fn get_xde_state() -> &'static XdeState {
 impl XdeState {
     fn new() -> Self {
         let ectx = Arc::new(ExecCtx { log: Box::new(opte::KernelLog {}) });
+
+        // Completely arbitrary watermark lmao.
+        let deliver = Arc::new(EssQueue::new(Some(NonZeroUsize::new(usize::MAX).unwrap())));
+        let worker_mailbox = deliver.clone();
+
+        let deliver_hdl = Some(spawn(|| xde_worker(worker_mailbox)));
+
         XdeState {
             underlay: KMutex::new(None, KMutexType::Driver),
             ectx,
             vpc_map: Arc::new(overlay::VpcMappings::new()),
             v2b: Arc::new(overlay::Virt2Boundary::new()),
+
+            deliver,
+            deliver_hdl,
         }
     }
 }
@@ -1254,7 +1279,13 @@ unsafe extern "C" fn xde_detach(
 
     // Reattach the XdeState to a Box, which takes ownership and will
     // free it on drop.
-    drop(Box::from_raw(state));
+    let mut xde = Box::from_raw(state);
+
+    // End the worker thread.
+    xde.deliver.quiesce();
+    xde.deliver_hdl.take().unwrap().join();
+
+    drop(xde);
 
     // Remove control device
     ddi_remove_minor_node(xde_dip, XDE_STR);
@@ -1530,8 +1561,19 @@ unsafe extern "C" fn xde_mc_tx(
     // by the mch they're being targeted to. E.g., either build a list
     // of chains (u1, u2, port0, port1, ...), or hold tx until another
     // packet breaks the run targeting the same dest.
-    while let Some(pkt) = chain.pop_front() {
-        xde_mc_tx_one(src_dev, pkt);
+    // while let Some(pkt) = chain.pop_front() {
+    //     xde_mc_tx_one(src_dev, pkt);
+    // }
+
+    let n_pkts = chain.len();
+
+    if let Err(_) = get_xde_state()
+        .deliver
+        .deliver(chain, || Origin::Port(src_dev.devname.clone()))
+    {
+        unsafe {
+            __dtrace_probe_worker__no__space(Direction::Out as _, n_pkts);
+        }
     }
 
     ptr::null_mut()
@@ -1676,6 +1718,85 @@ unsafe fn xde_mc_tx_one(
     // On return the Packet is dropped and its underlying mblk
     // segments are freed.
     ptr::null_mut()
+}
+
+// Doing it this wey for now because passing Arcs will really
+// complicate the detach flow + safety (e.g., Arcs to ports/ulays
+// outliving the quiesced callbacks)...
+// Strings suck but this is a POC, so w/e.
+enum Origin {
+    Underlay(usize),
+    Port(String),
+}
+
+// TODO: put somewhere sane
+
+pub const CPU_BEST: c_int = -4;
+
+extern "C" {
+    pub fn affinity_set(affinity: c_int);
+}
+
+fn xde_worker(mailbox: Arc<EssQueue<Origin>>) {
+    opte::engine::err!("XDE WORKER STARTED");
+
+    unsafe { affinity_set(CPU_BEST) };
+
+    while let Ok(packets) = mailbox.receive() {
+        unsafe {
+            __dtrace_probe_worker__start(packets.len());
+        }
+
+        let devs = unsafe { xde_devs.read() };
+        let xde = get_xde_state();
+        let ulay = xde.underlay.lock();
+
+        // TODO: hold packets out here for batched dispatch.
+        for (packet, origin) in packets {
+            let dir = if let Origin::Underlay(_) = &origin {
+                Direction::In
+            } else {
+                Direction::Out
+            };
+            unsafe {
+                __dtrace_probe_worker__pkt__start(dir as _);
+            }
+
+            match origin {
+                Origin::Port(port_name) => {
+                    let my_port =
+                        devs.iter().find(|port| port.devname == port_name);
+
+                    if let Some(port) = my_port {
+                        unsafe {
+                            xde_mc_tx_one(port, packet);
+                        }
+                    }
+                }
+                Origin::Underlay(0) => unsafe {
+                    if let Some(ulay) = &*ulay {
+                        xde_rx_one(&ulay.u1.mch, ptr::null_mut(), packet);
+                    }
+                },
+                Origin::Underlay(1) => unsafe {
+                    if let Some(ulay) = &*ulay {
+                        xde_rx_one(&ulay.u2.mch, ptr::null_mut(), packet);
+                    }
+                },
+                Origin::Underlay(n) => panic!("I don't have an {n}th underlay"),
+            };
+
+            unsafe {
+                __dtrace_probe_worker__pkt__end();
+            }
+        }
+
+        unsafe {
+            __dtrace_probe_worker__end();
+        }
+    }
+
+    opte::engine::err!("XDE WORKER EXITED");
 }
 
 /// This is a generic wrapper for references that should be dropped once not in
@@ -1832,8 +1953,20 @@ unsafe extern "C" fn xde_rx(
     // by the mch they're being targeted to. E.g., either build a list
     // of chains (port0, port1, ...), or hold tx until another
     // packet breaks the run targeting the same dest.
-    while let Some(pkt) = chain.pop_front() {
-        xde_rx_one(&mch, mrh, pkt);
+    // while let Some(pkt) = chain.pop_front() {
+    //     xde_rx_one(&mch, mrh, pkt);
+    // }
+
+    let n_pkts = chain.len();
+
+    // Eh... The only reason I can get away with this is because we never
+    // Hairpin anything on the underlay, for good reason lmao.
+    if let Err(_) =
+        get_xde_state().deliver.deliver(chain, || Origin::Underlay(0))
+    {
+        unsafe {
+            __dtrace_probe_worker__no__space(Direction::In as _, n_pkts);
+        }
     }
 }
 


### PR DESCRIPTION
We have some aspects of packet delivery that make worker threads and/or full-fledged squeues, interesting to experiment with:
* Packets for a logical port will arrive from both the underlay and its VNIC -- likely two threads with different CPU bindings.
* Ports are currently locked via mutex, such that we want to serialise packets bound for a port to be processed by the same kthread.
* Packets arriving on the VNIC backing an OPTE port are delivered one packet at a time. (I have not yet dug into this behaviour on the illumos side).
* Packets arriving on the Underlay will be delivered one-at-a-time until we can finalise/implement the ongoing illumos flows design work.

Currently this branch includes some Rust wrappers around kcondvars and thread creation/binding in a kernel module context (and a basic MPSC with worse contention than I'd like). I'm using this as a space to hash out some ideas in this space, even if the lifetime of this work is inevitably temporary.