### PR TITLE
`DevMap` should not expose cloneable references

### DIFF
--- a/xde/src/dev_map.rs
+++ b/xde/src/dev_map.rs
@@ -72,20 +72,20 @@ impl DevMap {
     /// Return a reference to an `XdeDev` using its address.
     #[inline]
     #[must_use]
-    pub fn get_by_key(&self, key: VniMac) -> Option<&Dev> {
-        self.devs.get(&key)
+    pub fn get_by_key(&self, key: VniMac) -> Option<&XdeDev> {
+        self.devs.get(&key).map(Arc::as_ref)
     }
 
     /// Return a reference to an `XdeDev` using its name.
     #[inline]
     #[must_use]
-    pub fn get_by_name(&self, name: &str) -> Option<&Dev> {
-        self.names.get(name)
+    pub fn get_by_name(&self, name: &str) -> Option<&XdeDev> {
+        self.names.get(name).map(Arc::as_ref)
     }
 
     /// Return an iterator over all `XdeDev`s, sorted by address.
-    pub fn iter(&self) -> impl Iterator<Item = &Dev> {
-        self.devs.values()
+    pub fn iter(&self) -> impl Iterator<Item = &XdeDev> {
+        self.devs.values().map(Arc::as_ref)
     }
 
     /// Return an iterator over all `XdeDev`s, sorted by address.


### PR DESCRIPTION
One of the purposes of `DevMap` is to ensure that the datapath does not inappropriately clone out and extend the lifetime of any ports. As it turns out, the code using `DevMap` is doing the right thing, but its API surface is overly permissive and should be making an `Arc::clone` or similar impossible.