### PR TITLE
Only compile XDE/ubench with LTO enabled

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [alias]
 xtask = "run --package xtask --"
-ubench = "bench --package opte-bench --bench userland --"
+ubench = "bench --package opte-bench --bench userland --profile release-lto --"
 kbench = "bench --package opte-bench --bench xde --"
 
 [env]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,4 +83,7 @@ poptrie = { git = "https://github.com/oxidecomputer/poptrie", branch = "multipat
 
 [profile.release]
 debug = 2
+
+[profile.release-lto]
+inherits = "release"
 lto = true

--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -14,7 +14,7 @@ mkdir -p proto/kernel/drv/amd64
 mkdir -p proto/opt/oxide/opte/bin
 mkdir -p proto/usr/lib/devfsadm/linkmod
 cp ../target/release/opteadm proto/opt/oxide/opte/bin/
-cp ../target/x86_64-unknown-unknown/release/xde proto/kernel/drv/amd64
+cp ../target/x86_64-unknown-unknown/release-lto/xde proto/kernel/drv/amd64
 cp ../xde/xde.conf proto/kernel/drv/
 cp ../target/i686-unknown-illumos/release/libxde_link.so proto/usr/lib/devfsadm/linkmod/SUNW_xde_link.so
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use anyhow::Context;
 use anyhow::Result;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -216,11 +216,16 @@ fn elevate(operation: &str, extra_args: &[&str]) -> Result<bool> {
 }
 
 fn cmd_build(release_only: bool) -> Result<()> {
-    let modes = if release_only { &[false][..] } else { &[true, false] };
+    let modes = if release_only {
+        &[PkgProfile::Release][..]
+    } else {
+        &[PkgProfile::Release, PkgProfile::Debug]
+    };
 
     for release_mode in modes {
         BuildTarget::OpteAdm.build(*release_mode)?;
         BuildTarget::Xde.build(*release_mode)?;
+        BuildTarget::XdeLink.build(*release_mode)?;
     }
 
     Ok(())
@@ -315,9 +320,42 @@ fn raw_install() -> Result<()> {
     Ok(())
 }
 
+#[derive(Copy, Clone, Debug)]
+enum PkgProfile {
+    Debug,
+    Release,
+}
+
+#[derive(Copy, Clone, Debug)]
+enum RustProfile {
+    Debug,
+    Release,
+    ReleaseLto,
+}
+
+impl RustProfile {
+    const fn name(self) -> &'static str {
+        match self {
+            RustProfile::Debug => "dev",
+            RustProfile::Release => "release",
+            RustProfile::ReleaseLto => "release-lto",
+        }
+    }
+
+    const fn folder(self) -> &'static str {
+        match self {
+            RustProfile::Debug => "debug",
+            RustProfile::Release => "release",
+            RustProfile::ReleaseLto => "release-lto",
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
 enum BuildTarget {
     OpteAdm,
     Xde,
+    XdeLink,
 }
 
 fn build_cargo_bin(
@@ -368,26 +406,35 @@ fn build_cargo_bin(
 }
 
 impl BuildTarget {
-    fn build(&self, debug: bool) -> Result<()> {
-        let (profile, xde_profile) = if debug { ("debug", "debug") } else { ("release", "release-lto") };
+    const fn rust_profile(self, profile: PkgProfile) -> RustProfile {
+        match (profile, self) {
+            (PkgProfile::Debug, _) => RustProfile::Debug,
+            (PkgProfile::Release, BuildTarget::Xde) => RustProfile::ReleaseLto,
+            (PkgProfile::Release, _) => RustProfile::Release,
+        }
+    }
+
+    fn build(&self, profile: PkgProfile) -> Result<()> {
+        let meta = cargo_meta();
+        let rust_profile = self.rust_profile(profile);
+        let p_name = rust_profile.name();
+        let p_folder = rust_profile.folder();
         match self {
             Self::OpteAdm => {
-                println!("Building opteadm ({profile}).");
-                build_cargo_bin(&["--bin", "opteadm"], profile, None, true)
+                println!("Building opteadm ({p_name}).");
+                build_cargo_bin(&["--bin", "opteadm"], p_name, None, true)
             }
             Self::Xde => {
-                println!("Building xde ({profile}).");
-                let meta = cargo_meta();
-                build_cargo_bin(&[], xde_profile, Some("xde"), false)?;
+                println!("Building xde ({p_name}).");
+                build_cargo_bin(&[], p_name, Some("xde"), false)?;
 
-                let out_name = if debug {
-                    "xde.dbg"
-                } else {
-                    "xde"
+                let out_name = match profile {
+                    PkgProfile::Debug => "xde.dbg",
+                    PkgProfile::Release => "xde",
                 };
                 let target_dir = meta
                     .target_directory
-                    .join(format!("{KMOD_TARGET}/{xde_profile}"));
+                    .join(format!("{KMOD_TARGET}/{p_folder}"));
 
                 println!("Linking xde kmod...");
                 Command::new("ld")
@@ -405,14 +452,16 @@ impl BuildTarget {
                     ])
                     .output_nocapture()
                     .context("failed to link XDE kernel module")?;
-
-                println!("Building xde dev link helper ({profile}).");
-                build_cargo_bin(&[], profile, Some("xde/xde-link"), false)?;
+                Ok(())
+            }
+            Self::XdeLink => {
+                println!("Building xde dev link helper ({p_name}).");
+                build_cargo_bin(&[], p_name, Some("xde/xde-link"), false)?;
 
                 // verify no panicking in the devfsadm plugin
                 let nm_output = Command::new("nm")
                     .arg(meta.target_directory.join(format!(
-                        "i686-unknown-illumos/{profile}/libxde_link.so"
+                        "i686-unknown-illumos/{p_folder}/libxde_link.so"
                     )))
                     .output()?;
 


### PR DESCRIPTION
Before:
```bash
kyle@farme:~/gits/opte$ time cargo xtask install
...
   Compiling xtask v0.1.0 (/develop/gits/opte/xtask)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 15.26s
     Running `target/debug/xtask install`
Building opteadm (release).
...
   Compiling oxide-vpc v0.1.0 (/develop/gits/opte/lib/oxide-vpc)
   Compiling opte-ioctl v0.1.0 (/develop/gits/opte/lib/opte-ioctl)
    Finished `release` profile [optimized + debuginfo] target(s) in 54.47s
Building xde (release).
   Compiling xde v0.1.0 (/develop/gits/opte/xde)
    Finished `release` profile [optimized + debuginfo] target(s) in 56.70s
Linking xde kmod...
Building xde dev link helper (release).
   Compiling compiler_builtins v0.1.146
   Compiling core v0.0.0 (/home/kyle/.rustup/toolchains/nightly-2025-02-20-x86_64-unknown-illumos/lib/rustlib/src/rust/library/core)
   Compiling xde-link v0.1.0 (/develop/gits/opte/xde/xde-link)
   Compiling rustc-std-workspace-core v1.99.0 (/home/kyle/.rustup/toolchains/nightly-2025-02-20-x86_64-unknown-illumos/lib/rustlib/src/rust/library/rustc-std-workspace-core)
   Compiling alloc v0.0.0 (/home/kyle/.rustup/toolchains/nightly-2025-02-20-x86_64-unknown-illumos/lib/rustlib/src/rust/library/alloc)
    Finished `release` profile [optimized + debuginfo] target(s) in 19.75s
Command requires admin privileges to install xde kernel module. Continue? [yY] Exiting...

real    2m27.355s
user    7m27.327s
sys     0m45.371s
```

After:
```bash
kyle@farme:~/gits/opte$ time cargo xtask install
...
   Compiling xtask v0.1.0 (/develop/gits/opte/xtask)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.85s
     Running `target/debug/xtask install`
Building opteadm (release).
...
   Compiling oxide-vpc v0.1.0 (/develop/gits/opte/lib/oxide-vpc)
   Compiling opte-ioctl v0.1.0 (/develop/gits/opte/lib/opte-ioctl)
    Finished `release` profile [optimized + debuginfo] target(s) in 39.79s
Building xde (release).
...
   Compiling xde v0.1.0 (/develop/gits/opte/xde)
    Finished `release-lto` profile [optimized + debuginfo] target(s) in 56.61s
Linking xde kmod...
Building xde dev link helper (release).
   Compiling compiler_builtins v0.1.146
   Compiling core v0.0.0 (/home/kyle/.rustup/toolchains/nightly-2025-02-20-x86_64-unknown-illumos/lib/rustlib/src/rust/library/core)
   Compiling xde-link v0.1.0 (/develop/gits/opte/xde/xde-link)
   Compiling rustc-std-workspace-core v1.99.0 (/home/kyle/.rustup/toolchains/nightly-2025-02-20-x86_64-unknown-illumos/lib/rustlib/src/rust/library/rustc-std-workspace-core)
   Compiling alloc v0.0.0 (/home/kyle/.rustup/toolchains/nightly-2025-02-20-x86_64-unknown-illumos/lib/rustlib/src/rust/library/alloc)
    Finished `release` profile [optimized + debuginfo] target(s) in 19.91s
Command requires admin privileges to install xde kernel module. Continue? [yY]                                                                                                              Exiting...

real    2m12.931s
user    9m5.097s
sys     0m46.227s
```

Realistically, this drops the cost of an incremental compile from ~67s to 50s on my Helios workstation.

Closes #702.