### PR TITLE
Advertise `MAC_CAPAB_OVERLAY`

### DIFF
--- a/xde/src/mac/sys.rs
+++ b/xde/src/mac/sys.rs
@@ -615,6 +615,7 @@ pub enum mac_capab_t {
     MAC_CAPAB_NO_ZCOPY = 0x00100000, /* boolean only, no data */
     MAC_CAPAB_LEGACY = 0x00200000, /* data is mac_capab_legacy_t */
     MAC_CAPAB_VRRP = 0x00400000, /* data is mac_capab_vrrp_t */
+    MAC_CAPAB_OVERLAY = 0x00800000, /* boolean only, no data */
     MAC_CAPAB_TRANSCEIVER = 0x01000000, /* mac_capab_transciever_t */
     MAC_CAPAB_LED = 0x02000000,  /* data is mac_capab_led_t */
 }

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -3096,6 +3096,13 @@ unsafe extern "C" fn xde_mc_getcapab(
 
             boolean_t::B_TRUE
         }
+        // We *are* an overlay device, and this helpfully convinces MAC
+        // to give us eight softrings without advertising MAC_CAPAB_RINGS
+        // (and pretending to have 8 physical rings, get polled by an SRS...).
+        //
+        // We want, in future, to dynamically size the softring count of
+        // an XDE port to 1-to-1 match the number of viona queues above it.
+        mac::mac_capab_t::MAC_CAPAB_OVERLAY => boolean_t::B_TRUE,
         _ => boolean_t::B_FALSE,
     }
 }


### PR DESCRIPTION
This is a GLDv3-private capability, but stlouis will use this information to determine whether we should receive 10GbE equiavalent software fanout (i.e., up to 8 soft rings).

Using this capability (with some [stlouis changes](https://github.com/oxidecomputer/stlouis/issues/893) to remove the VNIC requirement) should allow us to avoid having all fan-in from being serialised by a single softring worker thread.