### PR TITLE
Various MTU fixes.

### DIFF
--- a/lib/opte/src/ddi/mblk.rs
+++ b/lib/opte/src/ddi/mblk.rs
@@ -790,9 +790,10 @@ impl MsgBlk {
 
     /// Return the offloads currently requested by a packet.
     #[cfg_attr(any(feature = "std", test), allow(unused))]
-    pub fn offload_flags(&self) -> MblkOffloadFlags {
+    pub fn offload_flags(&self) -> MblkOffloadInfo {
         let mut cso_out = 0u32;
         let mut lso_out = 0u32;
+        let mut mss = 0u32;
 
         #[cfg(all(not(feature = "std"), not(test)))]
         unsafe {
@@ -806,13 +807,21 @@ impl MsgBlk {
             );
             illumos_sys_hdrs::mac::mac_lso_get(
                 self.0.as_ptr(),
-                ptr::null_mut(),
+                &raw mut mss,
                 &raw mut lso_out,
             );
         };
 
-        MblkOffloadFlags::from_bits_retain(cso_out | lso_out)
+        MblkOffloadInfo {
+            flags: MblkOffloadFlags::from_bits_retain(cso_out | lso_out),
+            mss,
+        }
     }
+}
+
+pub struct MblkOffloadInfo {
+    pub flags: MblkOffloadFlags,
+    pub mss: u32,
 }
 
 impl AsMblk for MsgBlk {

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -1775,7 +1775,7 @@ unsafe fn xde_mc_tx_one(src_dev: &XdeDev, mut pkt: MsgBlk) -> *mut mblk_t {
             // need to strip the flag to prevent a drop, in cases where we'd
             // ask to split a packet back into... 1 segment.
             // Hardware tends to handle this without issue.
-            if meoi_len.saturating_sub(
+            if ulp_meoi.meoi_len.saturating_sub(
                 non_eth_payl_bytes
                     + u32::try_from(Ethernet::MINIMUM_LENGTH)
                         .expect("14B < u32::MAX"),

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -1792,8 +1792,9 @@ unsafe fn xde_mc_tx_one(src_dev: &XdeDev, mut pkt: MsgBlk) -> *mut mblk_t {
             // ask to split a packet back into... 1 segment.
             // Hardware tends to handle this without issue.
             if meoi_len.saturating_sub(
-                u32::try_from(Ethernet::MINIMUM_LENGTH)
-                    .expect("14B < u32::MAX"),
+                non_eth_payl_bytes
+                    + u32::try_from(Ethernet::MINIMUM_LENGTH)
+                        .expect("14B < u32::MAX"),
             ) <= mss
             {
                 flags.remove(MblkOffloadFlags::HW_LSO);


### PR DESCRIPTION
First, we missed one branch in the overlay action for setting the `mtu_unrestricted` property on VPC-local packets. This ended up getting missed because the bench/xde-test runner set up the routing table differently to omicron.

Second, when we open up some limited ICMP families for Nexus (intending to support PMTUD), the illumos TCP stack will have its own (and better!) idea about what MSS is actually assigned to a flow. We now reuse this MSS when not explicitly boosting a flow into jumbo frame territory.

Closes #747.
Closes #748.