### PR TITLE
Rework rust toolchain installation

### DIFF
--- a/.github/buildomat/common.sh
+++ b/.github/buildomat/common.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Install both toolchains required for OPTE.
+# We pin to both a specific nightly *and* a stable compiler version
+# due to XDE's reliance on unstable features.
+rustup show active-toolchain || rustup toolchain install
+
+pushd xde
+rustup show active-toolchain || rustup toolchain install
+export NIGHTLY=`rustup show active-toolchain | head -n 1`
+popd
+
+function header {
+	echo "# ==== $* ==== #"
+}
+
+function install_pkg {
+    set +o errexit
+    pfexec pkg install $1
+    exit_code=$?
+    # 4 is the exit code returned from pkg when the package is already installed
+    if [[ $exit_code -ne 0 ]] && [[ $exit_code -ne 4 ]]; then
+        echo "package install failed for $1"
+        exit 1
+    fi
+    set -o errexit
+}

--- a/.github/buildomat/common.sh
+++ b/.github/buildomat/common.sh
@@ -7,7 +7,7 @@ rustup show active-toolchain || rustup toolchain install
 
 pushd xde
 rustup show active-toolchain || rustup toolchain install
-export NIGHTLY=`rustup show active-toolchain | head -n 1`
+export NIGHTLY=`rustup show active-toolchain -v | head -n 1 | cut -d' ' -f1`
 popd
 
 function header {

--- a/.github/buildomat/jobs/bench.sh
+++ b/.github/buildomat/jobs/bench.sh
@@ -3,7 +3,7 @@
 #: name = "bench"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "stable"
+#: rust_toolchain = true
 #: output_rules = [
 #:   "=/work/bench-results.tgz",
 #: ]
@@ -25,6 +25,8 @@
 #### <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
 set -o xtrace
+
+source .github/buildomat/common.sh
 
 pfexec pkg install brand/sparse opte iperf demangle flamegraph
 

--- a/.github/buildomat/jobs/opte-api.sh
+++ b/.github/buildomat/jobs/opte-api.sh
@@ -3,7 +3,7 @@
 #: name = "opte-api"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly-2024-11-18"
+#: rust_toolchain = true
 #: output_rules = []
 #:
 
@@ -11,9 +11,7 @@ set -o errexit
 set -o pipefail
 set -o xtrace
 
-function header {
-	echo "# ==== $* ==== #"
-}
+source .github/buildomat/common.sh
 
 cargo --version
 rustc --version
@@ -24,7 +22,7 @@ header "check API_VERSION"
 ./check-api-version.sh
 
 header "check style"
-ptime -m cargo +nightly-2024-11-18 fmt -- --check
+ptime -m cargo +$NIGHTLY fmt -- --check
 
 header "analyze std"
 ptime -m cargo clippy --all-targets

--- a/.github/buildomat/jobs/opte-ioctl.sh
+++ b/.github/buildomat/jobs/opte-ioctl.sh
@@ -3,7 +3,7 @@
 #: name = "opte-ioctl"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly-2024-11-18"
+#: rust_toolchain = true
 #: output_rules = []
 #:
 
@@ -11,9 +11,7 @@ set -o errexit
 set -o pipefail
 set -o xtrace
 
-function header {
-	echo "# ==== $* ==== #"
-}
+source .github/buildomat/common.sh
 
 cargo --version
 rustc --version
@@ -21,7 +19,7 @@ rustc --version
 cd lib/opte-ioctl
 
 header "check style"
-ptime -m cargo +nightly-2024-11-18 fmt -- --check
+ptime -m cargo +$NIGHTLY fmt -- --check
 
 header "analyze"
 ptime -m cargo clippy --all-targets

--- a/.github/buildomat/jobs/opte.sh
+++ b/.github/buildomat/jobs/opte.sh
@@ -3,7 +3,7 @@
 #: name = "opte"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly-2024-11-18"
+#: rust_toolchain = true
 #: output_rules = []
 #:
 
@@ -11,9 +11,7 @@ set -o errexit
 set -o pipefail
 set -o xtrace
 
-function header {
-	echo "# ==== $* ==== #"
-}
+source .github/buildomat/common.sh
 
 cargo --version
 rustc --version
@@ -21,7 +19,7 @@ rustc --version
 cd lib/opte
 
 header "check style"
-ptime -m cargo +nightly-2024-11-18 fmt -- --check
+ptime -m cargo +$NIGHTLY fmt -- --check
 
 header "check docs"
 #
@@ -30,13 +28,13 @@ header "check docs"
 #
 # Use nightly which is needed for the `kernel` feature.
 RUSTDOCFLAGS="-D warnings" ptime -m \
-	    cargo +nightly-2024-11-18 doc --no-default-features --features=api,std,engine,kernel
+	cargo +$NIGHTLY doc --no-default-features --features=api,std,engine,kernel
 
 header "analyze std + api"
 ptime -m cargo clippy --all-targets
 
 header "analyze no_std + engine + kernel"
-ptime -m cargo +nightly-2024-11-18 clippy --no-default-features --features engine,kernel
+ptime -m cargo +$NIGHTLY clippy --no-default-features --features engine,kernel
 
 header "test"
 ptime -m cargo test

--- a/.github/buildomat/jobs/opteadm.sh
+++ b/.github/buildomat/jobs/opteadm.sh
@@ -3,7 +3,7 @@
 #: name = "opteadm"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly-2024-11-18"
+#: rust_toolchain = true
 #: output_rules = [
 #:   "=/work/debug/opteadm",
 #:   "=/work/debug/opteadm.debug.sha256",
@@ -20,9 +20,7 @@ set -o errexit
 set -o pipefail
 set -o xtrace
 
-function header {
-	echo "# ==== $* ==== #"
-}
+source .github/buildomat/common.sh
 
 cargo --version
 rustc --version
@@ -30,7 +28,7 @@ rustc --version
 pushd bin/opteadm
 
 header "check style"
-ptime -m cargo +nightly-2024-11-18 fmt -- --check
+ptime -m cargo +$NIGHTLY fmt -- --check
 
 header "analyze"
 ptime -m cargo clippy --all-targets

--- a/.github/buildomat/jobs/oxide-vpc.sh
+++ b/.github/buildomat/jobs/oxide-vpc.sh
@@ -3,7 +3,7 @@
 #: name = "oxide-vpc"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly-2024-11-18"
+#: rust_toolchain = true
 #: output_rules = []
 #:
 
@@ -11,9 +11,7 @@ set -o errexit
 set -o pipefail
 set -o xtrace
 
-function header {
-	echo "# ==== $* ==== #"
-}
+source .github/buildomat/common.sh
 
 cargo --version
 rustc --version
@@ -21,7 +19,7 @@ rustc --version
 cd lib/oxide-vpc
 
 header "check style"
-ptime -m cargo +nightly-2024-11-18 fmt -- --check
+ptime -m cargo +$NIGHTLY fmt -- --check
 
 header "check docs"
 #
@@ -30,13 +28,13 @@ header "check docs"
 #
 # Use nightly which is needed for the `kernel` feature.
 RUSTDOCFLAGS="-D warnings" ptime -m \
-	    cargo +nightly-2024-11-18 doc --no-default-features --features=api,std,engine,kernel
+	    cargo +$NIGHTLY doc --no-default-features --features=api,std,engine,kernel
 
 header "analyze std + api + usdt"
 ptime -m cargo clippy --features usdt --all-targets
 
 header "analyze no_std + engine + kernel"
-ptime -m cargo +nightly-2024-11-18 clippy --no-default-features --features engine,kernel
+ptime -m cargo +$NIGHTLY clippy --no-default-features --features engine,kernel
 
 header "test"
 ptime -m cargo test

--- a/.github/buildomat/jobs/p5p.sh
+++ b/.github/buildomat/jobs/p5p.sh
@@ -3,7 +3,7 @@
 #: name = "opte-p5p"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "nightly-2024-11-18"
+#: rust_toolchain = true
 #: output_rules = [
 #:   "=/out/opte.p5p",
 #:   "=/out/opte.p5p.sha256",
@@ -24,6 +24,8 @@ set -o errexit
 set -o pipefail
 set -o xtrace
 
+source .github/buildomat/common.sh
+
 #
 # TGT_BASE allows one to run this more easily in their local
 # environment:
@@ -36,10 +38,6 @@ REL_SRC=target/x86_64-unknown-unknown/release
 REL_TGT=$TGT_BASE/release
 
 mkdir -p $REL_TGT
-
-function header {
-	echo "# ==== $* ==== #"
-}
 
 cargo --version
 rustc --version

--- a/.github/buildomat/jobs/test.sh
+++ b/.github/buildomat/jobs/test.sh
@@ -3,7 +3,6 @@
 #: name = "test"
 #: variety = "basic"
 #: target = "helios-2.0"
-#: rust_toolchain = "stable"
 #: output_rules = [
 #:   "/work/*.log",
 #: ]


### PR DESCRIPTION
CI on recent PRs is breaking, due to rustup 1.28.0+ no longer autoinstalling the correct rust toolchain version. This hurts us immediately since we have *two* toolchains (pinned nightly and stable), and deliberately specified the nightly for some tooling.

This PR changes this over to use buildomat's auto-installation for the stable variant, and the new toolchain show -> install pattern for nightly. This also lets us place `$NIGHTLY` into most of our `cargo fmt` invocations, which should reduce the busywork in future compiler bumps for XDE.