### PR TITLE
Use `BTreeMap`s to accelerate port lookup by name & VNI/MAC address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2698,6 +2698,7 @@ dependencies = [
  "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys)",
  "opteadm",
  "oxide-vpc",
+ "rand",
  "slog",
  "slog-async",
  "slog-envlogger",

--- a/bench/benches/xde.rs
+++ b/bench/benches/xde.rs
@@ -215,6 +215,14 @@ struct OpteCreateParams {
         default_value_t=ZoneBrand::Sparse,
     )]
     brand: ZoneBrand,
+
+    /// The number of additional OPTE ports which should be created.
+    ///
+    /// These ports will not be used for traffic generation, and are used
+    /// to impact the port lookup time for Rx'd packets. Ports will be
+    /// assigned random MAC addresses.
+    #[arg(short = 'P', long, default_value_t = 0)]
+    passive_ports: u32,
 }
 
 #[derive(Parser)]
@@ -425,6 +433,7 @@ fn over_nic(params: &OpteCreateParams, host: &str, pause: bool) -> Result<()> {
         (&params.underlay_nics[..2]).try_into().unwrap(),
         xde_tests::ZONE_B_PORT,
         &[xde_tests::ZONE_A_PORT],
+        params.passive_ports,
         params.brand.to_str(),
     )?;
     print_banner("Topology built!");
@@ -543,6 +552,7 @@ fn host_iperf(params: &OpteCreateParams) -> Result<()> {
         (&params.underlay_nics[..2]).try_into().unwrap(),
         xde_tests::ZONE_A_PORT,
         &[xde_tests::ZONE_B_PORT],
+        params.passive_ports,
         params.brand.to_str(),
     )?;
 

