### PR TITLE
Catchup on nightly clippy lints

### DIFF
--- a/crates/illumos-sys-hdrs/src/lib.rs
+++ b/crates/illumos-sys-hdrs/src/lib.rs
@@ -281,6 +281,7 @@ pub struct dblk_t {
     pub db_meoi: [u8; 16], // imprecise
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for dblk_t {
     fn default() -> Self {
         dblk_t {

--- a/crates/opte-api/src/cmd.rs
+++ b/crates/opte-api/src/cmd.rs
@@ -11,6 +11,7 @@ use super::encap::Vni;
 use super::ip::IpCidr;
 use super::mac::MacAddr;
 use alloc::string::String;
+use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::fmt::Debug;
 use illumos_sys_hdrs::c_int;
@@ -130,7 +131,7 @@ impl OpteCmdIoctl {
             match postcard::from_bytes(resp) {
                 Ok(cmd_err) => Some(cmd_err),
                 Err(deser_err) => {
-                    Some(OpteError::DeserCmdErr(format!("{}", deser_err)))
+                    Some(OpteError::DeserCmdErr(deser_err.to_string()))
                 }
             }
         } else {

--- a/crates/opte-api/src/ip.rs
+++ b/crates/opte-api/src/ip.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use super::mac::MacAddr;
 use crate::DomainName;
@@ -348,8 +348,8 @@ impl Default for IpAddr {
 impl fmt::Display for IpAddr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            IpAddr::Ip4(ip4) => write!(f, "{}", ip4),
-            IpAddr::Ip6(ip6) => write!(f, "{}", ip6),
+            IpAddr::Ip4(ip4) => write!(f, "{ip4}"),
+            IpAddr::Ip6(ip6) => write!(f, "{ip6}"),
         }
     }
 }
@@ -402,7 +402,7 @@ impl Ipv4Addr {
     /// Return the address after applying the network mask.
     pub fn mask(mut self, mask: u8) -> Result<Self, String> {
         if mask > 32 {
-            return Err(format!("bad mask: {}", mask));
+            return Err(format!("bad mask: {mask}"));
         }
 
         if mask == 0 {
@@ -482,11 +482,11 @@ impl FromStr for Ipv4Addr {
     fn from_str(val: &str) -> result::Result<Self, Self::Err> {
         let octets: Vec<u8> = val
             .split('.')
-            .map(|s| s.parse().map_err(|e| format!("{}", e)))
+            .map(|s| s.parse().map_err(|e| format!("{e}")))
             .collect::<result::Result<Vec<u8>, _>>()?;
 
         if octets.len() != 4 {
-            return Err(format!("malformed ip: {}", val));
+            return Err(format!("malformed ip: {val}"));
         }
 
         // At the time of writing there is no TryFrom impl for Vec to
@@ -510,7 +510,7 @@ impl Display for Ipv4Addr {
 // present it in a human-friendly manner.
 impl Debug for Ipv4Addr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Ipv4Addr {{ inner: {} }}", self)
+        write!(f, "Ipv4Addr {{ inner: {self} }}")
     }
 }
 
@@ -648,7 +648,7 @@ impl Ipv6Addr {
     /// Return the address after applying the network mask.
     pub fn mask(mut self, mask: u8) -> Result<Self, String> {
         if mask > 128 {
-            return Err(format!("bad mask: {}", mask));
+            return Err(format!("bad mask: {mask}"));
         }
 
         if mask == 128 {
@@ -708,7 +708,7 @@ impl Ipv6Addr {
 impl fmt::Display for Ipv6Addr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let sip6 = smoltcp::wire::Ipv6Address(self.bytes());
-        write!(f, "{}", sip6)
+        write!(f, "{sip6}")
     }
 }
 
@@ -853,8 +853,8 @@ impl IpCidr {
 impl fmt::Display for IpCidr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Ip4(ip4) => write!(f, "{}", ip4),
-            Self::Ip6(ip6) => write!(f, "{}", ip6),
+            Self::Ip4(ip4) => write!(f, "{ip4}"),
+            Self::Ip6(ip6) => write!(f, "{ip6}"),
         }
     }
 }
@@ -914,7 +914,7 @@ impl Ipv4PrefixLen {
 
     pub fn new(prefix_len: u8) -> Result<Self, String> {
         if prefix_len > 32 {
-            return Err(format!("bad IPv4 prefix length: {}", prefix_len));
+            return Err(format!("bad IPv4 prefix length: {prefix_len}"));
         }
 
         Ok(Self(prefix_len))
@@ -967,13 +967,13 @@ impl FromStr for Ipv4Cidr {
 
         let ip = match ip_s.parse() {
             Ok(v) => v,
-            Err(e) => return Err(format!("bad IP: {}", e)),
+            Err(e) => return Err(format!("bad IP: {e}")),
         };
 
         let raw = match prefix_s.parse::<u8>() {
             Ok(v) => v,
             Err(e) => {
-                return Err(format!("bad prefix length: {}", e));
+                return Err(format!("bad prefix length: {e}"));
             }
         };
 
@@ -1076,7 +1076,7 @@ impl core::cmp::PartialOrd for Ipv6Cidr {
 impl fmt::Display for Ipv6Cidr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (ip, prefix_len) = self.parts();
-        write!(f, "{}/{}", ip, prefix_len.val())
+        write!(f, "{ip}/{}", prefix_len.val())
     }
 }
 
@@ -1093,14 +1093,14 @@ impl FromStr for Ipv6Cidr {
         let ip = match ip_s.parse::<smoltcp::wire::Ipv6Address>() {
             Ok(v) => v.into(),
             Err(_) => {
-                return Err(format!("Bad IP address component: '{}'", ip_s));
+                return Err(format!("Bad IP address component: '{ip_s}'"));
             }
         };
 
         let prefix_len = match prefix_s.parse::<u8>() {
             Ok(v) => v,
             Err(e) => {
-                return Err(format!("bad prefix length: {}", e));
+                return Err(format!("bad prefix length: {e}"));
             }
         };
 
@@ -1128,7 +1128,7 @@ impl Ipv6PrefixLen {
 
     pub fn new(prefix_len: u8) -> result::Result<Self, String> {
         if prefix_len > 128 {
-            return Err(format!("bad IPv6 prefix length: {}", prefix_len));
+            return Err(format!("bad IPv6 prefix length: {prefix_len}"));
         }
 
         Ok(Self(prefix_len))

--- a/crates/opte-api/src/lib.rs
+++ b/crates/opte-api/src/lib.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 #![no_std]
 #![deny(unreachable_patterns)]
@@ -69,7 +69,7 @@ impl core::str::FromStr for Direction {
         match s.to_ascii_lowercase().as_str() {
             "in" => Ok(Direction::In),
             "out" => Ok(Direction::Out),
-            _ => Err(format!("invalid direction: {}", s)),
+            _ => Err(format!("invalid direction: {s}")),
         }
     }
 }
@@ -81,7 +81,7 @@ impl Display for Direction {
             Direction::Out => "OUT",
         };
 
-        write!(f, "{}", dirstr)
+        write!(f, "{dirstr}")
     }
 }
 

--- a/crates/opte-api/src/mac.rs
+++ b/crates/opte-api/src/mac.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use alloc::str::FromStr;
 use alloc::string::String;
@@ -95,8 +95,7 @@ impl FromStr for MacAddr {
         let octets: Vec<u8> = s
             .split(':')
             .map(|s| {
-                u8::from_str_radix(s, 16)
-                    .map_err(|_| format!("bad octet: {}", s))
+                u8::from_str_radix(s, 16).map_err(|_| format!("bad octet: {s}"))
             })
             .collect::<Result<Vec<u8>, _>>()?;
 
@@ -133,6 +132,6 @@ impl Display for MacAddr {
 // present it in a human-friendly manner.
 impl Debug for MacAddr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "MacAddr {{ inner: {} }}", self)
+        write!(f, "MacAddr {{ inner: {self} }}")
     }
 }

--- a/crates/opte-api/src/tcp.rs
+++ b/crates/opte-api/src/tcp.rs
@@ -40,6 +40,6 @@ impl Display for TcpState {
             TcpState::FinWait2 => "FIN_WAIT_2",
             TcpState::TimeWait => "TIME_WAIT",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }

--- a/lib/opte-ioctl/src/lib.rs
+++ b/lib/opte-ioctl/src/lib.rs
@@ -466,7 +466,7 @@ where
                 libc::EPERM => "permission denied".to_string(),
 
                 errno => {
-                    format!("unexpected errno: {}", errno)
+                    format!("unexpected errno: {errno}")
                 }
             };
 

--- a/lib/opte-test-utils/src/pcap.rs
+++ b/lib/opte-test-utils/src/pcap.rs
@@ -19,7 +19,7 @@ use std::io::Write;
 fn get_header(offset: &[u8]) -> (&[u8], PcapHeader) {
     match pcap::parse_pcap_header(offset) {
         Ok((new_offset, header)) => (new_offset, header),
-        Err(e) => panic!("failed to get header: {:?}", e),
+        Err(e) => panic!("failed to get header: {e:?}"),
     }
 }
 
@@ -32,7 +32,7 @@ fn next_block(offset: &[u8]) -> (&[u8], LegacyPcapBlock) {
             (new_offset, block)
         }
 
-        Err(e) => panic!("failed to get next block: {:?}", e),
+        Err(e) => panic!("failed to get next block: {e:?}"),
     }
 }
 

--- a/lib/opte/src/ddi/kstat.rs
+++ b/lib/opte/src/ddi/kstat.rs
@@ -292,7 +292,7 @@ impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::NameTooLong(name) => {
-                write!(f, "kstat name too long: {}", name)
+                write!(f, "kstat name too long: {name}")
             }
 
             Self::NulChar => write!(f, "kstat name contains NUL char"),

--- a/lib/opte/src/engine/arp.rs
+++ b/lib/opte/src/engine/arp.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 //! ARP headers and data.
 
@@ -54,7 +54,7 @@ impl Display for ArpOp {
             ArpOp::REPLY => "Reply",
             _ => "Unknown",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/lib/opte/src/engine/dhcp.rs
+++ b/lib/opte/src/engine/dhcp.rs
@@ -167,9 +167,9 @@ impl Display for MessageType {
             Nak => "Nak".to_string(),
             Release => "Release".to_string(),
             Inform => "Inform".to_string(),
-            Unknown(val) => format!("Unknown: {}", val),
+            Unknown(val) => format!("Unknown: {val}"),
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/lib/opte/src/engine/dhcpv6/mod.rs
+++ b/lib/opte/src/engine/dhcpv6/mod.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 //! Core implementation of DHCPv6 protocol.
 //!
@@ -75,6 +75,7 @@ pub mod protocol;
 pub use protocol::MessageType;
 
 use alloc::borrow::Cow;
+use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::fmt;
 use core::fmt::Display;
@@ -161,10 +162,10 @@ impl Display for Dhcpv6Action {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let addr_list = self
             .addresses()
-            .map(|addr| format!("{}", addr))
+            .map(|addr| addr.to_string())
             .collect::<Vec<_>>()
             .join(",");
-        write!(f, "DHCPv6 IA Addrs: [{}]", addr_list)
+        write!(f, "DHCPv6 IA Addrs: [{addr_list}]")
     }
 }
 

--- a/lib/opte/src/engine/dhcpv6/protocol.rs
+++ b/lib/opte/src/engine/dhcpv6/protocol.rs
@@ -66,7 +66,7 @@ impl fmt::Display for MessageType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use MessageType::*;
         match self {
-            Other(x) => write!(f, "Other({})", x),
+            Other(x) => write!(f, "Other({x})"),
             other => write!(
                 f,
                 "{}",

--- a/lib/opte/src/engine/ether.rs
+++ b/lib/opte/src/engine/ether.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 //! Ethernet frames.
 
@@ -101,7 +101,7 @@ impl Display for EtherType {
 /// [`EtherType`].
 impl Debug for EtherType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 
@@ -149,8 +149,7 @@ impl FromStr for EtherAddr {
         let octets: Vec<u8> = val
             .split(':')
             .map(|s| {
-                u8::from_str_radix(s, 16)
-                    .map_err(|_| format!("bad octet: {}", s))
+                u8::from_str_radix(s, 16).map_err(|_| format!("bad octet: {s}"))
             })
             .collect::<result::Result<Vec<u8>, _>>()?;
 
@@ -193,7 +192,7 @@ impl Display for EtherAddr {
 /// EtherAddr.
 impl Debug for EtherAddr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/lib/opte/src/engine/headers.rs
+++ b/lib/opte/src/engine/headers.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 //! Header metadata modifications for IP, ULP, and Encap.
 
@@ -260,8 +260,7 @@ impl HeaderLen for EncapMeta {
     fn packet_length(&self) -> usize {
         match self {
             EncapMeta::Geneve(g) => {
-                Self::MINIMUM_LENGTH
-                    + g.oxide_external_pkt.then_some(4).unwrap_or_default()
+                Self::MINIMUM_LENGTH + if g.oxide_external_pkt { 4 } else { 0 }
             }
         }
     }

--- a/lib/opte/src/engine/icmp/v4.rs
+++ b/lib/opte/src/engine/icmp/v4.rs
@@ -58,8 +58,7 @@ impl HairpinAction for IcmpEchoReply {
             // should be impossible, but we avoid panicking given the kernel
             // context.
             return Err(GenErr::Unexpected(format!(
-                "Expected ICMP packet metadata, but found: {:?}",
-                meta
+                "Expected ICMP packet metadata, but found: {meta:?}",
             )));
         };
 
@@ -76,8 +75,7 @@ impl HairpinAction for IcmpEchoReply {
                 // Echo Request. However, programming error could
                 // cause this to happen -- let's not take any chances.
                 return Err(GenErr::Unexpected(format!(
-                    "expected an ICMPv4 Echo Request, got {} {}",
-                    ty, code,
+                    "expected an ICMPv4 Echo Request, got {ty} {code}",
                 )));
             }
         };

--- a/lib/opte/src/engine/icmp/v6.rs
+++ b/lib/opte/src/engine/icmp/v6.rs
@@ -117,8 +117,7 @@ impl HairpinAction for Icmpv6EchoReply {
             // should be impossible, but we avoid panicking given the kernel
             // context.
             return Err(GenErr::Unexpected(format!(
-                "Expected ICMPv6 packet metadata, but found: {:?}",
-                meta
+                "Expected ICMPv6 packet metadata, but found: {meta:?}",
             )));
         };
 
@@ -135,8 +134,7 @@ impl HairpinAction for Icmpv6EchoReply {
                 // Echo Request. However, programming error could
                 // cause this to happen -- let's not take any chances.
                 return Err(GenErr::Unexpected(format!(
-                    "expected an ICMPv6 Echo Request, got {} {}",
-                    ty, code,
+                    "expected an ICMPv6 Echo Request, got {ty} {code}",
                 )));
             }
         };
@@ -250,8 +248,7 @@ impl HairpinAction for RouterAdvertisement {
             // should be impossible, but we avoid panicking given the kernel
             // context.
             return Err(GenErr::Unexpected(format!(
-                "Expected ICMPv6 packet metadata, but found: {:?}",
-                meta
+                "Expected ICMPv6 packet metadata, but found: {meta:?}",
             )));
         };
 
@@ -260,8 +257,7 @@ impl HairpinAction for RouterAdvertisement {
         let Some(ip6) = meta.inner_ip6() else {
             // We got the ICMPv6 metadata above but no IPv6 somehow?
             return Err(GenErr::Unexpected(format!(
-                "Expected IPv6 packet metadata, but found: {:?}",
-                meta
+                "Expected IPv6 packet metadata, but found: {meta:?}",
             )));
         };
         let src_ip = IpAddress::Ipv6(Ipv6Address(ip6.source().bytes()));
@@ -570,8 +566,7 @@ impl HairpinAction for NeighborAdvertisement {
             // should be impossible, but we avoid panicking given the kernel
             // context.
             return Err(GenErr::Unexpected(format!(
-                "Expected ICMPv6 packet metadata, but found: {:?}",
-                meta
+                "Expected ICMPv6 packet metadata, but found: {meta:?}",
             )));
         };
 
@@ -579,8 +574,7 @@ impl HairpinAction for NeighborAdvertisement {
         let metadata = meta.inner_ip6().ok_or_else(|| {
             // We got the ICMPv6 metadata above but no IPv6 somehow?
             GenErr::Unexpected(format!(
-                "Expected IPv6 packet metadata, but found: {:?}",
-                meta
+                "Expected IPv6 packet metadata, but found: {meta:?}",
             ))
         })?;
 

--- a/lib/opte/src/engine/packet.rs
+++ b/lib/opte/src/engine/packet.rs
@@ -127,7 +127,7 @@ pub enum BodyTransformError {
 
 impl From<smoltcp::wire::Error> for BodyTransformError {
     fn from(e: smoltcp::wire::Error) -> Self {
-        Self::ParseFailure(format!("{}", e))
+        Self::ParseFailure(format!("{e}"))
     }
 }
 

--- a/lib/opte/src/engine/port/mod.rs
+++ b/lib/opte/src/engine/port/mod.rs
@@ -248,7 +248,7 @@ impl From<kstat::Error> for PortCreateError {
 impl Display for PortCreateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::InitStats(e) => write!(f, "{}", e),
+            Self::InitStats(e) => write!(f, "{e}"),
         }
     }
 }
@@ -304,7 +304,7 @@ impl PortBuilder {
 
         Err(OpteError::BadLayerPos {
             layer: new_layer.name().to_string(),
-            pos: format!("{:?}", pos),
+            pos: format!("{pos:?}"),
         })
     }
 
@@ -506,7 +506,7 @@ impl Display for PortState {
             Paused => "paused",
             Restored => "restored",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -2064,7 +2064,7 @@ impl<N: NetworkImpl> Port<N> {
                     ),
                     Ok(v) => (LabelBlock::from_nested(v), None),
                     // TODO: Handle the error types in a zero-cost way.
-                    Err(e) => (Ok(LabelBlock::new()), Some(format!("ERROR: {:?}\0", e))),
+                    Err(e) => (Ok(LabelBlock::new()), Some(format!("ERROR: {e:?}\0"))),
                 };
 
                 // Truncation is captured *in* the LabelBlock.
@@ -2106,8 +2106,8 @@ impl<N: NetworkImpl> Port<N> {
                 let flow_b_s = flow_before.to_string();
                 let flow_a_s = flow_after.to_string();
                 let res_str = match res {
-                    Ok(v) => format!("{:?}", v),
-                    Err(e) => format!("ERROR: {:?}", e),
+                    Ok(v) => format!("{v:?}"),
+                    Err(e) => format!("ERROR: {e:?}"),
                 };
                 let _ = path;
 
@@ -2818,7 +2818,7 @@ impl<N: NetworkImpl> Port<N> {
                     }
                 }
 
-                panic!("layer not found: {}", name);
+                panic!("layer not found: {name}");
             }
         }
     }
@@ -2831,7 +2831,7 @@ impl<N: NetworkImpl> Port<N> {
             .iter()
             .find(|layer| layer.name() == layer_name)
             .map(|layer| layer.num_rules(dir))
-            .unwrap_or_else(|| panic!("layer not found: {}", layer_name))
+            .unwrap_or_else(|| panic!("layer not found: {layer_name}"))
     }
 }
 
@@ -2975,7 +2975,7 @@ impl Display for TcpFlowEntryStateInner {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.inbound_ufid {
             None => write!(f, "None {}", self.tcp_state),
-            Some(ufid) => write!(f, "{} {}", ufid, self.tcp_state),
+            Some(ufid) => write!(f, "{ufid} {}", self.tcp_state),
         }
     }
 }

--- a/lib/opte/src/engine/predicate.rs
+++ b/lib/opte/src/engine/predicate.rs
@@ -89,7 +89,7 @@ impl Display for EtherTypeMatch {
             Exact(et) if *et == ETHER_TYPE_IPV4 => write!(f, "IPv4"),
             Exact(et) if *et == ETHER_TYPE_IPV6 => write!(f, "IPv6"),
 
-            Exact(et) => write!(f, "0x{:X}", et),
+            Exact(et) => write!(f, "0x{et:X}"),
         }
     }
 }
@@ -112,7 +112,7 @@ impl Display for EtherAddrMatch {
         use EtherAddrMatch::*;
 
         match self {
-            Exact(addr) => write!(f, "{}", addr),
+            Exact(addr) => write!(f, "{addr}"),
         }
     }
 }
@@ -140,8 +140,8 @@ impl Display for Ipv4AddrMatch {
         use Ipv4AddrMatch::*;
 
         match self {
-            Exact(ip) => write!(f, "{}", ip),
-            Prefix(cidr) => write!(f, "{}", cidr),
+            Exact(ip) => write!(f, "{ip}"),
+            Prefix(cidr) => write!(f, "{cidr}"),
         }
     }
 }
@@ -169,8 +169,8 @@ impl Display for Ipv6AddrMatch {
         use Ipv6AddrMatch::*;
 
         match self {
-            Exact(ip) => write!(f, "{}", ip),
-            Prefix(cidr) => write!(f, "{}", cidr),
+            Exact(ip) => write!(f, "{ip}"),
+            Prefix(cidr) => write!(f, "{cidr}"),
         }
     }
 }
@@ -193,7 +193,7 @@ impl Display for IpProtoMatch {
         use IpProtoMatch::*;
 
         match self {
-            Exact(proto) => write!(f, "{}", proto),
+            Exact(proto) => write!(f, "{proto}"),
         }
     }
 }
