### PR TITLE
Only use `KMutexType::Driver` in `mutex_init`

### DIFF
--- a/lib/opte/src/ddi/sync.rs
+++ b/lib/opte/src/ddi/sync.rs
@@ -119,7 +119,8 @@ impl<T> KMutex<T> {
         // Safety: ???.
         unsafe {
             // MUTEX_DRIVER is the only type currently sanctioned by the DDI
-            // for use here. Other types require the priority argument to be set.
+            // for use here. The priority argument, when we provide it, will
+            // control whether we get adaptive/spin behaviour.
             mutex_init(
                 &mut kmutex,
                 ptr::null(),

--- a/lib/opte/src/ddi/sync.rs
+++ b/lib/opte/src/ddi/sync.rs
@@ -109,7 +109,7 @@ impl<T> KMutex<T> {
     /// `KMutex` is the new owner of `val`. All access from here on out
     /// must be done by acquiring a `KMutexGuard` via the `lock()`
     /// method.
-    pub fn new(val: T, mtype: KMutexType) -> Self {
+    pub fn new(val: T) -> Self {
         let mut kmutex = kmutex_t { _opaque: 0 };
         // TODO This assumes the mutex is never used in interrupt
         // context. Need to pass 4th arg to set priority.
@@ -118,7 +118,14 @@ impl<T> KMutex<T> {
         //
         // Safety: ???.
         unsafe {
-            mutex_init(&mut kmutex, ptr::null(), mtype.into(), ptr::null());
+            // MUTEX_DRIVER is the only type currently sanctioned by the DDI
+            // for use here. Other types require the priority argument to be set.
+            mutex_init(
+                &mut kmutex,
+                ptr::null(),
+                KMutexType::Driver.into(),
+                ptr::null(),
+            );
         }
 
         KMutex {
@@ -205,7 +212,7 @@ impl<T> KMutex<T> {
         self.inner.into_inner().unwrap()
     }
 
-    pub fn new(val: T, _mtype: KMutexType) -> Self {
+    pub fn new(val: T) -> Self {
         KMutex { inner: Mutex::new(val) }
     }
 

--- a/lib/opte/src/engine/port.rs
+++ b/lib/opte/src/engine/port.rs
@@ -64,7 +64,6 @@ use crate::ddi::kstat::KStatU64;
 use crate::ddi::mblk::MsgBlk;
 use crate::ddi::mblk::MsgBlkIterMut;
 use crate::ddi::sync::KMutex;
-use crate::ddi::sync::KMutexType;
 use crate::ddi::time::Moment;
 use crate::engine::flow_table::ExpiryPolicy;
 use crate::engine::packet::EmitSpec;
@@ -347,7 +346,7 @@ impl PortBuilder {
             ectx: self.ectx,
             epoch: AtomicU64::new(1),
             net,
-            data: KMutex::new(data, KMutexType::Driver),
+            data: KMutex::new(data),
         })
     }
 
@@ -399,7 +398,7 @@ impl PortBuilder {
             name_cstr,
             mac,
             ectx,
-            layers: KMutex::new(Vec::new(), KMutexType::Driver),
+            layers: KMutex::new(Vec::new()),
         }
     }
 
@@ -2322,7 +2321,7 @@ impl<N: NetworkImpl> Port<N> {
 
         let ufid_out = pkt.flow().mirror();
         let mut hte = UftEntry {
-            pair: KMutex::new(Some(ufid_out), KMutexType::Spin),
+            pair: KMutex::new(Some(ufid_out)),
             xforms: xforms.compile(pkt.checksums_dirty()),
             epoch,
             l4_hash: ufid_in.crc32(),
@@ -2547,7 +2546,7 @@ impl<N: NetworkImpl> Port<N> {
         let res = self.layers_process(data, Out, pkt, &mut xforms, ameta);
 
         let hte = UftEntry {
-            pair: KMutex::new(None, KMutexType::Spin),
+            pair: KMutex::new(None),
             xforms: xforms.compile(pkt.checksums_dirty()),
             epoch,
             l4_hash: flow_before.crc32(),
@@ -2845,18 +2844,15 @@ impl TcpFlowEntryState {
         bytes_in: u64,
     ) -> Self {
         Self {
-            inner: KMutex::new(
-                TcpFlowEntryStateInner {
-                    outbound_ufid,
-                    inbound_ufid: Some(inbound_ufid),
-                    tcp_state,
-                    segs_in: 1,
-                    segs_out: 0,
-                    bytes_in,
-                    bytes_out: 0,
-                },
-                KMutexType::Spin,
-            ),
+            inner: KMutex::new(TcpFlowEntryStateInner {
+                outbound_ufid,
+                inbound_ufid: Some(inbound_ufid),
+                tcp_state,
+                segs_in: 1,
+                segs_out: 0,
+                bytes_in,
+                bytes_out: 0,
+            }),
         }
     }
 
@@ -2866,18 +2862,15 @@ impl TcpFlowEntryState {
         bytes_out: u64,
     ) -> Self {
         Self {
-            inner: KMutex::new(
-                TcpFlowEntryStateInner {
-                    outbound_ufid,
-                    inbound_ufid: None,
-                    tcp_state,
-                    segs_in: 0,
-                    segs_out: 1,
-                    bytes_in: 0,
-                    bytes_out,
-                },
-                KMutexType::Spin,
-            ),
+            inner: KMutex::new(TcpFlowEntryStateInner {
+                outbound_ufid,
+                inbound_ufid: None,
+                tcp_state,
+                segs_in: 0,
+                segs_out: 1,
+                bytes_in: 0,
+                bytes_out,
+            }),
         }
     }
 

--- a/lib/opte/src/engine/snat.rs
+++ b/lib/opte/src/engine/snat.rs
@@ -29,7 +29,6 @@ use super::rule::ResourceEntry;
 use super::rule::ResourceError;
 use super::rule::StatefulAction;
 use crate::ddi::sync::KMutex;
-use crate::ddi::sync::KMutexType;
 use crate::engine::icmp::QueryEcho;
 use alloc::collections::btree_map::BTreeMap;
 use alloc::string::ToString;
@@ -134,7 +133,7 @@ impl<T: ConcreteIpAddr> NatPool<T> {
 
     /// Create a new NAT pool, with no entries.
     pub fn new() -> Self {
-        NatPool { free_list: KMutex::new(BTreeMap::new(), KMutexType::Driver) }
+        NatPool { free_list: KMutex::new(BTreeMap::new()) }
     }
 
     // A helper function to verify correct operation during testing.

--- a/lib/oxide-vpc/src/engine/overlay.rs
+++ b/lib/oxide-vpc/src/engine/overlay.rs
@@ -29,7 +29,6 @@ use opte::api::MacAddr;
 use opte::api::OpteError;
 use opte::ddi::sync::KMutex;
 use opte::ddi::sync::KMutexGuard;
-use opte::ddi::sync::KMutexType;
 use opte::ddi::sync::KRwLock;
 use opte::ddi::sync::KRwLockType;
 use opte::engine::ether::EtherMeta;
@@ -500,7 +499,7 @@ impl VpcMappings {
     }
 
     pub fn new() -> Self {
-        VpcMappings { inner: KMutex::new(BTreeMap::new(), KMutexType::Driver) }
+        VpcMappings { inner: KMutex::new(BTreeMap::new()) }
     }
 }
 
@@ -581,8 +580,8 @@ impl Virt2Boundary {
         pt6.init(KRwLockType::Driver);
 
         Virt2Boundary {
-            ip4: KMutex::new(BTreeMap::new(), KMutexType::Driver),
-            ip6: KMutex::new(BTreeMap::new(), KMutexType::Driver),
+            ip4: KMutex::new(BTreeMap::new()),
+            ip6: KMutex::new(BTreeMap::new()),
             pt4,
             pt6,
         }
@@ -736,8 +735,8 @@ impl Virt2Phys {
 
     pub fn new() -> Self {
         Virt2Phys {
-            ip4: KMutex::new(BTreeMap::new(), KMutexType::Driver),
-            ip6: KMutex::new(BTreeMap::new(), KMutexType::Driver),
+            ip4: KMutex::new(BTreeMap::new()),
+            ip6: KMutex::new(BTreeMap::new()),
         }
     }
 }

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -253,14 +253,13 @@ impl XdeState {
     fn new() -> Self {
         let ectx = Arc::new(ExecCtx { log: Box::new(opte::KernelLog {}) });
         XdeState {
-            underlay: KMutex::new(None, KMutexType::Driver),
+            underlay: KMutex::new(None),
             ectx,
             vpc_map: Arc::new(overlay::VpcMappings::new()),
             v2b: Arc::new(overlay::Virt2Boundary::new()),
             stats: KMutex::new(
                 KStatNamed::new("xde", "xde", XdeStats::new())
                     .expect("Name is well-constructed (len, no NUL bytes)"),
-                KMutexType::Driver,
             ),
             cleanup: Periodic::new(
                 c"XDE flow/cache expiry".to_owned(),


### PR DESCRIPTION
Pulled out of #636. We were creating some `Spin` locks which, misconfigured, would end up falling back to adaptive behaviour as part of LFT creation. Moreover, they would hit a debug assert and panic on test bits. (!!!)

Given that we have no means of specifying priority in `mutex_init`, we now make sure that all created `KMutex`es are correct by removing the illusion of free choice.