### PR TITLE
Explicitly drop non-echo ICMP at SNAT

### DIFF
--- a/lib/opte/src/engine/icmp/v4.rs
+++ b/lib/opte/src/engine/icmp/v4.rs
@@ -24,6 +24,7 @@ use ingot::types::HeaderParse;
 use opte::engine::Checksum as OpteCsum;
 pub use opte_api::ip::IcmpEchoReply;
 use smoltcp::wire;
+use smoltcp::wire::Icmpv4Message;
 
 impl HairpinAction for IcmpEchoReply {
     fn implicit_preds(&self) -> (Vec<Predicate>, Vec<DataPredicate>) {
@@ -198,8 +199,8 @@ impl Display for MessageType {
 impl<B: ByteSlice> QueryEcho for IcmpV4Packet<B> {
     #[inline]
     fn echo_id(&self) -> Option<u16> {
-        match (self.code(), self.ty()) {
-            (0, 0) | (0, 8) => {
+        match (self.ty().into(), self.code()) {
+            (Icmpv4Message::EchoRequest, 0) | (Icmpv4Message::EchoReply, 0) => {
                 ValidIcmpEcho::parse(self.rest_of_hdr_ref().as_slice())
                     .ok()
                     .map(|(v, ..)| v.id())
@@ -212,8 +213,8 @@ impl<B: ByteSlice> QueryEcho for IcmpV4Packet<B> {
 impl<B: ByteSlice> QueryEcho for ValidIcmpV4<B> {
     #[inline]
     fn echo_id(&self) -> Option<u16> {
-        match (self.code(), self.ty()) {
-            (0, 0) | (0, 8) => {
+        match (self.ty().into(), self.code()) {
+            (Icmpv4Message::EchoRequest, 0) | (Icmpv4Message::EchoReply, 0) => {
                 ValidIcmpEcho::parse(self.rest_of_hdr_ref().as_slice())
                     .ok()
                     .map(|(v, ..)| v.id())

--- a/lib/opte/src/engine/icmp/v6.rs
+++ b/lib/opte/src/engine/icmp/v6.rs
@@ -646,8 +646,8 @@ impl HairpinAction for NeighborAdvertisement {
 impl<B: ByteSlice> QueryEcho for IcmpV6Packet<B> {
     #[inline]
     fn echo_id(&self) -> Option<u16> {
-        match (self.code(), self.ty()) {
-            (0, 128) | (0, 129) => {
+        match (self.ty().into(), self.code()) {
+            (Icmpv6Message::EchoRequest, 0) | (Icmpv6Message::EchoReply, 0) => {
                 ValidIcmpEcho::parse(&self.rest_of_hdr_ref()[..])
                     .ok()
                     .map(|(v, ..)| v.id())
@@ -660,8 +660,8 @@ impl<B: ByteSlice> QueryEcho for IcmpV6Packet<B> {
 impl<B: ByteSlice> QueryEcho for ValidIcmpV6<B> {
     #[inline]
     fn echo_id(&self) -> Option<u16> {
-        match (self.code(), self.ty()) {
-            (0, 128) | (0, 129) => {
+        match (self.ty().into(), self.code()) {
+            (Icmpv6Message::EchoRequest, 0) | (Icmpv6Message::EchoReply, 0) => {
                 ValidIcmpEcho::parse(&self.rest_of_hdr_ref()[..])
                     .ok()
                     .map(|(v, ..)| v.id())


### PR DESCRIPTION
Our SNAT layer has limited support for ICMP traffic, and is limited to using the identifier of Echo Request/Reply traffic as a form of pseudo-port. For other ICMP traffic, there is no comparable field and the packet must be dropped.

This PR changes how this is requested, from a `GenDescError` (ordinarily used for programming errors or resource exhaustion) into a standard drop. This is more appropriate given that guests are free to (attempt to) send these other ICMP variants at their leisure, including in response to an ibound frame on a recently closed port.

Closes #727.