@@ -584,8 +584,7 @@ impl Display for DataPredicate {
             }
 
             Not(pred) => {
-                write!(f, "!")?;
-                Display::fmt(&pred, f)
+                write!(f, "!{pred}")
             }
         }
     }

--- a/lib/opte/src/engine/predicate.rs
+++ b/lib/opte/src/engine/predicate.rs
@@ -224,7 +224,7 @@ impl Display for PortMatch {
         use PortMatch::*;
 
         match self {
-            Exact(port) => write!(f, "{}", port),
+            Exact(port) => write!(f, "{port}"),
         }
     }
 }
@@ -256,7 +256,7 @@ impl Display for Predicate {
                     .map(|v| v.to_string())
                     .collect::<Vec<String>>()
                     .join(",");
-                write!(f, "inner.ether.ether_type={}", s)
+                write!(f, "inner.ether.ether_type={s}")
             }
 
             InnerEtherDst(list) => {
@@ -265,7 +265,7 @@ impl Display for Predicate {
                     .map(|v| v.to_string())
                     .collect::<Vec<String>>()
                     .join(",");
-                write!(f, "inner.ether.dst={}", s)
+                write!(f, "inner.ether.dst={s}")
             }
 
             InnerEtherSrc(list) => {
@@ -274,7 +274,7 @@ impl Display for Predicate {
                     .map(|v| v.to_string())
                     .collect::<Vec<String>>()
                     .join(",");
-                write!(f, "inner.ether.src={}", s)
+                write!(f, "inner.ether.src={s}")
             }
 
             InnerIpProto(list) => {
@@ -283,7 +283,7 @@ impl Display for Predicate {
                     .map(|v| v.to_string())
                     .collect::<Vec<String>>()
                     .join(",");
-                write!(f, "inner.ip.proto={}", s)
+                write!(f, "inner.ip.proto={s}")
             }
 
             InnerSrcIp4(list) => {
@@ -292,7 +292,7 @@ impl Display for Predicate {
                     .map(|v| v.to_string())
                     .collect::<Vec<String>>()
                     .join(",");
-                write!(f, "inner.ip.src={}", s)
+                write!(f, "inner.ip.src={s}")
             }
 
             InnerDstIp4(list) => {
@@ -301,7 +301,7 @@ impl Display for Predicate {
                     .map(|v| v.to_string())
                     .collect::<Vec<String>>()
                     .join(",");
-                write!(f, "inner.ip.dst={}", s)
+                write!(f, "inner.ip.dst={s}")
             }
 
             InnerSrcIp6(list) => {
@@ -310,7 +310,7 @@ impl Display for Predicate {
                     .map(|v| v.to_string())
                     .collect::<Vec<String>>()
                     .join(",");
-                write!(f, "inner.ip6.src={}", s)
+                write!(f, "inner.ip6.src={s}")
             }
 
             InnerDstIp6(list) => {
@@ -319,7 +319,7 @@ impl Display for Predicate {
                     .map(|v| v.to_string())
                     .collect::<Vec<String>>()
                     .join(",");
-                write!(f, "inner.ip6.dst={}", s)
+                write!(f, "inner.ip6.dst={s}")
             }
 
             InnerSrcPort(list) => {
@@ -328,7 +328,7 @@ impl Display for Predicate {
                     .map(|v| v.to_string())
                     .collect::<Vec<String>>()
                     .join(",");
-                write!(f, "inner.ulp.src={}", s)
+                write!(f, "inner.ulp.src={s}")
             }
 
             InnerDstPort(list) => {
@@ -337,11 +337,11 @@ impl Display for Predicate {
                     .map(|v| v.to_string())
                     .collect::<Vec<String>>()
                     .join(",");
-                write!(f, "inner.ulp.dst={}", s)
+                write!(f, "inner.ulp.dst={s}")
             }
 
             Meta(key, val) => {
-                write!(f, "meta: {}={}", key, val)
+                write!(f, "meta: {key}={val}")
             }
 
             Not(pred) => {

--- a/lib/opte/src/engine/rule.rs
+++ b/lib/opte/src/engine/rule.rs
@@ -781,7 +781,7 @@ pub enum GenBtError {
 
 impl From<smoltcp::wire::Error> for GenBtError {
     fn from(e: smoltcp::wire::Error) -> Self {
-        Self::ParseBody(format!("{}", e))
+        Self::ParseBody(format!("{e}"))
     }
 }
 
@@ -916,10 +916,10 @@ impl fmt::Display for Action {
             Self::StatefulAllow => write!(f, "Stateful Allow"),
             Self::Deny => write!(f, "Deny"),
             Self::HandlePacket => write!(f, "Handle Packet"),
-            Self::Meta(a) => write!(f, "Meta: {}", a),
-            Self::Static(a) => write!(f, "Static: {}", a),
-            Self::Stateful(a) => write!(f, "Stateful: {}", a),
-            Self::Hairpin(a) => write!(f, "Hairpin: {}", a),
+            Self::Meta(a) => write!(f, "Meta: {a}"),
+            Self::Static(a) => write!(f, "Static: {a}"),
+            Self::Stateful(a) => write!(f, "Stateful: {a}"),
+            Self::Hairpin(a) => write!(f, "Hairpin: {a}"),
         }
     }
 }

--- a/lib/opte/src/engine/snat.rs
+++ b/lib/opte/src/engine/snat.rs
@@ -285,14 +285,14 @@ impl Display for SNat<Ipv4Addr> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Here and below: all ULP-specific pools have the same SNAT mappings.
         let (pub_ip, ports) = self.tcp_pool.mapping(self.priv_ip).unwrap();
-        write!(f, "{}:{}-{}", pub_ip, ports.start(), ports.end())
+        write!(f, "{pub_ip}:{}-{}", ports.start(), ports.end())
     }
 }
 
 impl Display for SNat<Ipv6Addr> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (pub_ip, ports) = self.tcp_pool.mapping(self.priv_ip).unwrap();
-        write!(f, "[{}]:{}-{}", pub_ip, ports.start(), ports.end())
+        write!(f, "[{pub_ip}]:{}-{}", ports.start(), ports.end())
     }
 }
 
@@ -315,7 +315,7 @@ where
             _ if is_icmp => &self.icmp_pool,
             proto => {
                 return Err(GenDescError::Unexpected {
-                    msg: format!("SNAT pool (unexpected ULP: {})", proto),
+                    msg: format!("SNAT pool (unexpected ULP: {proto})"),
                 });
             }
         };
@@ -337,7 +337,7 @@ where
             }
 
             Err(ResourceError::NoMatch(ip)) => Err(GenDescError::Unexpected {
-                msg: format!("SNAT pool (no match: {})", ip),
+                msg: format!("SNAT pool (no match: {ip})"),
             }),
         }
     }

--- a/lib/opte/src/engine/snat.rs
+++ b/lib/opte/src/engine/snat.rs
@@ -178,7 +178,7 @@ impl<T: ConcreteIpAddr> FiniteResource for NatPool<T> {
             }
 
             None => {
-                panic!("cannot release port to unknown mapping: {}", priv_ip);
+                panic!("cannot release port to unknown mapping: {priv_ip}");
             }
         }
     }

