### PR TITLE
Set OPTE maximum port MTU during creation

### DIFF
--- a/bin/opteadm/src/bin/opteadm.rs
+++ b/bin/opteadm/src/bin/opteadm.rs
@@ -206,14 +206,17 @@ enum Command {
         #[arg(long)]
         src_underlay_addr: Ipv6Addr,
 
+        /// The MTU that should be assigned to the newly created OPTE port.
+        ///
+        /// If unset, this will default to the standard Ethernet MTU of 1500.
+        #[arg(long)]
+        mtu: Option<u32>,
+
         #[command(flatten)]
         external_net: ExternalNetConfig,
 
         #[command(flatten)]
         dhcp: DhcpConfig,
-
-        #[arg(long)]
-        passthrough: bool,
     },
 
     /// Delete an xde device
@@ -823,7 +826,7 @@ fn main() -> anyhow::Result<()> {
             src_underlay_addr,
             dhcp,
             external_net,
-            passthrough,
+            mtu,
         } => {
             let ip_cfg = match private_ip {
                 IpAddr::Ip4(private_ip) => {
@@ -877,7 +880,7 @@ fn main() -> anyhow::Result<()> {
                 dhcp: dhcp.into(),
             };
 
-            hdl.create_xde(&name, cfg, passthrough)?;
+            hdl.create_xde(&name, cfg, mtu)?;
         }
 
         Command::DeleteXde { name } => {

--- a/crates/opte-api/src/lib.rs
+++ b/crates/opte-api/src/lib.rs
@@ -51,7 +51,7 @@ pub use ulp::*;
 ///
 /// We rely on CI and the check-api-version.sh script to verify that
 /// this number is incremented anytime the oxide-api code changes.
-pub const API_VERSION: u64 = 40;
+pub const API_VERSION: u64 = 41;
 
 /// Major version of the OPTE package.
 pub const MAJOR_VERSION: u64 = 0;

--- a/crates/opte-api/src/ndp.rs
+++ b/crates/opte-api/src/ndp.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 //! Types for working with the IPv6 Neighbor Discovery Protocol
 
@@ -30,6 +30,10 @@ pub struct RouterAdvertisement {
     /// Managed address configuration, indicating that the peer can use DHCPv6
     /// to acquire an IPv6 address.
     pub managed_cfg: bool,
+
+    /// Configures whether router advertisements should advertise a given MTU to
+    /// guests.
+    pub mtu: Option<u32>,
 }
 
 impl RouterAdvertisement {
@@ -46,9 +50,14 @@ impl RouterAdvertisement {
     ///
     /// `managed_cfg` is set to `true` to indicate that the host can get further
     /// configuration from a DHCPv6 server running on the network.
-    pub fn new(src_mac: MacAddr, mac: MacAddr, managed_cfg: bool) -> Self {
+    pub fn new(
+        src_mac: MacAddr,
+        mac: MacAddr,
+        managed_cfg: bool,
+        mtu: Option<u32>,
+    ) -> Self {
         let ip = Ipv6Addr::from_eui64(&mac);
-        Self { src_mac, mac, ip, managed_cfg }
+        Self { src_mac, mac, ip, managed_cfg, mtu }
     }
 
     /// Return the IPv6 address the router sends advertisements from.

--- a/lib/opte-ioctl/src/lib.rs
+++ b/lib/opte-ioctl/src/lib.rs
@@ -127,7 +127,7 @@ impl OpteHdl {
         &self,
         name: &str,
         cfg: VpcCfg,
-        passthrough: bool,
+        mtu: Option<u32>,
     ) -> Result<NoResp, Error> {
         use libnet::link;
 
@@ -139,7 +139,7 @@ impl OpteHdl {
 
         let xde_devname = name.into();
         let cmd = OpteCmd::CreateXde;
-        let req = CreateXdeReq { xde_devname, linkid, cfg, passthrough };
+        let req = CreateXdeReq { xde_devname, linkid, cfg, mtu };
 
         let res = run_cmd_ioctl(self.device.as_raw_fd(), cmd, Some(&req));
 

--- a/lib/opte-test-utils/src/lib.rs
+++ b/lib/opte-test-utils/src/lib.rs
@@ -356,7 +356,7 @@ pub fn oxide_net_setup2(
         }
     };
 
-    let converted_cfg: oxide_vpc::cfg::VpcCfg = cfg.clone().into();
+    let converted_cfg = oxide_vpc::cfg::VpcCfg::with_mtu(cfg.clone(), 1500);
     let vpc_net = VpcNetwork { cfg: converted_cfg.clone() };
     let uft_limit = flow_table_limits.unwrap_or(UFT_LIMIT.unwrap());
     let tcp_limit = flow_table_limits.unwrap_or(TCP_LIMIT.unwrap());

--- a/lib/opte/src/engine/icmp/v6.rs
+++ b/lib/opte/src/engine/icmp/v6.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2025 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 //! ICMPv6 headers and processing.
 
@@ -324,10 +324,7 @@ impl HairpinAction for RouterAdvertisement {
             reachable_time: ZERO_DURATION,
             retrans_time: ZERO_DURATION,
             lladdr: Some(RawHardwareAddress::from_bytes(&self.mac)),
-            // TODO-completeness: Don't hardcode this.
-            //
-            // See https://github.com/oxidecomputer/opte/issues/263.
-            mtu: Some(1500),
+            mtu: self.mtu,
             // Indicate that there are no addresses considered on-link, other
             // than the router's advertised link-local address. This will
             // require all traffic from the client to go through OPTE.

--- a/lib/oxide-vpc/src/api.rs
+++ b/lib/oxide-vpc/src/api.rs
@@ -618,11 +618,10 @@ pub struct CreateXdeReq {
     /// details.
     pub cfg: VpcCfg,
 
-    /// This is a development tool for completely bypassing OPTE processing.
+    /// The MTU we should assign to the newly created OPTE port.
     ///
-    /// XXX Pretty sure we aren't making much use of this anymore, and
-    /// should go away before v1.
-    pub passthrough: bool,
+    /// If unset, this will default to the standard Ethernet MTU of 1500.
+    pub mtu: Option<u32>,
 }
 
 pub type SNat4Cfg = SNatCfg<Ipv4Addr>;

--- a/lib/oxide-vpc/src/cfg.rs
+++ b/lib/oxide-vpc/src/cfg.rs
@@ -110,9 +110,28 @@ pub struct VpcCfg {
 
     /// Configuration for DHCP responses created by OPTE.
     pub dhcp: DhcpCfg,
+
+    /// MTU value that this port has been configured with.
+    ///
+    /// This value must be explicitly filled by the driver to honour a request from
+    /// the control plane or according to the limits on the underlay devices
+    /// themselves.
+    pub mtu: u32,
 }
 
 impl VpcCfg {
+    pub fn with_mtu(value: api::VpcCfg, mtu: u32) -> Self {
+        Self {
+            ip_cfg: value.ip_cfg.into(),
+            guest_mac: value.guest_mac,
+            gateway_mac: value.gateway_mac,
+            vni: value.vni,
+            phys_ip: value.phys_ip,
+            dhcp: value.dhcp,
+            mtu,
+        }
+    }
+
     /// Return the IPv4 configuration, if it exists, or None.
     pub fn ipv4_cfg(&self) -> Option<&Ipv4Cfg> {
         match self.ip_cfg {
@@ -202,19 +221,6 @@ impl VpcCfg {
     }
 }
 
-impl From<api::VpcCfg> for VpcCfg {
-    fn from(value: api::VpcCfg) -> Self {
-        Self {
-            ip_cfg: value.ip_cfg.into(),
-            guest_mac: value.guest_mac,
-            gateway_mac: value.gateway_mac,
-            vni: value.vni,
-            phys_ip: value.phys_ip,
-            dhcp: value.dhcp,
-        }
-    }
-}
-
 impl From<api::IpCfg> for IpCfg {
     fn from(value: api::IpCfg) -> Self {
         match value {
@@ -258,12 +264,14 @@ mod tests {
     use super::*;
     use api::tests::test_vpc_cfg;
 
+    const ETHERNET_MTU: u32 = 1500;
+
     #[test]
     fn test_required_nat_space() {
         let cfg = test_vpc_cfg();
         // Each IPv4/v6 has the full port range.
         assert_eq!(
-            VpcCfg::from(cfg).required_nat_space(),
+            VpcCfg::with_mtu(cfg, ETHERNET_MTU).required_nat_space(),
             u32::from(u16::MAX) * 2
         );
     }
@@ -273,7 +281,10 @@ mod tests {
         let mut cfg = test_vpc_cfg();
         let api::IpCfg::DualStack { ipv6, .. } = cfg.ip_cfg else { panic!() };
         cfg.ip_cfg = api::IpCfg::Ipv6(ipv6);
-        assert_eq!(VpcCfg::from(cfg).required_nat_space(), u32::from(u16::MAX));
+        assert_eq!(
+            VpcCfg::with_mtu(cfg, ETHERNET_MTU).required_nat_space(),
+            u32::from(u16::MAX)
+        );
     }
 
     #[test]
@@ -281,6 +292,9 @@ mod tests {
         let mut cfg = test_vpc_cfg();
         let api::IpCfg::DualStack { ipv4, .. } = cfg.ip_cfg else { panic!() };
         cfg.ip_cfg = api::IpCfg::Ipv4(ipv4);
-        assert_eq!(VpcCfg::from(cfg).required_nat_space(), u32::from(u16::MAX));
+        assert_eq!(
+            VpcCfg::with_mtu(cfg, ETHERNET_MTU).required_nat_space(),
+            u32::from(u16::MAX)
+        );
     }
 }

--- a/lib/oxide-vpc/src/engine/gateway/icmpv6.rs
+++ b/lib/oxide-vpc/src/engine/gateway/icmpv6.rs
@@ -62,6 +62,9 @@ pub(super) fn setup(
             // "Managed Configuration", indicating the guest needs to use DHCPv6 to
             // acquire an IPv6 address.
             true,
+            // Out current disposition is to always include an MTU announcement in
+            // the NDP RA.
+            Some(ctx.cfg.mtu),
         ))),
         // Map an NDP Neighbor Solicitation from the guest to a neighbor
         // advertisement from the OPTE virtual gateway. Note that this is required

--- a/xde-tests/src/lib.rs
+++ b/xde-tests/src/lib.rs
@@ -316,7 +316,7 @@ impl OptePort {
             dhcp: DhcpCfg::default(),
         };
         let adm = OpteHdl::open()?;
-        adm.create_xde(name, cfg.clone(), false)?;
+        adm.create_xde(name, cfg.clone(), None)?;
         Ok(OptePort {
             name: name.into(),
             cfg,
@@ -372,7 +372,7 @@ impl OptePort {
             dhcp: DhcpCfg::default(),
         };
         let adm = OpteHdl::open()?;
-        adm.create_xde(name, cfg.clone(), false)?;
+        adm.create_xde(name, cfg.clone(), None)?;
         Ok(OptePort {
             name: name.into(),
             cfg,

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -616,6 +616,7 @@ pub struct XdeDev {
     linkid: datalink_id_t,
     mh: *mut mac::mac_handle,
     link_state: mac::link_state_t,
+    mtu: u32,
 
     // The OPTE port associated with this xde device.
     //
@@ -625,10 +626,6 @@ pub struct XdeDev {
     pub port: Arc<Port<VpcNetwork>>,
     port_v2p: Arc<overlay::Virt2Phys>,
     port_igw_map: KMutex<Option<InternetGatewayMap>>,
-
-    // Pass the packets through to the underlay devices, skipping
-    // opte-core processing.
-    passthrough: bool,
 
     pub vni: Vni,
 
@@ -1195,12 +1192,14 @@ fn create_xde(req: &CreateXdeReq) -> Result<NoResp, OpteError> {
     };
 
     let mut guest_addr = cfg.guest_mac.bytes();
+    let mtu = req.mtu.unwrap_or(u32::from(ETHERNET_MTU));
 
     let mut xde = Arc::new(XdeDev {
         devname: req.xde_devname.clone(),
         linkid: req.linkid,
         mh: ptr::null_mut(),
         link_state: mac::link_state_t::Down,
+        mtu,
         port: new_port(
             req.xde_devname.clone(),
             &cfg,
@@ -1213,7 +1212,6 @@ fn create_xde(req: &CreateXdeReq) -> Result<NoResp, OpteError> {
         port_v2p,
         vni: cfg.vni,
         port_igw_map: KMutex::new(None),
-        passthrough: req.passthrough,
         u1,
         u2,
         underlay_capab,
@@ -1241,7 +1239,7 @@ fn create_xde(req: &CreateXdeReq) -> Result<NoResp, OpteError> {
     mreg.m_priv_props = core::ptr::null_mut();
     mreg.m_instance = c_uint::MAX; // let mac handle this
     mreg.m_min_sdu = 1;
-    mreg.m_max_sdu = u32::from(ETHERNET_MTU); // TODO hardcode
+    mreg.m_max_sdu = mtu;
     mreg.m_multicast_sdu = 0;
     mreg.m_margin = crate::sys::VLAN_TAGSZ;
     mreg.m_v12n = mac::MAC_VIRT_NONE as u32;
@@ -2842,19 +2840,6 @@ fn xde_mc_tx_one<'a>(
         }
     };
 
-    // Send straight to underlay in passthrough mode.
-    if src_dev.passthrough {
-        // TODO We need to deal with flow control. This could actually
-        // get weird, this is the first provider to use mac_tx(). Is
-        // there something we can learn from aggr here? I need to
-        // refresh my memory on all of this.
-        //
-        // TODO Is there way to set mac_tx to must use result?
-        drop(parsed_pkt);
-        postbox.post_underlay(UnderlayIndex::U1, TxHint::NoneOrMixed, pkt);
-        return;
-    }
-
     let port = &src_dev.port;
 
     // The port processing code will fire a probe that describes what
@@ -3538,13 +3523,6 @@ fn xde_rx_one(
         None
     };
 
-    // We are in passthrough mode, skip OPTE processing.
-    if dev.passthrough {
-        drop(parsed_pkt);
-        postbox.post(port_key, pkt);
-        return None;
-    }
-
     let port = &dev.port;
 
     let res = port.process(Direction::In, parsed_pkt);
@@ -3650,13 +3628,6 @@ fn xde_rx_one_direct(
     } else {
         None
     };
-
-    // We are in passthrough mode, skip OPTE processing.
-    if dev.passthrough {
-        drop(parsed_pkt);
-        postbox.post(port_key, pkt);
-        return;
-    }
 
     let port = &dev.port;
 

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -1150,7 +1150,8 @@ fn create_xde(req: &CreateXdeReq) -> Result<NoResp, OpteError> {
             .clone()
     };
 
-    let cfg = VpcCfg::from(req.cfg.clone());
+    let mtu = req.mtu.unwrap_or(u32::from(ETHERNET_MTU));
+    let cfg = VpcCfg::with_mtu(req.cfg.clone(), mtu);
 
     // Because we hold the token, no one else will add to/remove from
     // the XdeDev map in parallel. Quickly check that there is no
@@ -1192,7 +1193,6 @@ fn create_xde(req: &CreateXdeReq) -> Result<NoResp, OpteError> {
     };
 
     let mut guest_addr = cfg.guest_mac.bytes();
-    let mtu = req.mtu.unwrap_or(u32::from(ETHERNET_MTU));
 
     let mut xde = Arc::new(XdeDev {
         devname: req.xde_devname.clone(),


### PR DESCRIPTION
This allows opteadm/sled-agent to define what the maximum MTU on a link will be on a per-port basis, which should be governed by some sense of control plane policy. I think that create-time is really the only time we can do this: assignment of max MTU (SDU in MAC parlance) happens as part of the call to `mac_register`, and in turn communication of MTU to a guest by viona is basically in a write-once register in the config space.

I think all that seems to need checking is that this is visible off the bat to viona via propolis, and that visibility holds whether or not the propolis is in a non-global zone.

Also closes #767.