--- a/bin/opteadm/src/bin/opteadm.rs
+++ b/bin/opteadm/src/bin/opteadm.rs
@@ -571,7 +571,20 @@ fn main() -> anyhow::Result<()> {
         Command::ListPorts => {
             let mut t = TabWriter::new(std::io::stdout());
             print_port_header(&mut t)?;
-            for p in hdl.list_ports()?.ports {
+            let mut ports = hdl.list_ports()?.ports;
+
+            ports.sort_by(|lhs, rhs| {
+                let l_opt_num: Option<u64> =
+                    lhs.name.strip_prefix("opte").and_then(|v| v.parse().ok());
+                let r_opt_num: Option<u64> =
+                    rhs.name.strip_prefix("opte").and_then(|v| v.parse().ok());
+
+                match (l_opt_num, r_opt_num) {
+                    (Some(l_n), Some(r_n)) => l_n.cmp(&r_n),
+                    _ => lhs.name.cmp(&rhs.name),
+                }
+            });
+            for p in ports {
                 print_port(&mut t, p)?;
             }
             t.flush()?;

--- a/xde-tests/Cargo.toml
+++ b/xde-tests/Cargo.toml
@@ -12,6 +12,7 @@ oxide-vpc.workspace = true
 
 anyhow.workspace = true
 libnet.workspace = true
+rand.workspace = true
 slog.workspace = true
 slog-async.workspace = true
 slog-envlogger.workspace = true

--- a/xde/src/dev_map.rs
+++ b/xde/src/dev_map.rs
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2024 Oxide Computer Company
+
+use crate::xde::XdeDev;
+use alloc::boxed::Box;
+use alloc::collections::btree_map::BTreeMap;
+use alloc::string::String;
+use opte::api::MacAddr;
+use opte::api::Vni;
+
+// From microbenchmarking (https://github.com/oxidecomputer/opte/issues/637)
+// it is apparent that we have *far* faster `Ord` and `Eq` implementations
+// on these wider integer types.
+type Key = (u32, u64);
+type Val = Box<XdeDev>;
+
+pub struct DevMap {
+    devs: BTreeMap<Key, Val>,
+    names: BTreeMap<String, Key>,
+}
+
+impl Default for DevMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DevMap {
+    pub const fn new() -> Self {
+        Self { devs: BTreeMap::new(), names: BTreeMap::new() }
+    }
+
+    pub fn insert(&mut self, val: Val) -> Option<Val> {
+        let key = get_key(&val);
+        _ = self.names.insert(val.devname.clone(), key);
+        self.devs.insert(key, val)
+    }
+
+    pub fn remove(&mut self, name: &str) -> Option<Val> {
+        self.devs.remove(&self.names.remove(name)?)
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn get(&self, vni: Vni, mac: MacAddr) -> Option<&Val> {
+        self.devs.get(&(vni.as_u32(), mac_to_u64(mac)))
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn get_by_name(&self, name: &str) -> Option<&Val> {
+        self.devs.get(self.names.get(name)?)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Val> {
+        self.devs.values()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.devs.is_empty()
+    }
+}
+
+#[inline(always)]
+fn mac_to_u64(val: MacAddr) -> u64 {
+    let val = val.bytes();
+    u64::from_be_bytes([0, 0, val[0], val[1], val[2], val[3], val[4], val[5]])
+}
+
+#[inline(always)]
+fn get_key(dev: &Val) -> Key {
+    (dev.vni.as_u32(), mac_to_u64(dev.port.mac_addr()))
+}

--- a/xde/src/dev_map.rs
+++ b/xde/src/dev_map.rs
@@ -13,10 +13,16 @@ use opte::api::Vni;
 
 // From microbenchmarking (https://github.com/oxidecomputer/opte/issues/637)
 // it is apparent that we have *far* faster `Ord` and `Eq` implementations
-// on these wider integer types.
+// on these wider integer types than (Vni, MacAddr).
 type Key = (u32, u64);
 type Val = Box<XdeDev>;
 
+/// `BTreeMap`-accelerated lookup of XDE ports.
+///
+/// `XdeDev`s are uniquely keyed on both their name, and their `(Vni, MacAddr)`
+/// pair. The former is used mostly by the control plane, and the latter by the
+/// data plane -- thus, querying by address provides a direct lookup. Any other
+/// lookups (e.g., multicast listeners) should return `Key`s or `&[Key]`s.
 pub struct DevMap {
     devs: BTreeMap<Key, Val>,
     names: BTreeMap<String, Key>,
@@ -33,32 +39,40 @@ impl DevMap {
         Self { devs: BTreeMap::new(), names: BTreeMap::new() }
     }
 
+    /// Insert an `XdeDev`.
+    ///
+    /// Returns an existing port, if one exists.
     pub fn insert(&mut self, val: Val) -> Option<Val> {
         let key = get_key(&val);
         _ = self.names.insert(val.devname.clone(), key);
         self.devs.insert(key, val)
     }
 
+    /// Remove an `XdeDev` using its name.
     pub fn remove(&mut self, name: &str) -> Option<Val> {
         self.devs.remove(&self.names.remove(name)?)
     }
 
+    /// Return a reference to an `XdeDev` using its address.
     #[inline]
     #[must_use]
     pub fn get(&self, vni: Vni, mac: MacAddr) -> Option<&Val> {
         self.devs.get(&(vni.as_u32(), mac_to_u64(mac)))
     }
 
+    /// Return a reference to an `XdeDev` using its name.
     #[inline]
     #[must_use]
     pub fn get_by_name(&self, name: &str) -> Option<&Val> {
         self.devs.get(self.names.get(name)?)
     }
 
+    /// Return an iterator over all `XdeDev`s, sorted by address.
     pub fn iter(&self) -> impl Iterator<Item = &Val> {
         self.devs.values()
     }
 
+    /// Return whether any ports currently exist.
     pub fn is_empty(&self) -> bool {
         self.devs.is_empty()
     }

--- a/xde/src/lib.rs
+++ b/xde/src/lib.rs
@@ -40,6 +40,7 @@ use illumos_sys_hdrs::size_t;
 use illumos_sys_hdrs::CE_WARN;
 use illumos_sys_hdrs::KM_SLEEP;
 
+pub mod dev_map;
 pub mod dls;
 pub mod ip;
 pub mod mac;


### PR DESCRIPTION
This PR moves all lookup of ports by data- and control-plane operations to make use of `BTreeMap`s and prevent linear scans from being used in any case. `cargo kbench` now supports the `-P` flag to spin up a number of ports with random MAC/VNI combinations.

On `glasgow`, using `./kbench remote -b omicron1 -u cxgbe0 cxgbe1 172.20.2.114 -p -P $N_PORTS` + `iperf -c 10.0.0.1 -R`, the measured throughput remains in the 2.85–3.0Gbps range regardless of choice of `-P` (up to 4096). At 16384 ports we could no longer consistently hit 3Gbps, but we hadn't dipped too badly (2.8–2.9Gbps). I haven't measured control-plane-op/remove times, but I would expect that they enjoy similar speedup at large port counts. E.g., firewall/router/IP state updates all require a name lookup to apply. Addition of ports will now be more expensive (assuming no realloc of the `Vec`), but this is an expected part of maintaining `BTreeMap`s and the tradeoff is worth it for the hotpath benefit.

Additionally, we now use a single periodic task for all flow/route expiry management, to prevent ourselves from spending the system's `ddi_periodic_add` budget. This should be no worse than the previous state of affairs – iterating over all ports requires only a read lock over the `DevMap`, which any Rx handler will already be doing.

Closes #637, closes #638.