--- a/lib/opte/src/engine/tcp_state.rs
+++ b/lib/opte/src/engine/tcp_state.rs
@@ -58,18 +58,16 @@ impl fmt::Display for TcpFlowStateError {
                 write!(
                     f,
                     "Unexpected TCP segment, \
-                    direction: {}, flow: {}, state: {}, \
-                    flags: 0x{:x}",
-                    direction, flow_id, state, flags,
+                    direction: {direction}, flow: {flow_id}, \
+                    state: {state}, flags: 0x{flags:x}",
                 )
             }
             TcpFlowStateError::NewFlow { direction, flow_id, state, flags } => {
                 write!(
                     f,
                     "Flow was reopened early by endpoint, \
-                    direction: {}, flow: {}, state: {}, \
-                    flags: 0x{:x}",
-                    direction, flow_id, state, flags,
+                    direction: {direction}, flow: {flow_id}, \
+                    state: {state}, flags: 0x{flags:x}",
                 )
             }
         }

--- a/lib/opte/src/lib.rs
+++ b/lib/opte/src/lib.rs
@@ -219,7 +219,7 @@ impl Display for LogLevel {
             Self::Warn => "[WARN]",
             Self::Error => "[ERROR]",
         };
-        write!(f, "{}", level_s)
+        write!(f, "{level_s}")
     }
 }
 
