### PR TITLE
Don't unwrap when removing invalid TCP state from fastpath.

### DIFF
--- a/lib/opte/src/engine/port.rs
+++ b/lib/opte/src/engine/port.rs
@@ -1396,9 +1396,9 @@ impl<N: NetworkImpl> Port<N> {
 
             let ufid_in = flow_lock.inbound_ufid.as_ref();
 
-            // Because we've dropped the port lock, another flow could have also
+            // Because we've dropped the port lock, another packet could have also
             // invalidated this flow and removed the entry. It could even install
-            // new UFT/TCP entries, depending on ordering.
+            // new UFT/TCP entries, depending on lock/process ordering.
             //
             // Verify that the state we want to remove still exists, and is
             // `Arc`-identical.


### PR DESCRIPTION
Now that the fastpath temporarily drops (and reacquires) the port lock when TCP state needs to be invalidated, we opened ourselves up to the possibility that another packet could have removed this state ahead of us. Equally, a packet could insert new TCP state which we might accidentally remove.

This PR removes the unwrap on removal to account for the race, and only removes TCP flows if they are pointer-equal.

Closes #618, closes #624.