### PR TITLE
`Cow`-ify `ActionMeta`

### DIFF
--- a/lib/oxide-vpc/src/engine/gateway/mod.rs
+++ b/lib/oxide-vpc/src/engine/gateway/mod.rs
@@ -258,7 +258,7 @@ impl MetaAction for VpcMeta {
         match self.vpc_mappings.ip_to_vni(&flow.dst_ip()) {
             Some(vni) => {
                 action_meta
-                    .insert(ACTION_META_VNI.to_string(), vni.to_string());
+                    .insert(ACTION_META_VNI.into(), vni.to_string().into());
                 Ok(AllowOrDeny::Allow(()))
             }
 

--- a/lib/oxide-vpc/src/engine/nat.rs
+++ b/lib/oxide-vpc/src/engine/nat.rs
@@ -144,7 +144,7 @@ fn create_nat_rules(
     let mut out_igw_nat_miss = Rule::new(NO_EIP_PRIORITY, Action::Deny);
     out_igw_nat_miss.add_predicate(Predicate::Meta(
         RouterTargetClass::KEY.to_string(),
-        RouterTargetClass::InternetGateway.as_meta(),
+        RouterTargetClass::InternetGateway.as_meta().into_owned(),
     ));
     out_rules.push(out_igw_nat_miss.finalize());
 
@@ -204,7 +204,9 @@ fn setup_ipv4_nat(
             ]));
             out_nat.add_predicate(Predicate::Meta(
                 RouterTargetInternal::KEY.to_string(),
-                RouterTargetInternal::InternetGateway(gw).as_meta(),
+                RouterTargetInternal::InternetGateway(gw)
+                    .as_meta()
+                    .into_owned(),
             ));
             out_rules.push(out_nat.finalize());
         }
@@ -250,7 +252,9 @@ fn setup_ipv4_nat(
             ]));
             out_nat.add_predicate(Predicate::Meta(
                 RouterTargetInternal::KEY.to_string(),
-                RouterTargetInternal::InternetGateway(igw_id).as_meta(),
+                RouterTargetInternal::InternetGateway(igw_id)
+                    .as_meta()
+                    .into_owned(),
             ));
             out_rules.push(out_nat.finalize());
         }
@@ -296,7 +300,9 @@ fn setup_ipv4_nat(
             ]));
             rule.add_predicate(Predicate::Meta(
                 RouterTargetInternal::KEY.to_string(),
-                RouterTargetInternal::InternetGateway(igw_id).as_meta(),
+                RouterTargetInternal::InternetGateway(igw_id)
+                    .as_meta()
+                    .into_owned(),
             ));
             out_rules.push(rule.finalize());
         }
@@ -353,7 +359,9 @@ fn setup_ipv6_nat(
             ]));
             out_nat.add_predicate(Predicate::Meta(
                 RouterTargetInternal::KEY.to_string(),
-                RouterTargetInternal::InternetGateway(gw).as_meta(),
+                RouterTargetInternal::InternetGateway(gw)
+                    .as_meta()
+                    .into_owned(),
             ));
             out_rules.push(out_nat.finalize());
         }
@@ -399,7 +407,9 @@ fn setup_ipv6_nat(
             ]));
             out_nat.add_predicate(Predicate::Meta(
                 RouterTargetInternal::KEY.to_string(),
-                RouterTargetInternal::InternetGateway(igw_id).as_meta(),
+                RouterTargetInternal::InternetGateway(igw_id)
+                    .as_meta()
+                    .into_owned(),
             ));
             out_rules.push(out_nat.finalize());
         }
@@ -445,7 +455,9 @@ fn setup_ipv6_nat(
             ]));
             rule.add_predicate(Predicate::Meta(
                 RouterTargetInternal::KEY.to_string(),
-                RouterTargetInternal::InternetGateway(igw_id).as_meta(),
+                RouterTargetInternal::InternetGateway(igw_id)
+                    .as_meta()
+                    .into_owned(),
             ));
             out_rules.push(rule.finalize());
         }

--- a/lib/oxide-vpc/src/engine/overlay.rs
+++ b/lib/oxide-vpc/src/engine/overlay.rs
@@ -400,7 +400,7 @@ impl StaticAction for DecapAction {
                 // is filled.
                 if !oxide_external_pkt {
                     action_meta
-                        .insert(ACTION_META_VNI.to_string(), vni.to_string());
+                        .insert(ACTION_META_VNI.into(), vni.to_string().into());
                 }
             }
 

--- a/lib/oxide-vpc/src/engine/router.rs
+++ b/lib/oxide-vpc/src/engine/router.rs
@@ -14,6 +14,7 @@ use crate::api::DelRouterEntryResp;
 use crate::api::RouterClass;
 use crate::api::RouterTarget;
 use crate::cfg::VpcCfg;
+use alloc::borrow::Cow;
 use alloc::string::String;
 use alloc::string::ToString;
 use alloc::sync::Arc;
@@ -70,12 +71,12 @@ impl RouterTargetInternal {
     pub const IP_KEY: &'static str = "router-target-ip";
     pub const GENERIC_META: &'static str = "ig";
 
-    pub fn generic_meta(&self) -> String {
-        Self::GENERIC_META.to_string()
+    pub fn generic_meta(&self) -> Cow<'static, str> {
+        Self::GENERIC_META.into()
     }
 
-    pub fn ip_key(&self) -> String {
-        Self::IP_KEY.to_string()
+    pub fn ip_key(&self) -> Cow<'static, str> {
+        Self::IP_KEY.into()
     }
 
     pub fn class(&self) -> RouterTargetClass {
@@ -126,16 +127,20 @@ impl ActionMetaValue for RouterTargetInternal {
         }
     }
 
-    fn as_meta(&self) -> String {
+    fn as_meta(&self) -> Cow<'static, str> {
         match self {
             Self::InternetGateway(ip) => match ip {
-                Some(ip) => format!("ig={ip}"),
-                None => String::from("ig"),
+                Some(ip) => format!("ig={ip}").into(),
+                None => "ig".into(),
             },
-            Self::Ip(IpAddr::Ip4(ip4)) => format!("ip4={ip4}"),
-            Self::Ip(IpAddr::Ip6(ip6)) => format!("ip6={ip6}"),
-            Self::VpcSubnet(IpCidr::Ip4(cidr4)) => format!("sub4={cidr4}"),
-            Self::VpcSubnet(IpCidr::Ip6(cidr6)) => format!("sub6={cidr6}"),
+            Self::Ip(IpAddr::Ip4(ip4)) => format!("ip4={ip4}").into(),
+            Self::Ip(IpAddr::Ip6(ip6)) => format!("ip6={ip6}").into(),
+            Self::VpcSubnet(IpCidr::Ip4(cidr4)) => {
+                format!("sub4={cidr4}").into()
+            }
+            Self::VpcSubnet(IpCidr::Ip6(cidr6)) => {
+                format!("sub6={cidr6}").into()
+            }
         }
     }
 }
@@ -170,7 +175,7 @@ impl ActionMetaValue for RouterTargetClass {
         }
     }
 
-    fn as_meta(&self) -> String {
+    fn as_meta(&self) -> Cow<'static, str> {
         match self {
             Self::InternetGateway => "ig".into(),
             Self::Ip => "ip".into(),


### PR DESCRIPTION
Mooves `ActionMeta` from a `String`->`String` map to something capable of holding `&'static str`s as both keys and values. This only really affects slowpath traffic, but this leads to fewer allocations when traversing that path.

Split out of #805, where this wasn't a necessary part of the fix.