@@ -230,7 +230,7 @@ pub struct PrintlnLog {}
 #[cfg(any(feature = "std", test))]
 impl LogProvider for PrintlnLog {
     fn log(&self, level: LogLevel, msg: &str) {
-        println!("{} {}", level, msg);
+        println!("{level} {msg}");
     }
 }
 

--- a/lib/oxide-vpc/src/api.rs
+++ b/lib/oxide-vpc/src/api.rs
@@ -385,7 +385,7 @@ impl FromStr for RouterTarget {
                 Some(("ip4", ip4s)) => {
                     let ip4 = ip4s
                         .parse::<std::net::Ipv4Addr>()
-                        .map_err(|e| format!("bad IP: {}", e))?;
+                        .map_err(|e| format!("bad IP: {e}"))?;
                     Ok(Self::Ip(IpAddr::Ip4(ip4.into())))
                 }
 
@@ -406,7 +406,7 @@ impl FromStr for RouterTarget {
                     uuid.parse::<Uuid>().map_err(|e| e.to_string())?,
                 ))),
 
-                _ => Err(format!("malformed router target: {}", lower)),
+                _ => Err(format!("malformed router target: {lower}")),
             },
         }
     }
@@ -417,11 +417,11 @@ impl Display for RouterTarget {
         match self {
             Self::Drop => write!(f, "Drop"),
             Self::InternetGateway(None) => write!(f, "ig"),
-            Self::InternetGateway(Some(id)) => write!(f, "ig={}", id),
-            Self::Ip(IpAddr::Ip4(ip4)) => write!(f, "ip4={}", ip4),
-            Self::Ip(IpAddr::Ip6(ip6)) => write!(f, "ip6={}", ip6),
-            Self::VpcSubnet(IpCidr::Ip4(sub4)) => write!(f, "sub4={}", sub4),
-            Self::VpcSubnet(IpCidr::Ip6(sub6)) => write!(f, "sub6={}", sub6),
+            Self::InternetGateway(Some(id)) => write!(f, "ig={id}"),
+            Self::Ip(IpAddr::Ip4(ip4)) => write!(f, "ip4={ip4}"),
+            Self::Ip(IpAddr::Ip6(ip6)) => write!(f, "ip6={ip6}"),
+            Self::VpcSubnet(IpCidr::Ip4(sub4)) => write!(f, "sub4={sub4}"),
+            Self::VpcSubnet(IpCidr::Ip6(sub6)) => write!(f, "sub6={sub6}"),
         }
     }
 }
