### PR TITLE
update oxnet to 0.1.0 from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,15 +925,6 @@ dependencies = [
 
 [[package]]
 name = "ipnetwork"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "ipnetwork"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
@@ -1054,29 +1045,7 @@ dependencies = [
 [[package]]
 name = "libnet"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/netadm-sys?branch=main#e07ad76458eb50601e0da4f9da16dbc942bfc2ba"
-dependencies = [
- "anyhow",
- "cfg-if",
- "colored",
- "dlpi",
- "libc",
- "num_enum",
- "nvpair",
- "nvpair-sys",
- "oxnet",
- "rand",
- "rusty-doors",
- "socket2",
- "thiserror 1.0.69",
- "tracing",
- "winnow 0.6.26",
-]
-
-[[package]]
-name = "libnet"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/netadm-sys#e07ad76458eb50601e0da4f9da16dbc942bfc2ba"
+source = "git+https://github.com/oxidecomputer/netadm-sys?branch=main#f4eae3d8070760922da93b9edd56ca4103b4c390"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1306,7 +1275,7 @@ version = "0.1.0"
 dependencies = [
  "illumos-sys-hdrs",
  "ingot",
- "ipnetwork 0.21.1",
+ "ipnetwork",
  "postcard",
  "serde",
  "smoltcp",
@@ -1347,7 +1316,7 @@ name = "opte-ioctl"
 version = "0.1.0"
 dependencies = [
  "libc",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys)",
+ "libnet",
  "opte",
  "oxide-vpc",
  "postcard",
@@ -1373,7 +1342,7 @@ dependencies = [
  "cfg-if",
  "clap",
  "libc",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys)",
+ "libnet",
  "opte",
  "opte-ioctl",
  "oxide-vpc",
@@ -1406,13 +1375,8 @@ dependencies = [
 [[package]]
 name = "oxnet"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/oxnet#49ee85dcd294901031c3395ee773363db1cdc289"
-dependencies = [
- "ipnetwork 0.20.0",
- "schemars",
- "serde",
- "serde_json",
-]
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff7aba867c36df803039621068faf1630d3039eb999c2f6c3950d1064d4fbbdf"
 
 [[package]]
 name = "parking_lot"
@@ -1837,30 +1801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.98",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1909,17 +1849,6 @@ name = "serde_derive"
 version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2724,7 +2653,7 @@ name = "xde-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys)",
+ "libnet",
  "opteadm",
  "oxide-vpc",
  "rand",
@@ -2812,10 +2741,10 @@ dependencies = [
 [[package]]
 name = "ztest"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/falcon?branch=main#651fb5889d66be90ac1afa4a730c573b643aef1e"
+source = "git+https://github.com/oxidecomputer/falcon?branch=main#f3fe0542198c08bbb82d16f168e6482db9bec5b9"
 dependencies = [
  "anyhow",
- "libnet 0.1.0 (git+https://github.com/oxidecomputer/netadm-sys?branch=main)",
+ "libnet",
  "oxnet",
  "tokio",
  "zone",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ ingot = { git = "https://github.com/oxidecomputer/ingot.git", rev = "bff93247fe7
 ipnetwork = { version = "0.21", default-features = false }
 itertools = { version = "0.14", default-features = false }
 libc = "0.2"
-libnet = { git = "https://github.com/oxidecomputer/netadm-sys" }
+libnet = { git = "https://github.com/oxidecomputer/netadm-sys", branch = "main" }
 nix = { version = "0.29", features = ["signal", "user"] }
 pcap-parser = "0.16"
 postcard = { version = "1", features = ["alloc"], default-features = false }


### PR DESCRIPTION
Also update libnet to explicitly specify `main`, in order to ensure that two
copies of the crate aren't floating around in other dependency graphs.
