### PR TITLE
Use `Token`-based locking on XDE management operations

### DIFF
--- a/crates/illumos-sys-hdrs/src/kernel.rs
+++ b/crates/illumos-sys-hdrs/src/kernel.rs
@@ -612,7 +612,8 @@ unsafe extern "C" {
         res: time_res_t,
     ) -> clock_t;
 
-    pub fn _curthread() -> *mut kthread_t;
+    // Underlies the `curthread` macro in kernel.
+    pub fn threadp() -> *mut kthread_t;
 
     pub fn nochpoll() -> c_int;
     pub fn nodev() -> c_int;

--- a/crates/illumos-sys-hdrs/src/kernel.rs
+++ b/crates/illumos-sys-hdrs/src/kernel.rs
@@ -416,6 +416,8 @@ unsafe extern "C" {
 
     pub type queue_t; // Definitely not using STREAMS.
 
+    pub type kthread_t;
+
     // DDI/DKI 9F
     pub fn allocb(size: size_t, pri: c_uint) -> *mut mblk_t;
 
@@ -575,6 +577,42 @@ unsafe extern "C" {
     pub fn rw_downgrade(rwlp: *mut krwlock_t);
     pub fn rw_tryupgrade(rwlp: *mut krwlock_t);
     pub fn rw_read_locked(rwlp: *mut krwlock_t);
+
+    pub fn cv_init(
+        cvp: *mut kcondvar_t,
+        name: *const c_char,
+        cv_type: kcv_type_t,
+        arg: *mut c_void,
+    );
+    pub fn cv_destroy(cvp: *mut kcondvar_t);
+    pub fn cv_wait(cvp: *mut kcondvar_t, mp: *mut kmutex_t);
+    pub fn cv_signal(cvp: *mut kcondvar_t);
+    pub fn cv_broadcast(cvp: *mut kcondvar_t);
+    pub fn cv_wait_sig(cvp: *mut kcondvar_t, mp: *mut kmutex_t) -> c_int;
+    pub fn cv_timedwait(
+        cvp: *mut kcondvar_t,
+        mp: *mut kmutex_t,
+        timeout: clock_t,
+    ) -> clock_t;
+    pub fn cv_timedwait_sig(
+        cvp: *mut kcondvar_t,
+        mp: *mut kmutex_t,
+        timeout: clock_t,
+    ) -> clock_t;
+    pub fn cv_reltimedwait(
+        cvp: *mut kcondvar_t,
+        mp: *mut kmutex_t,
+        delta: clock_t,
+        res: time_res_t,
+    ) -> clock_t;
+    pub fn cv_reltimedwait_sig(
+        cvp: *mut kcondvar_t,
+        mp: *mut kmutex_t,
+        delta: clock_t,
+        res: time_res_t,
+    ) -> clock_t;
+
+    pub fn _curthread() -> *mut kthread_t;
 
     pub fn nochpoll() -> c_int;
     pub fn nodev() -> c_int;

--- a/crates/illumos-sys-hdrs/src/lib.rs
+++ b/crates/illumos-sys-hdrs/src/lib.rs
@@ -222,6 +222,35 @@ pub enum krw_type_t {
 }
 
 // ======================================================================
+// uts/common/sys/condvar.h
+// ======================================================================
+
+#[repr(C)]
+pub struct kcondvar_t {
+    pub _opaque: c_ushort,
+}
+
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct kcv_type_t(pub c_int);
+impl kcv_type_t {
+    pub const CV_DEFAULT: Self = Self(0);
+    pub const CV_DRIVER: Self = Self(1);
+}
+
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct time_res_t(pub c_int);
+impl time_res_t {
+    pub const TR_NANOSEC: Self = Self(0);
+    pub const TR_MICROSEC: Self = Self(1);
+    pub const TR_MILLISEC: Self = Self(2);
+    pub const TR_SEC: Self = Self(3);
+    pub const TR_CLOCK_TICK: Self = Self(4);
+    pub const TR_COUNT: Self = Self(5);
+}
+
+// ======================================================================
 // uts/common/sys/stream.h
 // ======================================================================
 
@@ -323,6 +352,7 @@ pub type hrtime_t = c_longlong;
 // ======================================================================
 // uts/common/sys/types.h
 // ======================================================================
+pub type clock_t = c_long;
 pub type datalink_id_t = uint32_t;
 pub type dev_t = c_ulong;
 pub type id_t = c_int;

--- a/lib/opte/src/ddi/sync.rs
+++ b/lib/opte/src/ddi/sync.rs
@@ -17,10 +17,10 @@ cfg_if! {
         use core::ptr;
         use core::ptr::NonNull;
         use illumos_sys_hdrs::{
-            _curthread, cv_broadcast, cv_destroy, cv_init, cv_signal, cv_wait,
+            cv_broadcast, cv_destroy, cv_init, cv_signal, cv_wait,
             kcv_type_t, kcondvar_t, kmutex_t, krw_t, krwlock_t, kthread_t,
             mutex_enter, mutex_exit, mutex_destroy, mutex_init, mutex_tryenter,
-            rw_enter, rw_exit, rw_init, rw_destroy
+            rw_enter, rw_exit, rw_init, rw_destroy, threadp
         };
     } else {
         use std::sync::Condvar;
@@ -540,7 +540,7 @@ impl<T> TokenLock<T> {
 
         #[cfg(all(not(feature = "std"), not(test)))]
         let curthread = unsafe {
-            NonNull::new(_curthread())
+            NonNull::new(threadp())
                 .expect("current thread *must* be a valid pointer")
         };
 

--- a/xde/src/mac/mod.rs
+++ b/xde/src/mac/mod.rs
@@ -67,6 +67,19 @@ impl MacHandle {
         Ok(Self(mh))
     }
 
+    /// Grab a handle to the mac provider for the given link.
+    pub fn open_by_link_id(
+        link: LinkId,
+    ) -> Result<Self, MacOpenError<'static>> {
+        let mut mh = ptr::null_mut();
+        let ret = unsafe { mac_open_by_linkid(link.into(), &mut mh) };
+        if ret != 0 {
+            return Err(MacOpenError::OpenFailed("<unknown>", ret));
+        }
+
+        Ok(Self(mh))
+    }
+
     /// Get the primary MAC address associated with this device.
     pub fn get_mac_addr(&self) -> [u8; 6] {
         let mut mac = [0u8; 6];

--- a/xde/src/mac/sys.rs
+++ b/xde/src/mac/sys.rs
@@ -117,6 +117,10 @@ unsafe extern "C" {
         link: *const c_char,
         mhp: *mut *mut mac_handle,
     ) -> c_int;
+    pub fn mac_open_by_linkid(
+        link: datalink_id_t,
+        mhp: *mut *mut mac_handle,
+    ) -> c_int;
     pub fn mac_promisc_add(
         mch: *const mac_client_handle,
         ptype: mac_client_promisc_type_t,


### PR DESCRIPTION
This PR introduces a `TokenLock` type, which allows for a single thread to be in a critical section without actively holding a `KMutex` or a write on a `KRwLock`. This is used to ensure that we have at most one active ioctl handler performing management operations. Previously, we relied upon write locks to the `underlay` and `xde_devs` to enforce this constraint.

Underlay installation, port creation, and port destruction have been restructured to rely on the `TokenLock` as the main means of mutual exclusion, and then to access other locked resources (which may be shared with the datapath) more granularly. This allows us to ensure that any calls to DLS (link name resolution, device creation) are made without inappropriately holding any lock, but are still appropriately atomic with respect to one another.

Fixes #758.