### PR TITLE
return success from mc_multicst(9e)

### DIFF
--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -1995,6 +1995,19 @@ unsafe extern "C" fn xde_mc_multicst(
     _add: boolean_t,
     _addrp: *const u8,
 ) -> c_int {
+    // The value returned to the mc_multicst(9e) entry point is both an
+    // opportunity for xde to set up multicast filtering and to signal to the
+    // kernel that multicast addresses are supported for opte data links. Since
+    // we're not doing any hardware-based multicast filtering at the moment,
+    // it's sufficient to signal to the kernel that multicast addresses are
+    // supported for opte data links. If we do not return success here, the
+    // kernel will assign broadcast macs where multicast macs would normally be
+    // used. This breaks protocols such as IPv6 NDP that expect multicast MACs
+    // to be used.
+    //
+    // In the future we may have a more sophisticated approach here that
+    // actually programs hardware multicast filters, either for things like NDP
+    // or in response to signals from the guest such as VIRTIO_NET_F_CTRL_RX.
     0
 }
 


### PR DESCRIPTION
This came up in IPv6 e2e testing with omicron probes.

Wiring up `mc_multicst(9e)` is required for omicron probes setting up addresses directly on opte devices. The `NeighborAdvertisement` `HairpinAction` [expects multicast macs](https://github.com/oxidecomputer/opte/blob/de42c5e5c188faaa4810322f985f7f4a19474952/lib/opte/src/engine/icmp/v6.rs#L525). But without `mc_multicst(9e)` plumbed, multicast macs will fall back to broadcast macs, the `HairpinAction` predicates will fail and ndp will go nowhere in the probe zone.

My read of `mc_multicst(9e)` is that it is both an opportunity for a driver to set up multicast filtering on a device, and to signal to the kernel that multicast addressing is supported for data links on said device. Since we're not doing any hardware-based multicast filtering at the moment, I _think_ it's sufficient to simply signal multicast L2 address support to the kernel.

When we return `ENOTSUP` for the `mc_multicst` entry point, we see the following in the kernel logs when multicast addresses are assigned to OPTE data links.

```
ip: joining multicasts failed (4) on opte1 - will use link layer broadcasts for multicast
```

Which results in NDP traffic using broadcast macs instead of multicast macs.

I've taken this patch for a spin in a4x2. Everything comes up. NDP traffic flows over OPTE devices use multicast addressing and address setup works as expected.