### PR TITLE
Disable per-function sections

### DIFF
--- a/xde/x86_64-unknown-unknown.json
+++ b/xde/x86_64-unknown-unknown.json
@@ -16,6 +16,7 @@
     "llvm-target": "x86_64-none-none",
     "max-atomic-width": 64,
     "no-default-libraries": true,
+    "function-sections": false,
     "os": "illumos",
     "panic-strategy": "abort",
     "relax-elf-relocations": false,


### PR DESCRIPTION
Disable per-function sections by setting the,
`function-sections` parameter to `false` in the
target JSON file.

This reduces the number of generated sections from thousands to 36.