### PR TITLE
Use `omicron1` brand in CI

### DIFF
--- a/.github/buildomat/jobs/bench.sh
+++ b/.github/buildomat/jobs/bench.sh
@@ -28,7 +28,7 @@ set -o xtrace
 
 source .github/buildomat/common.sh
 
-pfexec pkg install brand/omicron1 opte iperf demangle flamegraph
+pfexec pkg install brand/omicron1 brand/omicron1/tools opte iperf demangle flamegraph
 
 svcadm enable /system/omicron/baseline
 

--- a/.github/buildomat/jobs/bench.sh
+++ b/.github/buildomat/jobs/bench.sh
@@ -37,7 +37,7 @@ if [[ -z $BUILDOMAT_JOB_ID ]]; then
     pfexec ln -s /work /input/xde/work
 fi
 
-/usr/lib/brand/omicron1/baseline -w /var/run/brand/omicron1/baseline
+pfexec /usr/lib/brand/omicron1/baseline -w /var/run/brand/omicron1/baseline
 
 function cleanup {
     pfexec chown -R `id -un`:`id -gn` .

--- a/.github/buildomat/jobs/bench.sh
+++ b/.github/buildomat/jobs/bench.sh
@@ -30,14 +30,14 @@ source .github/buildomat/common.sh
 
 pfexec pkg install brand/omicron1 brand/omicron1/tools opte iperf demangle flamegraph
 
-svcadm enable /system/omicron/baseline
-
 if [[ -z $BUILDOMAT_JOB_ID ]]; then
     echo Note: if you are running this locally, you must run the xde.sh job first
     echo to have the artifacts at the expected spot.
     pfexec mkdir -p /input/xde
     pfexec ln -s /work /input/xde/work
 fi
+
+/usr/lib/brand/omicron1/baseline -w /var/run/brand/omicron1/baseline
 
 function cleanup {
     pfexec chown -R `id -un`:`id -gn` .

--- a/.github/buildomat/jobs/bench.sh
+++ b/.github/buildomat/jobs/bench.sh
@@ -30,6 +30,8 @@ source .github/buildomat/common.sh
 
 pfexec pkg install brand/omicron1 opte iperf demangle flamegraph
 
+svcadm enable /system/omicron/baseline
+
 if [[ -z $BUILDOMAT_JOB_ID ]]; then
     echo Note: if you are running this locally, you must run the xde.sh job first
     echo to have the artifacts at the expected spot.

--- a/.github/buildomat/jobs/bench.sh
+++ b/.github/buildomat/jobs/bench.sh
@@ -28,7 +28,7 @@ set -o xtrace
 
 source .github/buildomat/common.sh
 
-pfexec pkg install brand/sparse opte iperf demangle flamegraph
+pfexec pkg install brand/omicron1 opte iperf demangle flamegraph
 
 if [[ -z $BUILDOMAT_JOB_ID ]]; then
     echo Note: if you are running this locally, you must run the xde.sh job first
@@ -110,7 +110,7 @@ pfexec cp /input/xde/work/release/xde /kernel/drv/amd64
 pfexec add_drv xde
 
 banner "bench"
-cargo kbench local
+cargo kbench local -b omicron1
 cargo ubench
 
 cp -r target/criterion $OUT_DIR

--- a/.github/buildomat/jobs/test.sh
+++ b/.github/buildomat/jobs/test.sh
@@ -20,7 +20,7 @@
 
 set -o xtrace
 
-pfexec pkg install brand/omicron1 opte
+pfexec pkg install brand/omicron1 brand/omicron1/tools opte
 
 svcadm enable /system/omicron/baseline
 

--- a/.github/buildomat/jobs/test.sh
+++ b/.github/buildomat/jobs/test.sh
@@ -20,7 +20,7 @@
 
 set -o xtrace
 
-pfexec pkg install brand/sparse opte
+pfexec pkg install brand/omicron1 opte
 
 if [[ -z $BUILDOMAT_JOB_ID ]]; then
     echo Note: if you are running this locally, you must run the xde.sh job first

--- a/.github/buildomat/jobs/test.sh
+++ b/.github/buildomat/jobs/test.sh
@@ -22,6 +22,8 @@ set -o xtrace
 
 pfexec pkg install brand/omicron1 opte
 
+svcadm enable /system/omicron/baseline
+
 if [[ -z $BUILDOMAT_JOB_ID ]]; then
     echo Note: if you are running this locally, you must run the xde.sh job first
     echo to have the artifacts at the expected spot.

--- a/.github/buildomat/jobs/test.sh
+++ b/.github/buildomat/jobs/test.sh
@@ -29,7 +29,7 @@ if [[ -z $BUILDOMAT_JOB_ID ]]; then
     pfexec ln -s /work /input/xde/work
 fi
 
-/usr/lib/brand/omicron1/baseline -w /var/run/brand/omicron1/baseline
+pfexec /usr/lib/brand/omicron1/baseline -w /var/run/brand/omicron1/baseline
 
 function cleanup {
     pfexec chown -R `id -un`:`id -gn` .

--- a/.github/buildomat/jobs/test.sh
+++ b/.github/buildomat/jobs/test.sh
@@ -22,14 +22,14 @@ set -o xtrace
 
 pfexec pkg install brand/omicron1 brand/omicron1/tools opte
 
-svcadm enable /system/omicron/baseline
-
 if [[ -z $BUILDOMAT_JOB_ID ]]; then
     echo Note: if you are running this locally, you must run the xde.sh job first
     echo to have the artifacts at the expected spot.
     pfexec mkdir -p /input/xde
     pfexec ln -s /work /input/xde/work
 fi
+
+/usr/lib/brand/omicron1/baseline -w /var/run/brand/omicron1/baseline
 
 function cleanup {
     pfexec chown -R `id -un`:`id -gn` .

--- a/xde-tests/src/lib.rs
+++ b/xde-tests/src/lib.rs
@@ -516,7 +516,7 @@ pub fn single_node_over_real_nic(
     println!("start zone");
     let a = OpteZone::new("a", &zfs, &[&opte.name], brand)?;
 
-    // std::thread::sleep(Duration::from_secs(30));
+    std::thread::sleep(Duration::from_secs(30));
 
     println!("setup zone");
     a.setup(&opte.name, opte.ip())?;

--- a/xde-tests/src/lib.rs
+++ b/xde-tests/src/lib.rs
@@ -250,6 +250,7 @@ pub struct Topology {
     pub v6_routes: Vec<RouteV6>,
     pub xde: Xde,
     pub lls: Vec<LinkLocal>,
+    pub vnics: Vec<Vnic>,
     pub simnet: Option<SimnetLink>,
     pub zfs: Arc<Zfs>,
 }
@@ -294,10 +295,12 @@ pub fn two_node_topology(brand: &str) -> Result<Topology> {
     // happen later), is forwarded to sim1, is decapsulated by opte1 and then
     // sent to vopte1.
     let sim = SimnetLink::new("xde_test_sim0", "xde_test_sim1")?;
-    let ll0 = LinkLocal::new(&sim.end_a, "ll")?;
-    let ll1 = LinkLocal::new(&sim.end_b, "ll")?;
+    let vn0 = Vnic::new("xde_test_vnic0", &sim.end_a)?;
+    let vn1 = Vnic::new("xde_test_vnic1", &sim.end_b)?;
+    let ll0 = LinkLocal::new(&vn0.name, "ll")?;
+    let ll1 = LinkLocal::new(&vn1.name, "ll")?;
 
-    Xde::set_xde_underlay(&sim.end_a, &sim.end_b)?;
+    Xde::set_xde_underlay(&vn0.name, &vn1.name)?;
     // TODO this is a sort of force unset underlay until we have an unset
     // underlay command. When this object drops it will remove the xde driver.
     // If we do not do this, xde will hold references to the simnet devices
@@ -327,7 +330,7 @@ pub fn two_node_topology(brand: &str) -> Result<Topology> {
     // sim1 and out sim0.
     println!("adding underlay route 0");
     let r0 =
-        RouteV6::new(opte0.underlay_ip(), 64, ll0.ip, Some(sim.end_b.clone()))?;
+        RouteV6::new(opte0.underlay_ip(), 64, ll0.ip, Some(vn1.name.clone()))?;
 
     // Create the second OPTE port with the provided overlay/underlay parameters.
     let opte1 =
@@ -340,7 +343,7 @@ pub fn two_node_topology(brand: &str) -> Result<Topology> {
     // loopback.
     println!("adding underlay route 1");
     let r1 =
-        RouteV6::new(opte1.underlay_ip(), 64, ll1.ip, Some(sim.end_a.clone()))?;
+        RouteV6::new(opte1.underlay_ip(), 64, ll1.ip, Some(vn0.name.clone()))?;
 
     // Set up a zfs pool for our test zones.
     let zfs = Arc::new(Zfs::new("opte2node")?);
@@ -360,6 +363,7 @@ pub fn two_node_topology(brand: &str) -> Result<Topology> {
     Ok(Topology {
         xde,
         lls: vec![ll0, ll1],
+        vnics: vec![vn0, vn1],
         simnet: Some(sim),
         nodes: vec![
             TestNode { zone: a, port: opte0 },
@@ -512,7 +516,7 @@ pub fn single_node_over_real_nic(
     println!("start zone");
     let a = OpteZone::new("a", &zfs, &[&opte.name], brand)?;
 
-    std::thread::sleep(Duration::from_secs(30));
+    // std::thread::sleep(Duration::from_secs(30));
 
     println!("setup zone");
     a.setup(&opte.name, opte.ip())?;
@@ -520,6 +524,7 @@ pub fn single_node_over_real_nic(
     Ok(Topology {
         xde,
         lls: vec![],
+        vnics: vec![],
         simnet: None,
         nodes: vec![TestNode { zone: a, port: opte }],
         null_ports,

--- a/xde-tests/src/lib.rs
+++ b/xde-tests/src/lib.rs
@@ -286,7 +286,7 @@ pub struct Topology {
 /// to OPTE and then to the adjacent vopte device. This is a nice little
 /// sanity checker to make sure basic opte/xde functionality is working - and
 /// that we're not hitting things like debug asserts in the OS.
-pub fn two_node_topology() -> Result<Topology> {
+pub fn two_node_topology(brand: &str) -> Result<Topology> {
     // Create the "underlay loopback". With simnet device pairs, any packet that
     // goes in one is forwarded to the other. In the topology depicted above,
     // this means that anything vopte0 sends, will be encapsulated onto the
@@ -347,9 +347,9 @@ pub fn two_node_topology() -> Result<Topology> {
 
     // Create a pair of zones to simulate our VM instances.
     println!("start zone a");
-    let a = OpteZone::new("a", &zfs, &[&opte0.name], "sparse")?;
+    let a = OpteZone::new("a", &zfs, &[&opte0.name], brand)?;
     println!("start zone b");
-    let b = OpteZone::new("b", &zfs, &[&opte1.name], "sparse")?;
+    let b = OpteZone::new("b", &zfs, &[&opte1.name], brand)?;
 
     println!("setup zone a");
     a.setup(&opte0.name, opte0.ip())?;

--- a/xde-tests/tests/loopback.rs
+++ b/xde-tests/tests/loopback.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 
 #[test]
 fn test_xde_loopback() -> Result<()> {
-    let topol = xde_tests::two_node_topology()?;
+    let topol = xde_tests::two_node_topology("omicron1")?;
 
     // Now we should be able to ping b from a on the overlay.
     _ = &topol.nodes[0]


### PR DESCRIPTION
Very quick PR to enable use of the `omicron1` brand in the `kbench local` benchmark, and the xde simnet connectivity test. This shaves a good 6 min off `xde-test` and `bench` in CI -- since sparse zones take so long to setup that it's worth spending ~1min to build the baseline for omicron1 zones.

Basically, this zone type requires that we put a VNIC ontop of each simnet endpoint and then use *that* as the underlay. This is also, as it turns out, a requirement to use packet siphons in these test cases.