### PR TITLE
`SetExternalIpsReq` should treat `None` as an empty list

### DIFF
--- a/lib/oxide-vpc/src/api.rs
+++ b/lib/oxide-vpc/src/api.rs
@@ -211,7 +211,7 @@ pub struct Ipv6Cfg {
 }
 
 /// Configuration of NAT assignments used by a VPC guest for external networking.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ExternalIpCfg<T> {
     /// The source NAT configuration for making outbound connections
     /// from the private network.

--- a/lib/oxide-vpc/src/engine/nat.rs
+++ b/lib/oxide-vpc/src/engine/nat.rs
@@ -519,6 +519,14 @@ fn setup_ipv6_nat(
     Ok(())
 }
 
+/// Replace all external IP-related rules in the NAT layer with a new set
+/// corresponding to `req.external_ips_v4` and  `req.external_ips_v6`.
+///
+/// Passing `None` (or `Some(ExternalIpCfg::default())`) will remove all IPs
+/// of the given family.
+///
+/// Passing `Some(_)` external IPs to a port which does not support that
+/// IP address family will return an error.
 pub fn set_external_ips(
     port: &Port<VpcNetwork>,
     req: SetExternalIpsReq,

--- a/lib/oxide-vpc/src/engine/nat.rs
+++ b/lib/oxide-vpc/src/engine/nat.rs
@@ -524,31 +524,35 @@ pub fn set_external_ips(
     req: SetExternalIpsReq,
 ) -> Result<(), OpteError> {
     let cfg = &port.network().cfg;
+
+    // Check for any cases where the control plane is trying to insert external
+    // IP state for network stack this port is not configured to support.
+    if (matches!(cfg.ip_cfg, IpCfg::Ipv4(_)) && req.external_ips_v6.is_some())
+        || (matches!(cfg.ip_cfg, IpCfg::Ipv6(_))
+            && req.external_ips_v4.is_some())
+    {
+        return Err(OpteError::InvalidIpCfg);
+    }
+
+    let v4_cfg = req.external_ips_v4.unwrap_or_default();
+    let v6_cfg = req.external_ips_v6.unwrap_or_default();
+
     // This procedure only holds one lock at a time: a `Dynamic`'s shared
     // space writelock, *or* the table lock via set_rules_soft.
     // The datapath will hold the table lock for processing, *and* the `Dynamic`'s
     // readlock when validating dirty match entries.
     // As such, the two should not deadlock.
-    match (&cfg.ip_cfg, req.external_ips_v4, req.external_ips_v6) {
-        (IpCfg::DualStack { ipv4, ipv6 }, Some(new_v4), Some(new_v6)) => {
-            ipv4.external_ips.store(new_v4);
-            ipv6.external_ips.store(new_v6);
+    match &cfg.ip_cfg {
+        IpCfg::DualStack { ipv4, ipv6 } => {
+            ipv4.external_ips.store(v4_cfg);
+            ipv6.external_ips.store(v6_cfg);
         }
-        (
-            IpCfg::Ipv4(ipv4) | IpCfg::DualStack { ipv4, .. },
-            Some(new_v4),
-            None,
-        ) => {
-            ipv4.external_ips.store(new_v4);
+        IpCfg::Ipv4(ipv4) => {
+            ipv4.external_ips.store(v4_cfg);
         }
-        (
-            IpCfg::Ipv6(ipv6) | IpCfg::DualStack { ipv6, .. },
-            None,
-            Some(new_v6),
-        ) => {
-            ipv6.external_ips.store(new_v6);
+        IpCfg::Ipv6(ipv6) => {
+            ipv6.external_ips.store(v6_cfg);
         }
-        _ => return Err(OpteError::InvalidIpCfg),
     }
 
     refresh_nat_rules(port, req.inet_gw_map.as_ref())

--- a/lib/oxide-vpc/tests/integration_tests.rs
+++ b/lib/oxide-vpc/tests/integration_tests.rs
@@ -1374,10 +1374,17 @@ fn external_ip_epoch_affinity_preserved() {
         ExternalIpCfg { floating_ips, ..v.external_ips.clone() }
     });
 
+    let (external_ips_v4, external_ips_v6) =
+        if let IpCfg::DualStack { ipv4, ipv6 } = &g1_cfg.ip_cfg {
+            (Some(ipv4.external_ips.clone()), Some(ipv6.external_ips.clone()))
+        } else {
+            panic!("port is built as dual-stack");
+        };
+
     let mut req = oxide_vpc::api::SetExternalIpsReq {
         port_name: g1.port.name().to_string(),
-        external_ips_v4: None,
-        external_ips_v6: None,
+        external_ips_v4,
+        external_ips_v6,
 
         // This test does not focus on controlling EIP selection
         // based on destination prefix.
@@ -4714,23 +4721,32 @@ fn select_eip_conditioned_on_igw() {
     // * All EIPs are valid on IGW4.
     //   - Packets will choose a random FIP, by priority ordering.
 
+    let v4_ext = ExternalIpCfg {
+        snat: Some(SNat4Cfg {
+            external_ip: "10.77.77.13".parse().unwrap(),
+            ports: 1025..=4096,
+        }),
+        ephemeral_ip: Some("192.168.0.1".parse().unwrap()),
+        floating_ips: vec![
+            "192.168.0.2".parse().unwrap(),
+            "192.168.0.3".parse().unwrap(),
+            "192.168.0.4".parse().unwrap(),
+        ],
+    };
+    let v6_ext = ExternalIpCfg {
+        snat: Some(SNat6Cfg {
+            external_ip: "2001:db8::1".parse().unwrap(),
+            ports: 1025..=4096,
+        }),
+        ephemeral_ip: None,
+        floating_ips: vec![],
+    };
     let ip_cfg = IpCfg::DualStack {
         ipv4: Ipv4Cfg {
             vpc_subnet: "172.30.0.0/22".parse().unwrap(),
             private_ip: "172.30.0.5".parse().unwrap(),
             gateway_ip: "172.30.0.1".parse().unwrap(),
-            external_ips: ExternalIpCfg {
-                snat: Some(SNat4Cfg {
-                    external_ip: "10.77.77.13".parse().unwrap(),
-                    ports: 1025..=4096,
-                }),
-                ephemeral_ip: Some("192.168.0.1".parse().unwrap()),
-                floating_ips: vec![
-                    "192.168.0.2".parse().unwrap(),
-                    "192.168.0.3".parse().unwrap(),
-                    "192.168.0.4".parse().unwrap(),
-                ],
-            },
+            external_ips: v4_ext,
             attached_subnets: BTreeMap::new(),
             transit_ips: BTreeMap::new(),
         },
@@ -4739,14 +4755,7 @@ fn select_eip_conditioned_on_igw() {
             vpc_subnet: "fd00::/64".parse().unwrap(),
             private_ip: "fd00::5".parse().unwrap(),
             gateway_ip: "fd00::1".parse().unwrap(),
-            external_ips: ExternalIpCfg {
-                snat: Some(SNat6Cfg {
-                    external_ip: "2001:db8::1".parse().unwrap(),
-                    ports: 1025..=4096,
-                }),
-                ephemeral_ip: None,
-                floating_ips: vec![],
-            },
+            external_ips: v6_ext.clone(),
             attached_subnets: BTreeMap::new(),
             transit_ips: BTreeMap::new(),
         },
@@ -4827,7 +4836,7 @@ fn select_eip_conditioned_on_igw() {
     let req = oxide_vpc::api::SetExternalIpsReq {
         port_name: g1.port.name().to_string(),
         external_ips_v4: new_v4_cfg,
-        external_ips_v6: None,
+        external_ips_v6: Some(v6_ext),
 
         // Setting the inet GW mappings for each external IP
         // enables the limiting we aim to test here.


### PR DESCRIPTION
The control plane treats no external IPs on a port by handing us `None` for its config, where the API previously expected that we would receive `Some(Default::default())` (i.e, an explicit clear operation). However the way we use this in practice is to perform an `ensure` operation on the complete set of config available to us. This change stops us from erroring out in the `(None, None)` case and correctly removes EIP config if the control plane gives us `None` rather than `Some(Default)`.

A few of the tests were implicitly relying on the old behaviour to selectively modify v4 or v6 EIPs, which is counter to how the control plane programs these rules. These have been fixed up.

Closes #972.