### PR TITLE
[multicast] Fix multicast Tx self-delivery exclusion using wrong VNI for port lookup

### DIFF
--- a/xde-tests/src/lib.rs
+++ b/xde-tests/src/lib.rs
@@ -13,7 +13,6 @@ use oxide_vpc::api::AddRouterEntryReq;
 use oxide_vpc::api::Address;
 use oxide_vpc::api::ClearMcast2PhysReq;
 use oxide_vpc::api::ClearMcastForwardingReq;
-use oxide_vpc::api::DEFAULT_MULTICAST_VNI;
 use oxide_vpc::api::DhcpCfg;
 use oxide_vpc::api::Direction;
 use oxide_vpc::api::ExternalIpCfg;
@@ -57,6 +56,10 @@ use std::time::Duration;
 use std::time::Instant;
 use zone::Zlogin;
 pub use ztest::*;
+
+/// VPC VNI for test ports, distinct from the multicast VNI so that
+/// port-keyed and multicast-keyed code paths are exercised separately.
+const TEST_VPC_VNI: u32 = 1000;
 
 /// Ensure a zone with the given name is not present.
 ///
@@ -308,7 +311,7 @@ impl OptePort {
             }),
             guest_mac: guest_mac.parse().unwrap(),
             gateway_mac: "a8:40:25:00:00:01".parse().unwrap(),
-            vni: Vni::new(DEFAULT_MULTICAST_VNI).unwrap(),
+            vni: Vni::new(TEST_VPC_VNI).unwrap(),
             phys_ip: phys_ip.parse().unwrap(),
             dhcp: DhcpCfg::default(),
         };
@@ -364,7 +367,7 @@ impl OptePort {
             },
             guest_mac: guest_mac.parse().unwrap(),
             gateway_mac: "a8:40:25:00:00:01".parse().unwrap(),
-            vni: Vni::new(DEFAULT_MULTICAST_VNI).unwrap(),
+            vni: Vni::new(TEST_VPC_VNI).unwrap(),
             phys_ip: phys_ip.parse().unwrap(),
             dhcp: DhcpCfg::default(),
         };
@@ -553,7 +556,7 @@ impl Xde {
             phys: PhysNet {
                 ether: ether.parse().unwrap(),
                 ip: ip.parse().unwrap(),
-                vni: Vni::new(DEFAULT_MULTICAST_VNI).unwrap(),
+                vni: Vni::new(TEST_VPC_VNI).unwrap(),
             },
         })?;
         Ok(())

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -2333,6 +2333,7 @@ fn handle_mcast_tx<'a>(
 
     // Local same-sled delivery: always deliver to subscribers on this sled,
     // independent of the Tx-only Replication instruction (not an access control mechanism).
+    //
     // The Replication type only affects how switches handle the packet on Tx.
     // Subscription is keyed by underlay (outer) IPv6 multicast address.
     let underlay_addr =
@@ -2340,7 +2341,9 @@ fn handle_mcast_tx<'a>(
     let group_key = MulticastUnderlay::new_unchecked(underlay_addr);
 
     if let Some(subscribers) = devs.mcast_subscribers(&group_key) {
-        let my_key = VniMac::new(ctx.vni, src_dev.port.mac_addr());
+        // Use the port's VPC VNI, not the multicast VNI from the
+        // Geneve header (ctx.vni), to match how DevMap keys on ports.
+        let my_key = VniMac::new(src_dev.vni, src_dev.port.mac_addr());
         for (key, filter) in subscribers {
             // Skip delivering to self
             if my_key == *key {


### PR DESCRIPTION
The sender self-exclusion check in `handle_mcast_tx` constructed a VniMac key with the multicast VNI from the Geneve header instead of the port's VPC VNI, which is unique. Since DevMap keys ports by VPC VNI, the previous check never matched, causing the sender to receive its own multicast packets.

The fix -> use src_dev.vni for the VniMac lookup key.