### PR TITLE
Build release XDE with `codegen-units = 1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,3 +88,5 @@ lto = "thin"
 [profile.release-lto]
 inherits = "release"
 lto = true
+codegen-units = 1
+


### PR DESCRIPTION
Shaves a few MB off the binary size of XDE, but does not seem to improve performance any.

So far as I can tell on my workstation, this has a minimal impact on build times. Double checking that this holds true from CI.