@@ -655,7 +655,7 @@ impl FromStr for FirewallRule {
         for token in s.to_ascii_lowercase().split(' ') {
             match token.split_once('=') {
                 None => {
-                    return Err(format!("bad token: {}", token));
+                    return Err(format!("bad token: {token}"));
                 }
 
                 Some(("dir", val)) => {
@@ -667,9 +667,10 @@ impl FromStr for FirewallRule {
                 }
 
                 Some(("priority", val)) => {
-                    priority = Some(val.parse::<u16>().map_err(|e| {
-                        format!("bad priroity: '{}' {}", val, e)
-                    })?);
+                    priority =
+                        Some(val.parse::<u16>().map_err(|e| {
+                            format!("bad priroity: '{val}' {e}")
+                        })?);
                 }
 
                 // Parse the filters.
@@ -687,7 +688,7 @@ impl FromStr for FirewallRule {
                 }
 
                 Some((_, _)) => {
-                    return Err(format!("invalid key: {}", token));
+                    return Err(format!("invalid key: {token}"));
                 }
             }
         }
@@ -733,7 +734,7 @@ impl FromStr for FirewallAction {
         match s.to_ascii_lowercase().as_str() {
             "allow" => Ok(FirewallAction::Allow),
             "deny" => Ok(FirewallAction::Deny),
-            _ => Err(format!("invalid action: {} ('allow' or 'deny')", s)),
+            _ => Err(format!("invalid action: {s} ('allow' or 'deny')")),
         }
     }
 }
@@ -831,16 +832,15 @@ impl FromStr for Address {
             "any" => Ok(Address::Any),
 
             addrstr => match addrstr.split_once('=') {
-                None => Err(format!(
-                    "malformed address specification: {}",
-                    addrstr,
-                )),
+                None => {
+                    Err(format!("malformed address specification: {addrstr}",))
+                }
                 Some(("ip", val)) => Ok(Address::Ip(val.parse()?)),
                 Some(("subnet", val)) => Ok(Address::Subnet(val.parse()?)),
                 Some(("vni", val)) => {
                     Ok(Address::Vni(val.parse().map_err(|e| format!("{e:?}"))?))
                 }
-                Some((key, _)) => Err(format!("invalid address type: {}", key)),
+                Some((key, _)) => Err(format!("invalid address type: {key}")),
             },
         }
     }
@@ -850,9 +850,9 @@ impl Display for Address {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Address::Any => write!(f, "ANY"),
-            Address::Ip(val) => write!(f, "{},", val),
-            Address::Subnet(val) => write!(f, "{},", val),
-            Address::Vni(val) => write!(f, "{}", val),
+            Address::Ip(val) => write!(f, "{val},"),
+            Address::Subnet(val) => write!(f, "{val},"),
+            Address::Vni(val) => write!(f, "{val}"),
         }
     }
 }
@@ -915,12 +915,12 @@ impl FromStr for Ports {
                     .collect::<result::Result<Vec<u16>, _>>()?;
 
                 if ports.is_empty() {
-                    return Err(format!("malformed ports spec: {}", s));
+                    return Err(format!("malformed ports spec: {s}"));
                 }
 
                 for p in ports.iter() {
                     if *p == DYNAMIC_PORT {
-                        return Err(format!("invalid port: {}", p));
+                        return Err(format!("invalid port: {p}"));
                     }
                 }
                 Ok(Ports::PortList(ports))

--- a/lib/oxide-vpc/src/api.rs
+++ b/lib/oxide-vpc/src/api.rs
@@ -669,7 +669,7 @@ impl FromStr for FirewallRule {
                 Some(("priority", val)) => {
                     priority =
                         Some(val.parse::<u16>().map_err(|e| {
-                            format!("bad priroity: '{val}' {e}")
+                            format!("bad priority: '{val}' {e}")
                         })?);
                 }
 
@@ -833,7 +833,7 @@ impl FromStr for Address {
 
             addrstr => match addrstr.split_once('=') {
                 None => {
-                    Err(format!("malformed address specification: {addrstr}",))
+                    Err(format!("malformed address specification: {addrstr}"))
                 }
                 Some(("ip", val)) => Ok(Address::Ip(val.parse()?)),
                 Some(("subnet", val)) => Ok(Address::Subnet(val.parse()?)),

--- a/lib/oxide-vpc/src/api.rs
+++ b/lib/oxide-vpc/src/api.rs
@@ -878,7 +878,7 @@ impl FromStr for ProtoFilter {
             "icmp6" => Ok(ProtoFilter::Proto(Protocol::ICMPv6)),
             "tcp" => Ok(ProtoFilter::Proto(Protocol::TCP)),
             "udp" => Ok(ProtoFilter::Proto(Protocol::UDP)),
-            _ => Err(format!("unknown protocol: {}", s)),
+            _ => Err(format!("unknown protocol: {s}")),
         }
     }
 }
@@ -888,7 +888,7 @@ impl Display for ProtoFilter {
         match self {
             ProtoFilter::Any => write!(f, "ANY"),
             ProtoFilter::Arp => write!(f, "ARP"),
-            ProtoFilter::Proto(proto) => write!(f, "{},", proto),
+            ProtoFilter::Proto(proto) => write!(f, "{proto}"),
         }
     }
 }

--- a/lib/oxide-vpc/src/engine/overlay.rs
+++ b/lib/oxide-vpc/src/engine/overlay.rs
@@ -227,8 +227,7 @@ impl StaticAction for EncapAction {
             Err(e) => {
                 return Err(GenHtError::Unexpected {
                     msg: format!(
-                        "failed to parse metadata entry '{}': {}",
-                        target_str, e
+                        "failed to parse metadata entry '{target_str}': {e}",
                     ),
                 });
             }

--- a/lib/oxide-vpc/src/engine/router.rs
+++ b/lib/oxide-vpc/src/engine/router.rs
@@ -121,7 +121,7 @@ impl ActionMetaValue for RouterTargetInternal {
                     Ok(Self::InternetGateway(Some(ig)))
                 }
 
-                _ => Err(format!("bad router target: {}", s)),
+                _ => Err(format!("bad router target: {s}")),
             },
         }
     }
@@ -129,13 +129,13 @@ impl ActionMetaValue for RouterTargetInternal {
     fn as_meta(&self) -> String {
         match self {
             Self::InternetGateway(ip) => match ip {
-                Some(ip) => format!("ig={}", ip),
+                Some(ip) => format!("ig={ip}"),
                 None => String::from("ig"),
             },
-            Self::Ip(IpAddr::Ip4(ip4)) => format!("ip4={}", ip4),
-            Self::Ip(IpAddr::Ip6(ip6)) => format!("ip6={}", ip6),
-            Self::VpcSubnet(IpCidr::Ip4(cidr4)) => format!("sub4={}", cidr4),
-            Self::VpcSubnet(IpCidr::Ip6(cidr6)) => format!("sub6={}", cidr6),
+            Self::Ip(IpAddr::Ip4(ip4)) => format!("ip4={ip4}"),
+            Self::Ip(IpAddr::Ip6(ip6)) => format!("ip6={ip6}"),
+            Self::VpcSubnet(IpCidr::Ip4(cidr4)) => format!("sub4={cidr4}"),
+            Self::VpcSubnet(IpCidr::Ip6(cidr6)) => format!("sub6={cidr6}"),
         }
     }
 }
@@ -143,11 +143,11 @@ impl ActionMetaValue for RouterTargetInternal {
 impl fmt::Display for RouterTargetInternal {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match self {
-            Self::InternetGateway(addr) => format!("IG({:?})", addr),
-            Self::Ip(addr) => format!("IP: {}", addr),
-            Self::VpcSubnet(sub) => format!("Subnet: {}", sub),
+            Self::InternetGateway(addr) => format!("IG({addr:?})"),
+            Self::Ip(addr) => format!("IP: {addr}"),
+            Self::VpcSubnet(sub) => format!("Subnet: {sub}"),
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 
@@ -166,7 +166,7 @@ impl ActionMetaValue for RouterTargetClass {
             "ig" => Ok(Self::InternetGateway),
             "ip" => Ok(Self::Ip),
             "subnet" => Ok(Self::VpcSubnet),
-            _ => Err(format!("bad router target class: {}", s)),
+            _ => Err(format!("bad router target class: {s}")),
         }
     }
 

--- a/xde/src/ioctl.rs
+++ b/xde/src/ioctl.rs
@@ -25,7 +25,7 @@ unsafe extern "C" {
 }
 
 fn dtrace_probe_copy_out_resp<T: Debug + Serialize>(resp: &T) {
-    let cstr = CString::new(format!("{:?}", resp)).unwrap();
+    let cstr = CString::new(format!("{resp:?}")).unwrap();
     unsafe {
         __dtrace_probe_copy__out__resp(cstr.as_ptr() as ddi::uintptr_t);
     }
@@ -107,7 +107,7 @@ impl<'a> IoctlEnvelope<'a> {
         match postcard::from_bytes(&bytes) {
             Ok(val) => Ok(val),
             Err(deser_error) => {
-                Err(OpteError::DeserCmdReq(format!("{}", deser_error)))
+                Err(OpteError::DeserCmdReq(format!("{deser_error}")))
             }
         }
     }
@@ -123,10 +123,10 @@ impl<'a> IoctlEnvelope<'a> {
         dtrace_probe_copy_out_resp(resp);
         let ser_result = match resp {
             Ok(v) => postcard::to_allocvec(v)
-                .map_err(|e| OpteError::SerCmdResp(format!("{}", e))),
+                .map_err(|e| OpteError::SerCmdResp(format!("{e}"))),
 
             Err(e) => postcard::to_allocvec(e)
-                .map_err(|e| OpteError::SerCmdErr(format!("{}", e))),
+                .map_err(|e| OpteError::SerCmdErr(format!("{e}"))),
         };
 
         // We failed to serialize the response, communicate this with ENOMSG.

--- a/xde/src/lib.rs
+++ b/xde/src/lib.rs
@@ -84,7 +84,7 @@ unsafe impl GlobalAlloc for KmemAlloc {
 
 #[panic_handler]
 fn panic_hdlr(info: &PanicInfo) -> ! {
-    let msg = CString::new(format!("{}", info)).expect("cstring new");
+    let msg = CString::new(format!("{info}")).expect("cstring new");
     unsafe {
         cmn_err(CE_WARN, msg.as_ptr());
         panic(msg.as_ptr());

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -878,11 +878,8 @@ fn delete_xde(req: &DeleteXdeReq) -> Result<NoResp, OpteError> {
     // Remove it, knowing that we may need to reinsert on a rollback.
     let xde = {
         let mut devs = token.devs.write();
-        let xde = devs
-            .remove(&req.xde_devname)
-            .ok_or_else(|| OpteError::PortNotFound(req.xde_devname.clone()))?;
-
-        xde
+        devs.remove(&req.xde_devname)
+            .ok_or_else(|| OpteError::PortNotFound(req.xde_devname.clone()))?
     };
 
     let return_port = |token: &TokenGuard<'_, XdeMgmt>, port| {

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -511,7 +511,7 @@ fn dtrace_probe_hdlr_resp<T>(resp: &Result<T, OpteError>)
 where
     T: CmdOk,
 {
-    let resp_arg = CString::new(format!("{:?}", resp)).unwrap();
+    let resp_arg = CString::new(format!("{resp:?}")).unwrap();
     __dtrace_probe_hdlr__resp(resp_arg.as_ptr() as uintptr_t);
 }
 
@@ -904,7 +904,7 @@ fn delete_xde(req: &DeleteXdeReq) -> Result<NoResp, OpteError> {
             return_port(&token, xde);
             return Err(OpteError::System {
                 errno: err,
-                msg: format!("failed to destroy DLS devnet: {}", err),
+                msg: format!("failed to destroy DLS devnet: {err}"),
             });
         }
     }
@@ -924,7 +924,7 @@ fn delete_xde(req: &DeleteXdeReq) -> Result<NoResp, OpteError> {
             return_port(&token, xde);
             return Err(OpteError::System {
                 errno: err,
-                msg: format!("failed to unregister mac: {}", err),
+                msg: format!("failed to unregister mac: {err}"),
             });
         }
     }


### PR DESCRIPTION
These were all fixed up in #759, but the build noise is getting a bit much on independent PRs so I'm pulling them out and making sure things still compile via this PR. Everything here is a result of following clippy's commands (or cleanup when doing so).

Broadly, these are all of the form `format!("{}", s)` -> `format!("{s}")`.

We have not changed the OPTE API in any way, so I will ignore CI complaining about `API_VERSION`.