### PR TITLE
Flow eviction and LFT/UFT lifecycle rework

### DIFF
--- a/lib/opte-test-utils/src/port_state.rs
+++ b/lib/opte-test-utils/src/port_state.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2025 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 //! Routines for verifying various Port state.
 
@@ -314,8 +314,10 @@ macro_rules! decr_na {
 /// assert the port state.
 #[macro_export]
 macro_rules! decr {
-    ($pav:expr, $fields:expr) => {
-        decr_na!($pav, $fields);
+    ($pav:expr, $fields_slice:expr) => {
+        for fields_str in &$fields_slice {
+            decr_na!($pav, fields_str);
+        }
         assert_port!($pav);
     };
 }

--- a/lib/opte/src/ddi/time.rs
+++ b/lib/opte/src/ddi/time.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2025 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 //! Moments, periodics, etc.
 use core::ops::Add;
@@ -27,7 +27,7 @@ pub const NANOS: u64 = 1_000_000_000;
 pub const NANOS_TO_MILLIS: u64 = 1_000_000;
 
 /// A moment in time.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Moment {
     #[cfg(all(not(feature = "std"), not(test)))]
     inner: ddi::hrtime_t,

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -151,37 +151,31 @@ pub trait FlowEntryInfo: fmt::Debug + Send + Sync {
 
 impl<S: FlowState> FlowEntryInfo for FlowEntry<S> {
     fn inherit_last_hit(&self, new_time: Moment) {
-        // The expectation right now is that this will be called within the
-        // port lock, so there will be no concurrent modification of the value.
-        let mut prior = self.lifetime.last_hit.load(Ordering::Relaxed);
         let new = new_time.raw_millis();
-        while new > prior {
-            if let Err(updated) = self.lifetime.last_hit.compare_exchange_weak(
-                prior,
-                new_time.raw_millis(),
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ) {
-                prior = updated
-            } else {
-                break;
-            }
-        }
+        // An error from the below call implies a concurrent modification with
+        // a time later than `new_time`. In that case there's just nothing left
+        // to do here.
+        _ = self.lifetime.last_hit.try_update(
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+            |prior| (prior < new).then_some(new),
+        );
     }
 
     fn eviction_priority(&self, now: Moment) -> Option<EvictionPriority> {
         let own_prio = self.policy.eviction_priority(self, now);
 
-        //
+        // An explicit signal that this flow is well-behaved wins outright.
         if let Some(EvictionPriority::Protected) = own_prio {
             return own_prio;
         }
-        // A priority of `None` is unevictable -- we don't have any
-        // information that tells us how poorly behaved.
+
+        // A priority of `None` tells us nothing, and will eventually resolve
+        // into `EvictionPriority::Protected` if no explicit priorities are
+        // provided.
         //
-        // If we have an explicit priority, we keep the *best*
-        // (lowest) priority which we know of. There should be at most
-        // one child in practice.
+        // If we have an explicit priority, we keep the most-protected (lowest)
+        // priority which we know of.
         let mut best_prio = own_prio;
         for maybe_child in &*self.lifetime.children.read() {
             if let Some(child) = maybe_child.0.upgrade() {
@@ -208,10 +202,10 @@ impl<S: FlowState> FlowEntryInfo for FlowEntry<S> {
 
     fn mark_evicted(&self) {
         if !self.lifetime.killed.swap(true, Ordering::Relaxed) {
-            // Any flow entry is only valid while all of its parents still exist.
-            // Timeout-driven expiry will not remove an entry while there are still
-            // live parents, but during eviction we need to go through and mark them
-            // as invalid in turn.
+            // Any flow entry is only valid while all of its parents still
+            // exist. Timeout-driven expiry will not remove an entry while there
+            // are still live parents, but during eviction we need to go through
+            // and mark them as invalid in turn.
             for maybe_child in &*self.lifetime.children.read() {
                 if let Some(child) = maybe_child.0.upgrade() {
                     child.mark_evicted();
@@ -266,7 +260,10 @@ impl<S: FlowState> FlowTable<S> {
         entry
     }
 
-    /// TODO
+    /// Add a new entry to the flow table, assigning it the same lifetime as
+    /// an existing entry in another table.
+    ///
+    /// As in [`Self::add_unchecked`], this elides the capacity check.
     pub fn add_unchecked_partner<T: FlowState>(
         &mut self,
         flow_id: InnerFlowId,
@@ -310,11 +307,11 @@ impl<S: FlowState> FlowTable<S> {
         let mut expired = vec![];
 
         self.map.retain(|flowid, entry| {
-            // A flow cannot be expired while it still has children relying upon
-            // its existence. We should also clear out any dangling entries at
-            // this time.
+            // A flow cannot be expired by the timer while it still has children
+            // relying upon its existence. Check whether any remain, and remove
+            // dangling references to child entries which have expired.
             {
-                // Since we have a write lock on the port, there shouldn't be
+                // We have a write lock on the port, so there shouldn't be
                 // contention here.
                 let mut children = entry.lifetime.children.write();
                 children.retain(|el| el.0.upgrade().is_some());
@@ -342,6 +339,10 @@ impl<S: FlowState> FlowTable<S> {
         expired
     }
 
+    /// Determine whether there is currently space for a new entry to be
+    /// inserted.
+    ///
+    /// If out of space, this method will attempt to evict an existing entry.
     pub fn check_for_space(&mut self) -> Result<()> {
         if self.map.len() < self.limit.get() as usize {
             return Ok(());
@@ -355,12 +356,18 @@ impl<S: FlowState> FlowTable<S> {
         }
     }
 
+    /// Select the flow entry most eligible for eviction (i.e., having the
+    /// numerically highest priority and the oldest timestamp).
+    ///
+    /// Entries which have been killed due to the loss of a dependency will be
+    /// used where possible.
     pub fn find_evictable_entry(&self) -> Option<(InnerFlowId, &FlowEntry<S>)> {
         let now = Moment::now();
 
-        // TODO(ky): some form of datastructure to accelerate?
+        // TODO: some form of datastructure to accelerate this?
         // Who would be responsible for keeping that up to date?
-        // If this cache is wrong, we're just hitting the O(n) scan anyhow?
+        // If that cache is wrong, we're just hitting the O(n) scan anyhow.
+
         let mut to_evict = None;
         for (key, entry) in self.map.iter() {
             if entry.is_killed() {
@@ -494,12 +501,16 @@ pub trait Dump: fmt::Debug + Send + Sync {
     fn dump(&self, hits: u64) -> Self::DumpVal;
 }
 
+/// Common functions needed from the interior state of a flow table entry.
 pub trait FlowState: Dump {
+    /// Return an iterator containing references to all flow entries from other
+    /// tables which underpin `self`.
     fn parents(&self) -> impl Iterator<Item = Arc<dyn FlowEntryInfo>> {
         [].into_iter()
     }
 }
 
+/// Lifecycle state for a flow entry or set of interlinked flow entries.
 struct FlowLifetime {
     /// This tracks the last time the flow was matched.
     ///
@@ -529,6 +540,7 @@ impl fmt::Debug for FlowLifetime {
     }
 }
 
+/// Helper newtype to deduplicate child flow entries by address.
 struct ByAddr(Weak<dyn FlowEntryInfo>);
 
 impl PartialEq for ByAddr {
@@ -554,6 +566,7 @@ impl PartialOrd for ByAddr {
 /// The FlowEntry holds any arbitrary state type `S`.
 #[derive(Debug)]
 pub struct FlowEntry<S: FlowState> {
+    /// The 5-tuple of this flow, used as the lookup key in the parent map.
     id: InnerFlowId,
 
     state: S,
@@ -561,6 +574,7 @@ pub struct FlowEntry<S: FlowState> {
     /// Number of times this flow has been matched.
     hits: AtomicU64,
 
+    /// State determining whether this flow can be expired or evicted.
     lifetime: Arc<FlowLifetime>,
 
     /// Records whether this flow predates a rule change, and
@@ -692,6 +706,9 @@ impl Dump for () {
     fn dump(&self, _hits: u64) {}
 }
 
+impl FlowState for () {}
+
+/// A score of how likely we are to evict a given flow.
 enum EvictionKey {
     Dead,
     Evictable(EvictionPriority, Moment),
@@ -707,8 +724,6 @@ mod test {
     use core::time::Duration;
 
     pub const FT_SIZE: Option<NonZeroU32> = NonZeroU32::new(16);
-
-    impl FlowState for () {}
 
     #[test]
     fn flow_expired() {

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -151,7 +151,7 @@ pub trait FlowEntryInfo: fmt::Debug + Send + Sync {
 
 impl<S: FlowState> FlowEntryInfo for FlowEntry<S> {
     fn inherit_last_hit(&self, new_time: Moment) {
-        let new = new_time.raw_millis();
+        let new = new_time.raw();
         // An error from the below call implies a concurrent modification with
         // a time later than `new_time`. In that case there's just nothing left
         // to do here.
@@ -392,7 +392,8 @@ impl<S: FlowState> FlowTable<S> {
                     ))
                 }
                 Some((EvictionKey::Evictable(curr_prio, curr_time), ..))
-                    if prio >= curr_prio && last_hit < curr_time =>
+                    if prio > curr_prio
+                        || (prio == curr_prio && last_hit < curr_time) =>
                 {
                     to_evict = Some((
                         EvictionKey::Evictable(prio, last_hit),
@@ -700,14 +701,6 @@ unsafe extern "C" {
     );
 }
 
-impl Dump for () {
-    type DumpVal = ();
-
-    fn dump(&self, _hits: u64) {}
-}
-
-impl FlowState for () {}
-
 /// A score of how likely we are to evict a given flow.
 enum EvictionKey {
     Dead,
@@ -722,6 +715,29 @@ mod test {
     use crate::engine::packet::AddrPair;
     use crate::engine::packet::FLOW_ID_DEFAULT;
     use core::time::Duration;
+
+    impl Dump for () {
+        type DumpVal = ();
+
+        fn dump(&self, _hits: u64) {}
+    }
+
+    impl FlowState for () {}
+
+    #[derive(Debug, Clone)]
+    struct ParentSet(Vec<Arc<dyn FlowEntryInfo>>);
+
+    impl Dump for ParentSet {
+        type DumpVal = ();
+
+        fn dump(&self, _hits: u64) {}
+    }
+
+    impl FlowState for ParentSet {
+        fn parents(&self) -> impl Iterator<Item = Arc<dyn FlowEntryInfo>> {
+            self.0.iter().cloned()
+        }
+    }
 
     pub const FT_SIZE: Option<NonZeroU32> = NonZeroU32::new(16);
 
@@ -829,6 +845,41 @@ mod test {
     }
 
     #[test]
+    fn timer_expiry_propagation() {
+        let flowid = InnerFlowId {
+            proto: Protocol::TCP.into(),
+            addrs: AddrPair::V4 {
+                src: "192.168.2.10".parse().unwrap(),
+                dst: "76.76.21.21".parse().unwrap(),
+            },
+            proto_info: PortInfo { src_port: 37890, dst_port: 443 }.into(),
+        };
+
+        let mut ft1 =
+            FlowTable::new("port", "parent-table", FT_SIZE.unwrap(), None);
+        let mut ft2 =
+            FlowTable::new("port", "child-table", FT_SIZE.unwrap(), None);
+        let fe1 = ft1.add(flowid, ()).unwrap();
+        let fe2 =
+            ft2.add(flowid, ParentSet(vec![fe1.clone() as Arc<_>])).unwrap();
+
+        let t1 = fe2.last_hit();
+        fe1.push_child(&(fe2.clone() as Arc<dyn FlowEntryInfo>));
+
+        // Updating the last-hit time of a flow won't immediately propagate to
+        // its children.
+        let t2 = t1 + Duration::from_secs(10);
+        fe2.hit_at(t2);
+        assert!(fe1.last_hit() <= t1);
+
+        // When fe2 is expired, it should pass on its expiry time to fe1.
+        let t3 = t2 + Duration::new(FLOW_DEF_EXPIRE_SECS, 0);
+        ft2.expire_flows(t3, |_| FLOW_ID_DEFAULT);
+        assert_eq!(ft2.num_flows(), 0);
+        assert_eq!(fe1.last_hit(), t2);
+    }
+
+    #[test]
     fn eviction_basics() {
         let flowid = InnerFlowId {
             proto: Protocol::TCP.into(),
@@ -884,6 +935,61 @@ mod test {
     }
 
     #[test]
+    fn eviction_selects_highest_prio() {
+        let flowid = InnerFlowId {
+            proto: Protocol::TCP.into(),
+            addrs: AddrPair::V4 {
+                src: "192.168.2.10".parse().unwrap(),
+                dst: "76.76.21.21".parse().unwrap(),
+            },
+            proto_info: PortInfo { src_port: 37890, dst_port: 443 }.into(),
+        };
+
+        let sacrificial_flow = InnerFlowId {
+            proto: Protocol::UDP.into(),
+            addrs: AddrPair::V4 {
+                src: "192.168.2.10".parse().unwrap(),
+                dst: "76.76.21.21".parse().unwrap(),
+            },
+            proto_info: PortInfo { src_port: 5, dst_port: 443 }.into(),
+        };
+
+        let mut evict_ft = FlowTable::new(
+            "port",
+            "prio-table",
+            FT_SIZE.unwrap(),
+            Some(Arc::new(FixedPolicy {
+                time: Duration::from_secs(FLOW_DEF_EXPIRE_SECS),
+                default: Some(EvictionPriority::Evictable(NonZeroU16::MIN)),
+                manual: vec![(
+                    sacrificial_flow,
+                    EvictionPriority::Evictable(16.try_into().unwrap()),
+                )]
+                .into_iter()
+                .collect(),
+            })),
+        );
+        for i in 0..evict_ft.limit.get() {
+            let new_id = InnerFlowId {
+                proto: Protocol::UDP.into(),
+                addrs: AddrPair::V4 {
+                    src: "192.168.2.10".parse().unwrap(),
+                    dst: "76.76.21.21".parse().unwrap(),
+                },
+                proto_info: PortInfo { src_port: i as u16, dst_port: 443 }
+                    .into(),
+            };
+            evict_ft.add(new_id, ()).unwrap();
+        }
+
+        // On a table where every flow is evictable, we can!
+        assert!(evict_ft.map.contains_key(&sacrificial_flow));
+        assert!(evict_ft.add(flowid, ()).is_ok());
+        assert_eq!(evict_ft.num_flows(), FT_SIZE.unwrap().get());
+        assert!(!evict_ft.map.contains_key(&sacrificial_flow));
+    }
+
+    #[test]
     fn eviction_invalidates_descendents() {
         let flowid = InnerFlowId {
             proto: Protocol::TCP.into(),
@@ -918,5 +1024,89 @@ mod test {
         assert!(fe2.is_killed());
         assert!(fe3.is_killed());
         assert!(!fe_out_of_chain.is_killed());
+    }
+
+    #[test]
+    fn eviction_priority_inheritance() {
+        let flowid = InnerFlowId {
+            proto: Protocol::UDP.into(),
+            addrs: AddrPair::V4 {
+                src: "192.168.2.10".parse().unwrap(),
+                dst: "76.76.21.21".parse().unwrap(),
+            },
+            proto_info: PortInfo { src_port: 37890, dst_port: 443 }.into(),
+        };
+
+        let mut ft1 =
+            FlowTable::new("port", "parent-table", FT_SIZE.unwrap(), None);
+        let mut ft2 = FlowTable::new(
+            "port",
+            "child-table",
+            FT_SIZE.unwrap(),
+            Some(Arc::new(FixedPolicy {
+                time: Duration::from_secs(FLOW_DEF_EXPIRE_SECS),
+                default: Some(EvictionPriority::Evictable(NonZeroU16::MAX)),
+                manual: Default::default(),
+            })),
+        );
+        let mut ft2_2 = FlowTable::new(
+            "port",
+            "other-child-table",
+            FT_SIZE.unwrap(),
+            Some(Arc::new(FixedPolicy {
+                time: Duration::from_secs(FLOW_DEF_EXPIRE_SECS),
+                default: Some(EvictionPriority::Evictable(NonZeroU16::MIN)),
+                manual: Default::default(),
+            })),
+        );
+        let mut ft2_3 = FlowTable::new(
+            "port",
+            "other-other-child-table",
+            FT_SIZE.unwrap(),
+            Some(Arc::new(FixedPolicy {
+                time: Duration::from_secs(FLOW_DEF_EXPIRE_SECS),
+                default: Some(EvictionPriority::Protected),
+                manual: Default::default(),
+            })),
+        );
+
+        let fe1 = ft1.add(flowid, ()).unwrap();
+        let fe2 = ft2.add(flowid, ()).unwrap();
+        let fe2_2 = ft2_2.add(flowid, ()).unwrap();
+        let fe2_3 = ft2_3.add(flowid, ()).unwrap();
+
+        // By default, we have no entry expressing a preference.
+        let now = fe2_3.last_hit();
+        assert_eq!(fe1.eviction_priority(now), None);
+
+        // When an explicit priority is requested by any descendent, we choose the
+        // strongest requirement that the flow remain in place. Each flow we push
+        // here makes the flow less likely for eviction.
+        fe1.push_child(&(fe2.clone() as Arc<dyn FlowEntryInfo>));
+        assert_eq!(
+            fe1.eviction_priority(now),
+            Some(EvictionPriority::Evictable(NonZeroU16::MAX)),
+        );
+
+        fe1.push_child(&(fe2_2.clone() as Arc<dyn FlowEntryInfo>));
+        assert_eq!(
+            fe1.eviction_priority(now),
+            Some(EvictionPriority::Evictable(NonZeroU16::MIN)),
+        );
+
+        fe1.push_child(&(fe2_3.clone() as Arc<dyn FlowEntryInfo>));
+        assert_eq!(
+            fe1.eviction_priority(now),
+            Some(EvictionPriority::Protected),
+        );
+
+        // Removal of any entry (i.e., because that entry expired) should result
+        // in a corresponding change to the flow priority.
+        fe1.remove_child(&(fe2_3 as Arc<dyn FlowEntryInfo>));
+        fe1.remove_child(&(fe2_2 as Arc<dyn FlowEntryInfo>));
+        assert_eq!(
+            fe1.eviction_priority(now),
+            Some(EvictionPriority::Evictable(NonZeroU16::MAX)),
+        );
     }
 }

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2025 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 //! The flow table implementation.
 //!
@@ -10,15 +10,18 @@
 //! tables: UFT, LFT, and the TCP Flow Table.
 
 use super::packet::InnerFlowId;
+use crate::ddi::sync::KRwLock;
 use crate::ddi::time::MILLIS;
 use crate::ddi::time::Moment;
-use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
+use alloc::collections::BTreeSet;
 use alloc::ffi::CString;
 use alloc::string::String;
 use alloc::sync::Arc;
+use alloc::sync::Weak;
 use alloc::vec::Vec;
 use core::fmt;
+use core::num::NonZeroU16;
 use core::num::NonZeroU32;
 use core::sync::atomic::AtomicBool;
 use core::sync::atomic::AtomicU64;
@@ -63,52 +66,173 @@ impl Ttl {
     }
 }
 
+/// A metric of how stale a flow entry is, used to determine whether
+/// any existing entry can be evicted to make room for a new one.
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Default)]
+pub enum EvictionPriority {
+    /// The flow is not eligible for eviction.
+    #[default]
+    Protected,
+    /// The flow entry may be evicted to make room for a new one.
+    ///
+    /// A numerically larger priority is more eligible for eviction.
+    Evictable(NonZeroU16),
+}
+
 /// A policy for expiring flow table entries over time.
-pub trait ExpiryPolicy<S: Dump>: fmt::Debug + Send + Sync {
+pub trait ExpiryPolicy<S: FlowState>: fmt::Debug + Send + Sync {
     /// Returns whether the given flow should be removed, given current flow
     /// state, the time a packet was last received, and the current time.
     fn is_expired(&self, entry: &FlowEntry<S>, now: Moment) -> bool;
+
+    /// Returns whether a given flow can be evicted in favour of a new one
+    /// prior to its expiry time.
+    ///
+    /// If so, this function will return `Some(priority)` -- a higher priority
+    /// is more eligible to be evicted.
+    fn eviction_priority(
+        &self,
+        entry: &FlowEntry<S>,
+        now: Moment,
+    ) -> Option<EvictionPriority>;
 }
 
-impl<S: Dump> ExpiryPolicy<S> for Ttl {
+impl<S: FlowState> ExpiryPolicy<S> for Ttl {
     fn is_expired(&self, entry: &FlowEntry<S>, now: Moment) -> bool {
-        entry.is_expired(now, *self)
+        self.is_expired(entry.last_hit(), now)
+    }
+
+    fn eviction_priority(
+        &self,
+        entry: &FlowEntry<S>,
+        _now: Moment,
+    ) -> Option<EvictionPriority> {
+        // TCP flows are expected to have a `TcpFlowEntryState` registered as
+        // a child or ancestor. If present, this will reduce the eviction
+        // priority to a level appropriate to how long the flow has been in its
+        // current state. Otherwise we should assume the flow has closed and
+        // that this entry is unneeded.
+        //
+        // Other flows in these tables have no additional context to suggest
+        // that they are lingering too long in a given state.
+        match entry.id().protocol() {
+            opte_api::Protocol::TCP => {
+                Some(EvictionPriority::Evictable(NonZeroU16::MAX))
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Methods of a [`FlowEntry`] called on related flows across table boundaries.
+///
+/// This is only intended to be implemented by [`FlowEntry`], but must be a
+/// trait as the state type parameter `S: `[`FlowState`] differs on a table by
+/// table basis.
+pub trait FlowEntryInfo: fmt::Debug + Send + Sync {
+    /// Set the last hit time on this entry to `new_time` if it is later
+    /// than the stored value.
+    fn inherit_last_hit(&self, new_time: Moment);
+
+    /// Determine whether this flow entry can be evicted to make room for
+    /// another, recursively checking all children when needed.
+    fn eviction_priority(&self, now: Moment) -> Option<EvictionPriority>;
+
+    /// Set `self` as a parent node to `child`.
+    fn push_child(&self, child: &Arc<dyn FlowEntryInfo>);
+
+    /// Remove `child` from this entry's list of children.
+    fn remove_child(&self, child: &Arc<dyn FlowEntryInfo>);
+
+    /// Mark this flow entry, and all those which depend on it for validity,
+    /// as being invalid.
+    fn mark_evicted(&self);
+}
+
+impl<S: FlowState> FlowEntryInfo for FlowEntry<S> {
+    fn inherit_last_hit(&self, new_time: Moment) {
+        // The expectation right now is that this will be called within the
+        // port lock, so there will be no concurrent modification of the value.
+        let mut prior = self.lifetime.last_hit.load(Ordering::Relaxed);
+        let new = new_time.raw_millis();
+        while new > prior {
+            if let Err(updated) = self.lifetime.last_hit.compare_exchange_weak(
+                prior,
+                new_time.raw_millis(),
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                prior = updated
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn eviction_priority(&self, now: Moment) -> Option<EvictionPriority> {
+        let own_prio = self.policy.eviction_priority(self, now);
+
+        //
+        if let Some(EvictionPriority::Protected) = own_prio {
+            return own_prio;
+        }
+        // A priority of `None` is unevictable -- we don't have any
+        // information that tells us how poorly behaved.
+        //
+        // If we have an explicit priority, we keep the *best*
+        // (lowest) priority which we know of. There should be at most
+        // one child in practice.
+        let mut best_prio = own_prio;
+        for maybe_child in &*self.lifetime.children.read() {
+            if let Some(child) = maybe_child.0.upgrade() {
+                match (best_prio, child.eviction_priority(now)) {
+                    (None, a) => best_prio = a,
+                    (Some(_), None) => {}
+                    (Some(old), Some(new)) => best_prio = Some(new.min(old)),
+                }
+            }
+        }
+
+        best_prio
+    }
+
+    fn push_child(&self, child: &Arc<dyn FlowEntryInfo>) {
+        let mut children = self.lifetime.children.write();
+        children.insert(ByAddr(Arc::downgrade(child)));
+    }
+
+    fn remove_child(&self, child: &Arc<dyn FlowEntryInfo>) {
+        let mut children = self.lifetime.children.write();
+        children.remove(&ByAddr(Arc::downgrade(child)));
+    }
+
+    fn mark_evicted(&self) {
+        if !self.lifetime.killed.swap(true, Ordering::Relaxed) {
+            // Any flow entry is only valid while all of its parents still exist.
+            // Timeout-driven expiry will not remove an entry while there are still
+            // live parents, but during eviction we need to go through and mark them
+            // as invalid in turn.
+            for maybe_child in &*self.lifetime.children.read() {
+                if let Some(child) = maybe_child.0.upgrade() {
+                    child.mark_evicted();
+                }
+            }
+        }
     }
 }
 
 pub type FlowTableDump<T> = Vec<(InnerFlowId, T)>;
 
 #[derive(Debug)]
-pub struct FlowTable<S: Dump> {
+pub struct FlowTable<S: FlowState> {
     port_c: CString,
     name_c: CString,
     limit: NonZeroU32,
-    policy: Box<dyn ExpiryPolicy<S>>,
+    policy: Arc<dyn ExpiryPolicy<S>>,
     map: BTreeMap<InnerFlowId, Arc<FlowEntry<S>>>,
 }
 
-impl<S> FlowTable<S>
-where
-    S: fmt::Debug + Dump,
-{
-    /// Add a new entry to the flow table.
-    ///
-    /// # Errors
-    ///
-    /// If the table is at max capacity, an error is returned and no
-    /// modification is made to the table.
-    ///
-    /// If an entry already exists for this flow, it is overwritten.
-    pub fn add(&mut self, flow_id: InnerFlowId, state: S) -> Result<()> {
-        if self.map.len() == self.limit.get() as usize {
-            return Err(OpteError::MaxCapacity(self.limit.get() as u64));
-        }
-
-        let entry = FlowEntry::new(state);
-        self.map.insert(flow_id, entry.into());
-        Ok(())
-    }
-
+impl<S: FlowState> FlowTable<S> {
     /// Add a new entry to the flow table, returning a shared refrence to
     /// the entry.
     ///
@@ -118,26 +242,42 @@ where
     /// modification is made to the table.
     ///
     /// If an entry already exists for this flow, it is overwritten.
-    pub fn add_and_return(
+    pub fn add(
         &mut self,
         flow_id: InnerFlowId,
         state: S,
     ) -> Result<Arc<FlowEntry<S>>> {
-        if self.map.len() == self.limit.get() as usize {
-            return Err(OpteError::MaxCapacity(self.limit.get() as u64));
-        }
-
-        let entry = Arc::new(FlowEntry::new(state));
-        self.map.insert(flow_id, entry.clone());
+        self.check_for_space()?;
+        let entry = Arc::new(FlowEntry::new(flow_id, state, self));
+        self.map.insert(flow_id, Arc::clone(&entry));
         Ok(entry)
     }
 
     /// Add a new entry to the flow table while eliding the capacity check.
     ///
     /// This is meant for table implementations that enforce their own limit.
-    pub fn add_unchecked(&mut self, flow_id: InnerFlowId, state: S) {
-        let entry = FlowEntry::new(state);
-        self.map.insert(flow_id, entry.into());
+    pub fn add_unchecked(
+        &mut self,
+        flow_id: InnerFlowId,
+        state: S,
+    ) -> Arc<FlowEntry<S>> {
+        let entry = Arc::new(FlowEntry::new(flow_id, state, self));
+        self.map.insert(flow_id, Arc::clone(&entry));
+        entry
+    }
+
+    /// TODO
+    pub fn add_unchecked_partner<T: FlowState>(
+        &mut self,
+        flow_id: InnerFlowId,
+        state: S,
+        partner: &FlowEntry<T>,
+    ) -> Arc<FlowEntry<S>> {
+        let mut entry = FlowEntry::new(flow_id, state, self);
+        entry.lifetime = Arc::clone(&partner.lifetime);
+        let entry = Arc::new(entry);
+        self.map.insert(flow_id, Arc::clone(&entry));
+        entry
     }
 
     // Clear all entries from the flow table.
@@ -155,7 +295,10 @@ where
 
     pub fn expire(&mut self, flowid: &InnerFlowId) {
         flow_expired_probe(&self.port_c, &self.name_c, flowid, None, None);
-        self.map.remove(flowid);
+        if let Some(entry) = self.map.remove(flowid) {
+            entry.propagate_last_hit();
+            entry.mark_evicted();
+        }
     }
 
     pub fn expire_flows<F>(&mut self, now: Moment, f: F) -> Vec<InnerFlowId>
@@ -167,22 +310,94 @@ where
         let mut expired = vec![];
 
         self.map.retain(|flowid, entry| {
-            if self.policy.is_expired(entry, now) {
+            // A flow cannot be expired while it still has children relying upon
+            // its existence. We should also clear out any dangling entries at
+            // this time.
+            {
+                // Since we have a write lock on the port, there shouldn't be
+                // contention here.
+                let mut children = entry.lifetime.children.write();
+                children.retain(|el| el.0.upgrade().is_some());
+                if !children.is_empty() {
+                    return true;
+                }
+            }
+            if entry.is_expired(now) {
+                let my_time = entry.last_hit();
                 flow_expired_probe(
                     port_c,
                     name_c,
                     flowid,
-                    Some(entry.last_hit.load(Ordering::Relaxed)),
+                    Some(my_time.raw_millis()),
                     Some(now.raw_millis()),
                 );
+                entry.propagate_last_hit();
                 expired.push(f(entry.state()));
                 return false;
             }
 
-            true
+            !entry.is_killed()
         });
 
         expired
+    }
+
+    pub fn check_for_space(&mut self) -> Result<()> {
+        if self.map.len() < self.limit.get() as usize {
+            return Ok(());
+        }
+
+        if let Some((key, _)) = self.find_evictable_entry() {
+            self.expire(&key);
+            Ok(())
+        } else {
+            Err(OpteError::MaxCapacity(self.limit.get() as u64))
+        }
+    }
+
+    pub fn find_evictable_entry(&self) -> Option<(InnerFlowId, &FlowEntry<S>)> {
+        let now = Moment::now();
+
+        // TODO(ky): some form of datastructure to accelerate?
+        // Who would be responsible for keeping that up to date?
+        // If this cache is wrong, we're just hitting the O(n) scan anyhow?
+        let mut to_evict = None;
+        for (key, entry) in self.map.iter() {
+            if entry.is_killed() {
+                to_evict = Some((EvictionKey::Dead, *key, entry));
+                break;
+            }
+
+            // If we have no information, then default to preserving the flow.
+            let prio = entry.eviction_priority(now).unwrap_or_default();
+            if let EvictionPriority::Protected = prio {
+                continue;
+            }
+
+            let last_hit = entry.last_hit();
+
+            match to_evict {
+                None => {
+                    to_evict = Some((
+                        EvictionKey::Evictable(prio, last_hit),
+                        *key,
+                        entry,
+                    ))
+                }
+                Some((EvictionKey::Evictable(curr_prio, curr_time), ..))
+                    if prio >= curr_prio && last_hit < curr_time =>
+                {
+                    to_evict = Some((
+                        EvictionKey::Evictable(prio, last_hit),
+                        *key,
+                        entry,
+                    ));
+                }
+                Some(_) => {}
+            }
+        }
+
+        to_evict.map(|(_, k, v)| (k, v.as_ref()))
     }
 
     /// Get the maximum number of entries this flow table may hold.
@@ -190,10 +405,11 @@ where
         self.limit
     }
 
-    /// Get a reference to the flow entry for a given flow, if one
-    /// exists.
+    /// Get a reference to the flow entry for a given flow, if one exists.
     pub fn get(&self, flow_id: &InnerFlowId) -> Option<&Arc<FlowEntry<S>>> {
-        self.map.get(flow_id)
+        // Flows which are marked as `killed` no longer really exist, but they
+        // have not yet been reaped.
+        self.map.get(flow_id).and_then(|v| (!v.is_killed()).then_some(v))
     }
 
     /// Mark all flow table entries as requiring revalidation after a
@@ -211,9 +427,9 @@ where
         port: &str,
         name: &str,
         limit: NonZeroU32,
-        policy: Option<Box<dyn ExpiryPolicy<S>>>,
+        policy: Option<Arc<dyn ExpiryPolicy<S>>>,
     ) -> FlowTable<S> {
-        let policy = policy.unwrap_or_else(|| Box::new(FLOW_DEF_TTL));
+        let policy = policy.unwrap_or_else(|| Arc::new(FLOW_DEF_TTL));
 
         Self {
             port_c: CString::new(port).unwrap(),
@@ -231,6 +447,12 @@ where
 
     pub fn remove(&mut self, flow: &InnerFlowId) -> Option<Arc<FlowEntry<S>>> {
         self.map.remove(flow)
+    }
+
+    pub fn iter(
+        &self,
+    ) -> impl Iterator<Item = (&InnerFlowId, &Arc<FlowEntry<S>>)> {
+        self.map.iter()
     }
 }
 
@@ -266,34 +488,95 @@ fn flow_expired_probe(
 
 /// A type that can be "dumped" for the purposes of presenting an
 /// external view into internal state of the [`FlowEntry<T>`].
-pub trait Dump {
+pub trait Dump: fmt::Debug + Send + Sync {
     type DumpVal: DeserializeOwned + Serialize;
 
     fn dump(&self, hits: u64) -> Self::DumpVal;
 }
 
-/// The FlowEntry holds any arbitrary state type `S`.
-#[derive(Debug)]
-pub struct FlowEntry<S: Dump> {
-    state: S,
+pub trait FlowState: Dump {
+    fn parents(&self) -> impl Iterator<Item = Arc<dyn FlowEntryInfo>> {
+        [].into_iter()
+    }
+}
 
-    /// Number of times this flow has been matched.
-    hits: AtomicU64,
-
+struct FlowLifetime {
     /// This tracks the last time the flow was matched.
     ///
     /// These are raw u64s sourced from a `Moment`, which tracks time
     /// in nanoseconds.
     last_hit: AtomicU64,
 
+    /// Whether this flow entry has been explicitly removed.
+    killed: AtomicBool,
+
+    /// Entries in remote tables which rely on the continued existence of
+    /// this flow.
+    ///
+    /// Child entries can also provide a flow with a measure of whether
+    /// it is eligible for eviction.
+    children: KRwLock<BTreeSet<ByAddr>>,
+}
+
+impl fmt::Debug for FlowLifetime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let FlowLifetime { last_hit, killed, children: _ } = self;
+        f.debug_struct("FlowEntry")
+            .field("last_hit", last_hit)
+            .field("killed", killed)
+            .field("children", &"<lock>")
+            .finish()
+    }
+}
+
+struct ByAddr(Weak<dyn FlowEntryInfo>);
+
+impl PartialEq for ByAddr {
+    fn eq(&self, other: &Self) -> bool {
+        core::ptr::addr_eq(self.0.as_ptr(), other.0.as_ptr())
+    }
+}
+
+impl Eq for ByAddr {}
+
+impl Ord for ByAddr {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.0.as_ptr().cast::<()>().cmp(&other.0.as_ptr().cast::<()>())
+    }
+}
+
+impl PartialOrd for ByAddr {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// The FlowEntry holds any arbitrary state type `S`.
+#[derive(Debug)]
+pub struct FlowEntry<S: FlowState> {
+    id: InnerFlowId,
+
+    state: S,
+
+    /// Number of times this flow has been matched.
+    hits: AtomicU64,
+
+    lifetime: Arc<FlowLifetime>,
+
     /// Records whether this flow predates a rule change, and
     /// must rerun rule processing before `state` can be used.
     dirty: AtomicBool,
+
+    policy: Arc<dyn ExpiryPolicy<S>>,
 }
 
-impl<S: Dump> FlowEntry<S> {
+impl<S: FlowState> FlowEntry<S> {
     fn dump(&self) -> S::DumpVal {
         self.state.dump(self.hits.load(Ordering::Relaxed))
+    }
+
+    pub fn id(&self) -> &InnerFlowId {
+        &self.id
     }
 
     pub fn state_mut(&mut self) -> &mut S {
@@ -325,7 +608,7 @@ impl<S: Dump> FlowEntry<S> {
     /// the port lock.**
     pub(crate) fn hit_at(&self, now: Moment) {
         self.hits.fetch_add(1, Ordering::Relaxed);
-        self.last_hit.store(now.raw(), Ordering::Relaxed);
+        self.lifetime.last_hit.store(now.raw(), Ordering::Relaxed);
     }
 
     pub fn is_dirty(&self) -> bool {
@@ -341,19 +624,41 @@ impl<S: Dump> FlowEntry<S> {
     }
 
     pub fn last_hit(&self) -> Moment {
-        Moment::from_raw_nanos(self.last_hit.load(Ordering::Relaxed))
+        Moment::from_raw_nanos(self.lifetime.last_hit.load(Ordering::Relaxed))
     }
 
-    fn is_expired(&self, now: Moment, ttl: Ttl) -> bool {
-        ttl.is_expired(self.last_hit(), now)
+    /// Returns whether this flow entry has explicitly been marked as invalid
+    /// (e.g., one of its ancestors has been evicted).
+    fn is_killed(&self) -> bool {
+        self.lifetime.killed.load(Ordering::Relaxed)
     }
 
-    fn new(state: S) -> Self {
+    /// Returns whether this flow entry is past its policy's expiry time.
+    fn is_expired(&self, now: Moment) -> bool {
+        self.policy.is_expired(self, now)
+    }
+
+    /// Update the last hit time of this flow entry's parents if it has been
+    /// used more recently.
+    fn propagate_last_hit(&self) {
+        let my_time = self.last_hit();
+        for parent in self.state.parents() {
+            parent.inherit_last_hit(my_time);
+        }
+    }
+
+    fn new(id: InnerFlowId, state: S, in_table: &FlowTable<S>) -> Self {
         FlowEntry {
+            id,
             state,
             hits: 0.into(),
-            last_hit: Moment::now().raw().into(),
             dirty: false.into(),
+            policy: Arc::clone(&in_table.policy),
+            lifetime: Arc::new(FlowLifetime {
+                last_hit: Moment::now().raw().into(),
+                killed: false.into(),
+                children: KRwLock::new(BTreeSet::new()),
+            }),
         }
     }
 }
@@ -387,6 +692,11 @@ impl Dump for () {
     fn dump(&self, _hits: u64) {}
 }
 
+enum EvictionKey {
+    Dead,
+    Evictable(EvictionPriority, Moment),
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -397,6 +707,8 @@ mod test {
     use core::time::Duration;
 
     pub const FT_SIZE: Option<NonZeroU32> = NonZeroU32::new(16);
+
+    impl FlowState for () {}
 
     #[test]
     fn flow_expired() {

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -705,6 +705,65 @@ enum EvictionKey {
     Evictable(EvictionPriority, Moment),
 }
 
+pub mod util {
+    use std::num::NonZeroU16;
+
+    /// Choose a priority value between `start_prio..=end_prio`
+    /// based on `delta_ms`'s position between two timestamps.
+    ///
+    /// Returns `None` if start > end. Clamps to `start_prio` when delta
+    /// is before the time range, and to `end_prio` when delta falls after it.
+    pub fn priority_lerp(
+        start_time_ms: u64,
+        start_prio: NonZeroU16,
+        end_time_ms: u64,
+        end_prio: NonZeroU16,
+        delta_ms: u64,
+    ) -> Option<NonZeroU16> {
+        if start_time_ms > end_time_ms || end_prio < start_prio {
+            return None;
+        }
+
+        Some(if delta_ms <= start_time_ms {
+            start_prio
+        } else if delta_ms >= end_time_ms {
+            end_prio
+        } else {
+            // Compute our priority using fixed point arithmetic.
+            // Since we're working in terms of 16-bit numbers, we need as
+            // many bits of fractional precision between 0.0 and 1.0.
+            const SCALE: u64 = 16;
+            const ONE_SCALED: u64 = 1 << SCALE;
+            const FRACTION_MASK: u64 = ONE_SCALED - 1;
+
+            debug_assert_eq!(FRACTION_MASK.count_ones(), SCALE as u32);
+            debug_assert_eq!(
+                FRACTION_MASK.leading_zeros(),
+                u64::BITS - (SCALE as u32)
+            );
+
+            // Fixed-point division of a real by an integer is fairly
+            // straightforward -- don't convert the denominator into the
+            // target base.
+            let inner_pos = (delta_ms - start_time_ms) << SCALE;
+            let window_len = end_time_ms - start_time_ms;
+
+            let inner_frac = inner_pos / window_len;
+
+            let n_entries = u64::from(end_prio.get() - start_prio.get());
+
+            let entry_fixed_pt = n_entries * inner_frac;
+
+            let round_up = entry_fixed_pt & FRACTION_MASK >= ONE_SCALED / 2;
+            let entry = u16::try_from(entry_fixed_pt >> SCALE)
+                .expect("start and end points of lerp are both u16s")
+                + u16::from(round_up);
+
+            start_prio.saturating_add(entry)
+        })
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -1174,4 +1174,69 @@ mod test {
             Some(EvictionPriority::Evictable(NonZeroU16::MAX)),
         );
     }
+
+    #[test]
+    fn priority_lerp() {
+        let low = 10.try_into().unwrap();
+        let high = 20.try_into().unwrap();
+
+        assert_eq!(
+            util::priority_lerp(500, low, 1_000, high, 750),
+            Some(15.try_into().unwrap()),
+        );
+
+        // Double check rounding.
+        assert_eq!(
+            util::priority_lerp(500, low, 1_000, high, 975),
+            Some(19.try_into().unwrap()),
+        );
+
+        assert_eq!(util::priority_lerp(500, low, 1_000, high, 976), Some(high));
+
+        // Show we don't shoot past [low, high] at boundaries.
+        assert_eq!(util::priority_lerp(500, low, 1_000, high, 501), Some(low));
+
+        assert_eq!(util::priority_lerp(500, low, 1_000, high, 999), Some(high));
+    }
+
+    #[test]
+    fn priority_lerp_clamps() {
+        let low = 10.try_into().unwrap();
+        let high = 20.try_into().unwrap();
+
+        assert_eq!(util::priority_lerp(500, low, 1_000, high, 200), Some(low));
+
+        assert_eq!(
+            util::priority_lerp(500, low, 1_000, high, 10_000),
+            Some(high),
+        );
+    }
+
+    #[test]
+    fn priority_lerp_rejects_bad_params() {
+        // Start > end time is an illegal parameter choice.
+        assert_eq!(
+            util::priority_lerp(
+                1_000,
+                1.try_into().unwrap(),
+                500,
+                2.try_into().unwrap(),
+                750
+            ),
+            None
+        );
+
+        // We could support linear interpolation down from a higher to lower
+        // value, but have no reason to do so today.
+        assert_eq!(
+            util::priority_lerp(
+                0,
+                2.try_into().unwrap(),
+                10,
+                1.try_into().unwrap(),
+                5
+            ),
+            None
+        );
+    }
 }

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -506,9 +506,7 @@ pub trait Dump: fmt::Debug + Send + Sync {
 pub trait FlowState: Dump {
     /// Return an iterator containing references to all flow entries from other
     /// tables which underpin `self`.
-    fn parents(&self) -> impl Iterator<Item = Arc<dyn FlowEntryInfo>> {
-        [].into_iter()
-    }
+    fn parents(&self) -> impl Iterator<Item = Arc<dyn FlowEntryInfo>>;
 }
 
 /// Lifecycle state for a flow entry or set of interlinked flow entries.
@@ -722,7 +720,11 @@ mod test {
         fn dump(&self, _hits: u64) {}
     }
 
-    impl FlowState for () {}
+    impl FlowState for () {
+        fn parents(&self) -> impl Iterator<Item = Arc<dyn FlowEntryInfo>> {
+            [].into_iter()
+        }
+    }
 
     #[derive(Debug, Clone)]
     struct ParentSet(Vec<Arc<dyn FlowEntryInfo>>);

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -706,7 +706,7 @@ enum EvictionKey {
 }
 
 pub mod util {
-    use std::num::NonZeroU16;
+    use core::num::NonZeroU16;
 
     /// Choose a priority value between `start_prio..=end_prio`
     /// based on `delta_ms`'s position between two timestamps.

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -982,7 +982,11 @@ mod test {
             evict_ft.add(new_id, ()).unwrap();
         }
 
-        // On a table where every flow is evictable, we can!
+        // We've set this table up so that one of these flows will have a
+        // far higher eviction priority than its neighbours. This could
+        // be driven by protocol, by time, or some other aspect of flow state.
+        //
+        // This is the entry we will evict, regardless of the age of all others.
         assert!(evict_ft.map.contains_key(&sacrificial_flow));
         assert!(evict_ft.add(flowid, ()).is_ok());
         assert_eq!(evict_ft.num_flows(), FT_SIZE.unwrap().get());

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -725,6 +725,28 @@ mod test {
 
     pub const FT_SIZE: Option<NonZeroU32> = NonZeroU32::new(16);
 
+    #[derive(Debug, Clone)]
+    struct FixedPolicy {
+        time: Duration,
+        default: Option<EvictionPriority>,
+        manual: BTreeMap<InnerFlowId, EvictionPriority>,
+    }
+
+    impl<S: FlowState> ExpiryPolicy<S> for FixedPolicy {
+        fn is_expired(&self, entry: &FlowEntry<S>, now: Moment) -> bool {
+            entry.last_hit().delta_as_millis(now)
+                >= (self.time.as_millis() as u64)
+        }
+
+        fn eviction_priority(
+            &self,
+            entry: &FlowEntry<S>,
+            _now: Moment,
+        ) -> Option<EvictionPriority> {
+            self.manual.get(entry.id()).copied().or(self.default)
+        }
+    }
+
     #[test]
     fn flow_expired() {
         let flowid = InnerFlowId {
@@ -768,5 +790,133 @@ mod test {
         assert_eq!(ft.num_flows(), 1);
         ft.clear();
         assert_eq!(ft.num_flows(), 0);
+    }
+
+    #[test]
+    fn children_prevent_timer_expiry() {
+        let flowid = InnerFlowId {
+            proto: Protocol::TCP.into(),
+            addrs: AddrPair::V4 {
+                src: "192.168.2.10".parse().unwrap(),
+                dst: "76.76.21.21".parse().unwrap(),
+            },
+            proto_info: PortInfo { src_port: 37890, dst_port: 443 }.into(),
+        };
+
+        let mut ft1 =
+            FlowTable::new("port", "parent-table", FT_SIZE.unwrap(), None);
+        let mut ft2 =
+            FlowTable::new("port", "child-table", FT_SIZE.unwrap(), None);
+        let fe1 = ft1.add(flowid, ()).unwrap();
+        let fe2 = ft2.add(flowid, ()).unwrap();
+
+        let now = fe2.last_hit();
+        fe1.push_child(&(fe2 as Arc<dyn FlowEntryInfo>));
+
+        // A flow entry cannot be removed by the timer until all its children
+        // have been evicted or expired.
+        let t2 = now + Duration::new(FLOW_DEF_EXPIRE_SECS, 0);
+        ft1.expire_flows(t2, |_| FLOW_ID_DEFAULT);
+        assert_eq!(ft1.num_flows(), 1);
+
+        // If we go via ft2 first, we will be able to remove its entries (which
+        // have no children), which in turn makes ft1's entries available for
+        // eviction.
+        ft2.expire_flows(t2, |_| FLOW_ID_DEFAULT);
+        assert_eq!(ft2.num_flows(), 0);
+        ft1.expire_flows(t2, |_| FLOW_ID_DEFAULT);
+        assert_eq!(ft1.num_flows(), 0);
+    }
+
+    #[test]
+    fn eviction_basics() {
+        let flowid = InnerFlowId {
+            proto: Protocol::TCP.into(),
+            addrs: AddrPair::V4 {
+                src: "192.168.2.10".parse().unwrap(),
+                dst: "76.76.21.21".parse().unwrap(),
+            },
+            proto_info: PortInfo { src_port: 37890, dst_port: 443 }.into(),
+        };
+
+        // Fill up the tables.
+        let mut default_ft =
+            FlowTable::new("port", "no-prio-table", FT_SIZE.unwrap(), None);
+        let mut evict_ft = FlowTable::new(
+            "port",
+            "prio-table",
+            FT_SIZE.unwrap(),
+            Some(Arc::new(FixedPolicy {
+                time: Duration::from_secs(FLOW_DEF_EXPIRE_SECS),
+                default: Some(EvictionPriority::Evictable(NonZeroU16::MIN)),
+                manual: Default::default(),
+            })),
+        );
+        for i in 0..default_ft.limit.get() {
+            let new_id = InnerFlowId {
+                proto: Protocol::UDP.into(),
+                addrs: AddrPair::V4 {
+                    src: "192.168.2.10".parse().unwrap(),
+                    dst: "76.76.21.21".parse().unwrap(),
+                },
+                proto_info: PortInfo { src_port: i as u16, dst_port: 443 }
+                    .into(),
+            };
+            default_ft.add(new_id, ()).unwrap();
+            evict_ft.add(new_id, ()).unwrap();
+        }
+
+        // With the default policy and a table full of UDP entries, we can't make
+        // room for anything new.
+        assert!(default_ft.add(flowid, ()).is_err());
+        assert_eq!(default_ft.num_flows(), FT_SIZE.unwrap().get());
+
+        // On a table where every flow is evictable, we can!
+        assert!(evict_ft.add(flowid, ()).is_ok());
+        assert_eq!(evict_ft.num_flows(), FT_SIZE.unwrap().get());
+
+        // If we soft-kill a flow entry (i.e., one of its ancestors was evicted)
+        // then we can make room to insert a new one.
+        default_ft.map.values().next().unwrap().mark_evicted();
+        assert_eq!(default_ft.num_flows(), FT_SIZE.unwrap().get());
+        assert!(default_ft.add(flowid, ()).is_ok());
+        assert_eq!(default_ft.num_flows(), FT_SIZE.unwrap().get());
+    }
+
+    #[test]
+    fn eviction_invalidates_descendents() {
+        let flowid = InnerFlowId {
+            proto: Protocol::TCP.into(),
+            addrs: AddrPair::V4 {
+                src: "192.168.2.10".parse().unwrap(),
+                dst: "76.76.21.21".parse().unwrap(),
+            },
+            proto_info: PortInfo { src_port: 37890, dst_port: 443 }.into(),
+        };
+
+        let mut ft1 =
+            FlowTable::new("port", "parent-table", FT_SIZE.unwrap(), None);
+        let mut ft2 =
+            FlowTable::new("port", "child-table", FT_SIZE.unwrap(), None);
+        let mut ft2_2 =
+            FlowTable::new("port", "other-child-table", FT_SIZE.unwrap(), None);
+        let mut ft3 =
+            FlowTable::new("port", "grandchild-table", FT_SIZE.unwrap(), None);
+        let fe1 = ft1.add(flowid, ()).unwrap();
+        let fe2 = ft2.add(flowid, ()).unwrap();
+        let fe_out_of_chain = ft2_2.add(flowid, ()).unwrap();
+        let fe3 = ft3.add(flowid, ()).unwrap();
+
+        fe1.push_child(&(fe2.clone() as Arc<dyn FlowEntryInfo>));
+        fe2.push_child(&(fe3.clone() as Arc<dyn FlowEntryInfo>));
+        fe_out_of_chain.push_child(&(fe3.clone() as Arc<dyn FlowEntryInfo>));
+
+        // If we invalidate fe1, then all of its *direct descendants* will also
+        // be invalid.
+        fe1.mark_evicted();
+        assert!(fe1.is_killed());
+        assert!(fe2.is_killed());
+        assert!(fe3.is_killed());
+        assert!(!fe_out_of_chain.is_killed());
     }
 }

--- a/lib/opte/src/engine/layer.rs
+++ b/lib/opte/src/engine/layer.rs
@@ -39,6 +39,7 @@ use crate::ddi::kstat::KStatProvider;
 use crate::ddi::kstat::KStatU64;
 use crate::ddi::mblk::MsgBlk;
 use crate::ddi::time::Moment;
+use crate::engine::flow_table::FlowState;
 use alloc::ffi::CString;
 use alloc::string::String;
 use alloc::string::ToString;
@@ -182,6 +183,8 @@ impl Dump for LftOutEntry {
     }
 }
 
+impl FlowState for LftOutEntry {}
+
 struct LayerFlowTable {
     limit: NonZeroU32,
     count: u32,
@@ -196,18 +199,25 @@ pub struct LftDump {
 }
 
 impl LayerFlowTable {
+    #[must_use]
     fn add_pair(
         &mut self,
         action_desc: ActionDescEntry,
         in_flow: InnerFlowId,
         out_flow: InnerFlowId,
-    ) {
+    ) -> (Arc<FlowEntry<ActionDescEntry>>, Arc<FlowEntry<LftOutEntry>>) {
         // We add unchekced because the limit is now enforced by
         // LayerFlowTable, not the individual flow tables.
-        self.ft_in.add_unchecked(in_flow, action_desc.clone());
+        //
+        // The LayerFlowTable, being the lowest level in the stateful flow
+        // hierarchy,
+        let in_lft = self.ft_in.add_unchecked(in_flow, action_desc.clone());
         let out_entry = LftOutEntry { in_flow_pair: in_flow, action_desc };
-        self.ft_out.add_unchecked(out_flow, out_entry);
+        let out_lft =
+            self.ft_out.add_unchecked_partner(out_flow, out_entry, &in_lft);
         self.count += 1;
+
+        (in_lft, out_lft)
     }
 
     /// Clear all flow table entries.
@@ -234,6 +244,9 @@ impl LayerFlowTable {
         // should be checked, and if either side is expired the pair
         // is considered expired (or active). Maybe this should be
         // configurable?
+
+        // Flow table in/out entries share a lifetime struct, so...
+        // XXX
         let to_expire =
             self.ft_out.expire_flows(now, LftOutEntry::extract_pair);
         for flow in to_expire {
@@ -242,14 +255,14 @@ impl LayerFlowTable {
         self.count = self.ft_out.num_flows();
     }
 
-    fn get_in(&self, flow: &InnerFlowId) -> EntryState {
+    fn get_in(&self, flow: &InnerFlowId) -> EntryState<'_, ActionDescEntry> {
         match self.ft_in.get(flow) {
             Some(entry) => {
                 entry.hit();
                 if entry.is_dirty() {
-                    EntryState::Dirty(entry.state().clone())
+                    EntryState::Dirty(entry)
                 } else {
-                    EntryState::Clean(entry.state().clone())
+                    EntryState::Clean(entry)
                 }
             }
 
@@ -257,15 +270,14 @@ impl LayerFlowTable {
         }
     }
 
-    fn get_out(&self, flow: &InnerFlowId) -> EntryState {
+    fn get_out(&self, flow: &InnerFlowId) -> EntryState<'_, LftOutEntry> {
         match self.ft_out.get(flow) {
             Some(entry) => {
                 entry.hit();
-                let action = entry.state().action_desc.clone();
                 if entry.is_dirty() {
-                    EntryState::Dirty(action)
+                    EntryState::Dirty(entry)
                 } else {
-                    EntryState::Clean(action)
+                    EntryState::Clean(entry)
                 }
             }
 
@@ -331,14 +343,14 @@ impl LayerFlowTable {
 }
 
 /// The result of a flowtable lookup.
-pub enum EntryState {
+pub enum EntryState<'a, S: FlowState> {
     /// No flow entry was found matching a given flowid.
     None,
     /// An existing flow table entry was found.
-    Clean(ActionDescEntry),
+    Clean(&'a Arc<FlowEntry<S>>),
     /// An existing flow table entry was found, but rule processing must be rerun
     /// to use the original action or invalidate the underlying entry.
-    Dirty(ActionDescEntry),
+    Dirty(&'a Arc<FlowEntry<S>>),
 }
 
 /// The default action of a layer.
@@ -397,6 +409,8 @@ impl Display for ActionDescEntry {
         }
     }
 }
+
+impl FlowState for ActionDescEntry {}
 
 /// The actions of a layer.
 ///
@@ -782,6 +796,36 @@ impl Layer {
         }
     }
 
+    /// Yelp.
+    fn check_for_space(
+        &mut self,
+        dir: Direction,
+    ) -> result::Result<(), LayerError> {
+        if self.ft.count < self.ft.limit.get() {
+            return Ok(());
+        }
+
+        // Both in/out share the same `killed` flag, children, and evictability,
+        // so we only need to check the outbound table.
+        if let Some((out_key, out_entry)) =
+            self.ft.ft_out.find_evictable_entry()
+        {
+            let in_key = out_entry.state().in_flow_pair;
+
+            self.ft.ft_out.expire(&out_key);
+            self.ft.ft_in.expire(&in_key);
+            self.ft.count = self.ft.ft_out.num_flows();
+            Ok(())
+        } else {
+            let stat = match dir {
+                Direction::In => &self.stats.vals.in_lft_full,
+                Direction::Out => &self.stats.vals.out_lft_full,
+            };
+            stat.incr(1);
+            Err(LayerError::FlowTableFull { layer: self.name, dir })
+        }
+    }
+
     pub(crate) fn process(
         &mut self,
         ectx: &ExecCtx,
@@ -816,19 +860,25 @@ impl Layer {
         // Do we have a FlowTable entry? If so, use it.
         let flow = *pkt.flow();
         let action = match self.ft.get_in(&flow) {
-            EntryState::Dirty(ActionDescEntry::Desc(action))
-                if action.is_valid() =>
-            {
-                self.ft.mark_clean(Direction::In, &flow);
-                Some(ActionDescEntry::Desc(action))
+            EntryState::Dirty(action) => {
+                if let ActionDescEntry::Desc(desc) = action.state()
+                    && desc.is_valid()
+                {
+                    let desc = Arc::clone(desc);
+                    pkt.record_lft(Arc::clone(action) as _);
+                    self.ft.mark_clean(Direction::In, &flow);
+                    Some(ActionDescEntry::Desc(desc))
+                } else {
+                    // NoOps are included in this case as we can't ask the actor whether
+                    // it remains valid: the simplest method to do so is to rerun lookup.
+                    self.ft.remove_in(&flow);
+                    None
+                }
             }
-            EntryState::Dirty(_) => {
-                // NoOps are included in this case as we can't ask the actor whether
-                // it remains valid: the simplest method to do so is to rerun lookup.
-                self.ft.remove_in(&flow);
-                None
+            EntryState::Clean(action) => {
+                pkt.record_lft(Arc::clone(action) as _);
+                Some(action.state().clone())
             }
-            EntryState::Clean(action) => Some(action),
             EntryState::None => None,
         };
 
@@ -895,13 +945,7 @@ impl Layer {
             Action::Allow => Ok(LayerResult::Allow),
 
             Action::StatefulAllow => {
-                if self.ft.count == self.ft.limit.get() {
-                    self.stats.vals.in_lft_full += 1;
-                    return Err(LayerError::FlowTableFull {
-                        layer: self.name,
-                        dir: In,
-                    });
-                }
+                self.check_for_space(In)?;
 
                 // The outbound flow ID mirrors the inbound. Remember,
                 // the "top" of layer represents how the client sees
@@ -909,7 +953,8 @@ impl Layer {
                 // represents how the network sees the traffic.
                 let flow_out = pkt.flow().mirror();
                 let desc = ActionDescEntry::NoOp;
-                self.ft.add_pair(desc, *pkt.flow(), flow_out);
+                let (in_lft, _) = self.ft.add_pair(desc, *pkt.flow(), flow_out);
+                pkt.record_lft(in_lft);
                 self.stats.vals.flows += 1;
                 Ok(LayerResult::Allow)
             }
@@ -1005,14 +1050,6 @@ impl Layer {
                 // In general, the semantic of a StatefulAction is
                 // that it gets an FT entry. If there are no slots
                 // available, then we must fail until one opens up.
-                if self.ft.count == self.ft.limit.get() {
-                    self.stats.vals.in_lft_full += 1;
-                    return Err(LayerError::FlowTableFull {
-                        layer: self.name,
-                        dir: In,
-                    });
-                }
-
                 let desc = match action.gen_desc(pkt.flow(), pkt, ameta) {
                     Ok(aord) => match aord {
                         AllowOrDeny::Allow(desc) => desc,
@@ -1030,6 +1067,12 @@ impl Layer {
                         return Err(LayerError::GenDesc(e));
                     }
                 };
+
+                // TODO(ky): this (and equivalent Out) are moved to here purely to
+                // satiate the borrow checker. The comment above is right that we're
+                // just wasting effort by generating a descriptor before knowing that
+                // there's space ahead of time.
+                self.check_for_space(In)?;
 
                 let flow_before = *pkt.flow();
                 let ht_in = desc.gen_ht(In, ameta);
@@ -1058,11 +1101,12 @@ impl Layer {
                 // The final step is to mirror the IPs and ports to
                 // reflect the traffic direction change.
                 let flow_out = pkt.flow().mirror();
-                self.ft.add_pair(
+                let (in_lft, _) = self.ft.add_pair(
                     ActionDescEntry::Desc(desc),
                     flow_before,
                     flow_out,
                 );
+                pkt.record_lft(in_lft);
                 self.stats.vals.flows += 1;
                 Ok(LayerResult::Allow)
             }
@@ -1102,19 +1146,25 @@ impl Layer {
         // Do we have a FlowTable entry? If so, use it.
         let flow = *pkt.flow();
         let action = match self.ft.get_out(&flow) {
-            EntryState::Dirty(ActionDescEntry::Desc(action))
-                if action.is_valid() =>
-            {
-                self.ft.mark_clean(Direction::Out, &flow);
-                Some(ActionDescEntry::Desc(action))
+            EntryState::Dirty(action) => {
+                if let ActionDescEntry::Desc(desc) = &action.state().action_desc
+                    && desc.is_valid()
+                {
+                    let desc = Arc::clone(desc);
+                    pkt.record_lft(Arc::clone(action) as _);
+                    self.ft.mark_clean(Direction::Out, &flow);
+                    Some(ActionDescEntry::Desc(desc))
+                } else {
+                    // NoOps are included in this case as we can't ask the actor whether
+                    // it remains valid: the simplest method to do so is to rerun lookup.
+                    self.ft.remove_out(&flow);
+                    None
+                }
             }
-            EntryState::Dirty(_) => {
-                // NoOps are included in this case as we can't ask the actor whether
-                // it remains valid: the simplest method to do so is to rerun lookup.
-                self.ft.remove_out(&flow);
-                None
+            EntryState::Clean(action) => {
+                pkt.record_lft(Arc::clone(action) as _);
+                Some(action.state().action_desc.clone())
             }
-            EntryState::Clean(action) => Some(action),
             EntryState::None => None,
         };
 
@@ -1181,13 +1231,7 @@ impl Layer {
             Action::Allow => Ok(LayerResult::Allow),
 
             Action::StatefulAllow => {
-                if self.ft.count == self.ft.limit.get() {
-                    self.stats.vals.out_lft_full += 1;
-                    return Err(LayerError::FlowTableFull {
-                        layer: self.name,
-                        dir: Out,
-                    });
-                }
+                self.check_for_space(Out)?;
 
                 // The inbound flow ID must be calculated _after_ the
                 // header transformation. Remember, the "top"
@@ -1197,7 +1241,12 @@ impl Layer {
                 // The final step is to mirror the IPs and ports to
                 // reflect the traffic direction change.
                 let flow_in = pkt.flow().mirror();
-                self.ft.add_pair(ActionDescEntry::NoOp, flow_in, *pkt.flow());
+                let (_, out_lft) = self.ft.add_pair(
+                    ActionDescEntry::NoOp,
+                    flow_in,
+                    *pkt.flow(),
+                );
+                pkt.record_lft(out_lft);
                 self.stats.vals.flows += 1;
                 Ok(LayerResult::Allow)
             }
@@ -1293,14 +1342,6 @@ impl Layer {
                 // In general, the semantic of a StatefulAction is
                 // that it gets an FT entry. If there are no slots
                 // available, then we must fail until one opens up.
-                if self.ft.count == self.ft.limit.get() {
-                    self.stats.vals.out_lft_full += 1;
-                    return Err(LayerError::FlowTableFull {
-                        layer: self.name,
-                        dir: Out,
-                    });
-                }
-
                 let desc = match action.gen_desc(pkt.flow(), pkt, ameta) {
                     Ok(aord) => match aord {
                         AllowOrDeny::Allow(desc) => desc,
@@ -1318,6 +1359,12 @@ impl Layer {
                         return Err(LayerError::GenDesc(e));
                     }
                 };
+
+                // TODO(ky): this (and equivalent in) are moved to here purely to
+                // satiate the borrow checker. The comment above is right that we're
+                // just wasting effort by generating a descriptor before knowing that
+                // there's space ahead of time.
+                self.check_for_space(Out)?;
 
                 let flow_before = *pkt.flow();
                 let ht_out = desc.gen_ht(Out, ameta);
@@ -1347,11 +1394,12 @@ impl Layer {
                 // to mirror the IPs and ports to reflect the traffic
                 // direction change.
                 let flow_in = pkt.flow().mirror();
-                self.ft.add_pair(
+                let (_, out_lft) = self.ft.add_pair(
                     ActionDescEntry::Desc(desc),
                     flow_in,
                     flow_before,
                 );
+                pkt.record_lft(out_lft);
                 self.stats.vals.flows += 1;
                 Ok(LayerResult::Allow)
             }

--- a/lib/opte/src/engine/layer.rs
+++ b/lib/opte/src/engine/layer.rs
@@ -9,6 +9,7 @@
 use super::flow_table::Dump;
 use super::flow_table::FLOW_DEF_EXPIRE_SECS;
 use super::flow_table::FlowEntry;
+use super::flow_table::FlowEntryInfo;
 use super::flow_table::FlowTable;
 use super::flow_table::FlowTableDump;
 use super::packet::BodyTransformError;
@@ -185,7 +186,11 @@ impl Dump for LftOutEntry {
     }
 }
 
-impl FlowState for LftOutEntry {}
+impl FlowState for LftOutEntry {
+    fn parents(&self) -> impl Iterator<Item = Arc<dyn FlowEntryInfo>> {
+        [].into_iter()
+    }
+}
 
 struct LayerFlowTable {
     limit: NonZeroU32,
@@ -399,7 +404,11 @@ impl Display for ActionDescEntry {
     }
 }
 
-impl FlowState for ActionDescEntry {}
+impl FlowState for ActionDescEntry {
+    fn parents(&self) -> impl Iterator<Item = Arc<dyn FlowEntryInfo>> {
+        [].into_iter()
+    }
+}
 
 /// The actions of a layer.
 ///

--- a/lib/opte/src/engine/layer.rs
+++ b/lib/opte/src/engine/layer.rs
@@ -50,6 +50,8 @@ use core::fmt;
 use core::fmt::Display;
 use core::num::NonZeroU32;
 use core::result;
+use core::sync::atomic::AtomicU64;
+use core::sync::atomic::Ordering;
 use illumos_sys_hdrs::c_char;
 use illumos_sys_hdrs::uintptr_t;
 use opte_api::ActionDescEntryDump;
@@ -206,11 +208,11 @@ impl LayerFlowTable {
         in_flow: InnerFlowId,
         out_flow: InnerFlowId,
     ) -> (Arc<FlowEntry<ActionDescEntry>>, Arc<FlowEntry<LftOutEntry>>) {
-        // We add unchekced because the limit is now enforced by
-        // LayerFlowTable, not the individual flow tables.
-        //
-        // The LayerFlowTable, being the lowest level in the stateful flow
-        // hierarchy,
+        // We add unchecked because the limit is now enforced by
+        // LayerFlowTable, not the individual flow tables. Because these flow
+        // entries must be retired in pairs (and we want, e.g., inbound flow
+        // hits to sustain the outbound flow and vice-versa) we create the out
+        // entry as a _partner_ of the inbound one.
         let in_lft = self.ft_in.add_unchecked(in_flow, action_desc.clone());
         let out_entry = LftOutEntry { in_flow_pair: in_flow, action_desc };
         let out_lft =
@@ -232,21 +234,8 @@ impl LayerFlowTable {
     }
 
     fn expire_flows(&mut self, now: Moment) {
-        // XXX The two sides can have different traffic patterns and
-        // thus one side could be considered expired while the other
-        // is active. You could have one side seeing packets while the
-        // other side is idle; so what do we do? Currently this impl
-        // bases expiration on the outgoing side only, but expires
-        // both entries (just like it's imperative to add an entry as
-        // a pair, it's also imperative to remove an entry as a pair).
-        // Perhaps the two sides should share a single moment (though
-        // that would required mutex or atomic). Or perhaps both sides
-        // should be checked, and if either side is expired the pair
-        // is considered expired (or active). Maybe this should be
-        // configurable?
-
-        // Flow table in/out entries share a lifetime struct, so...
-        // XXX
+        // Flow table in/out entries share a lifetime struct, so it's irrelevant
+        // which of these tables we check first.
         let to_expire =
             self.ft_out.expire_flows(now, LftOutEntry::extract_pair);
         for flow in to_expire {
@@ -503,6 +492,11 @@ struct LayerStats {
 
     /// The number of times set_rules() has been called.
     set_rules_called: KStatU64,
+}
+
+enum SpaceCreated {
+    AmpleSpace,
+    Evict { in_key: InnerFlowId, out_key: InnerFlowId },
 }
 
 pub struct Layer {
@@ -796,13 +790,16 @@ impl Layer {
         }
     }
 
-    /// Yelp.
+    /// Determine whether there is currently space for a new entry to be
+    /// inserted.
+    ///
+    /// If out of space, this method will attempt to evict an existing entry.
     fn check_for_space(
-        &mut self,
+        &self,
         dir: Direction,
-    ) -> result::Result<(), LayerError> {
+    ) -> result::Result<SpaceCreated, LayerError> {
         if self.ft.count < self.ft.limit.get() {
-            return Ok(());
+            return Ok(SpaceCreated::AmpleSpace);
         }
 
         // Both in/out share the same `killed` flag, children, and evictability,
@@ -811,11 +808,7 @@ impl Layer {
             self.ft.ft_out.find_evictable_entry()
         {
             let in_key = out_entry.state().in_flow_pair;
-
-            self.ft.ft_out.expire(&out_key);
-            self.ft.ft_in.expire(&in_key);
-            self.ft.count = self.ft.ft_out.num_flows();
-            Ok(())
+            Ok(SpaceCreated::Evict { out_key, in_key })
         } else {
             let stat = match dir {
                 Direction::In => &self.stats.vals.in_lft_full,
@@ -823,6 +816,14 @@ impl Layer {
             };
             stat.incr(1);
             Err(LayerError::FlowTableFull { layer: self.name, dir })
+        }
+    }
+
+    fn complete_eviction(&mut self, entry: SpaceCreated) {
+        if let SpaceCreated::Evict { in_key, out_key } = entry {
+            self.ft.ft_out.expire(&out_key);
+            self.ft.ft_in.expire(&in_key);
+            self.ft.count = self.ft.ft_out.num_flows();
         }
     }
 
@@ -869,8 +870,9 @@ impl Layer {
                     self.ft.mark_clean(Direction::In, &flow);
                     Some(ActionDescEntry::Desc(desc))
                 } else {
-                    // NoOps are included in this case as we can't ask the actor whether
-                    // it remains valid: the simplest method to do so is to rerun lookup.
+                    // NoOps are included in this case as we can't ask the actor
+                    // whether it remains valid: the simplest method to do so is
+                    // to rerun lookup.
                     self.ft.remove_in(&flow);
                     None
                 }
@@ -945,7 +947,8 @@ impl Layer {
             Action::Allow => Ok(LayerResult::Allow),
 
             Action::StatefulAllow => {
-                self.check_for_space(In)?;
+                let write_to = self.check_for_space(In)?;
+                self.complete_eviction(write_to);
 
                 // The outbound flow ID mirrors the inbound. Remember,
                 // the "top" of layer represents how the client sees
@@ -1050,6 +1053,8 @@ impl Layer {
                 // In general, the semantic of a StatefulAction is
                 // that it gets an FT entry. If there are no slots
                 // available, then we must fail until one opens up.
+                let write_to = self.check_for_space(In)?;
+
                 let desc = match action.gen_desc(pkt.flow(), pkt, ameta) {
                     Ok(aord) => match aord {
                         AllowOrDeny::Allow(desc) => desc,
@@ -1068,11 +1073,7 @@ impl Layer {
                     }
                 };
 
-                // TODO(ky): this (and equivalent Out) are moved to here purely to
-                // satiate the borrow checker. The comment above is right that we're
-                // just wasting effort by generating a descriptor before knowing that
-                // there's space ahead of time.
-                self.check_for_space(In)?;
+                self.complete_eviction(write_to);
 
                 let flow_before = *pkt.flow();
                 let ht_in = desc.gen_ht(In, ameta);
@@ -1155,8 +1156,9 @@ impl Layer {
                     self.ft.mark_clean(Direction::Out, &flow);
                     Some(ActionDescEntry::Desc(desc))
                 } else {
-                    // NoOps are included in this case as we can't ask the actor whether
-                    // it remains valid: the simplest method to do so is to rerun lookup.
+                    // NoOps are included in this case as we can't ask the actor
+                    // whether it remains valid: the simplest method to do so is
+                    // to rerun lookup.
                     self.ft.remove_out(&flow);
                     None
                 }
@@ -1231,7 +1233,8 @@ impl Layer {
             Action::Allow => Ok(LayerResult::Allow),
 
             Action::StatefulAllow => {
-                self.check_for_space(Out)?;
+                let write_to = self.check_for_space(Out)?;
+                self.complete_eviction(write_to);
 
                 // The inbound flow ID must be calculated _after_ the
                 // header transformation. Remember, the "top"
@@ -1342,6 +1345,8 @@ impl Layer {
                 // In general, the semantic of a StatefulAction is
                 // that it gets an FT entry. If there are no slots
                 // available, then we must fail until one opens up.
+                let write_to = self.check_for_space(Out)?;
+
                 let desc = match action.gen_desc(pkt.flow(), pkt, ameta) {
                     Ok(aord) => match aord {
                         AllowOrDeny::Allow(desc) => desc,
@@ -1360,11 +1365,7 @@ impl Layer {
                     }
                 };
 
-                // TODO(ky): this (and equivalent in) are moved to here purely to
-                // satiate the borrow checker. The comment above is right that we're
-                // just wasting effort by generating a descriptor before knowing that
-                // there's space ahead of time.
-                self.check_for_space(Out)?;
+                self.complete_eviction(write_to);
 
                 let flow_before = *pkt.flow();
                 let ht_out = desc.gen_ht(Out, ameta);
@@ -1569,13 +1570,17 @@ impl Layer {
 #[derive(Debug)]
 struct RuleTableEntry {
     id: RuleId,
-    hits: u64,
+    hits: AtomicU64,
     rule: Rule<rule::Finalized>,
 }
 
 impl From<&RuleTableEntry> for RuleTableEntryDump {
     fn from(rte: &RuleTableEntry) -> Self {
-        Self { id: rte.id, hits: rte.hits, rule: RuleDump::from(&rte.rule) }
+        Self {
+            id: rte.id,
+            hits: rte.hits.load(Ordering::Relaxed),
+            rule: RuleDump::from(&rte.rule),
+        }
     }
 }
 
@@ -1603,12 +1608,14 @@ impl RuleTable {
     fn add(&mut self, rule: Rule<rule::Finalized>) {
         match self.find_pos(&rule) {
             RulePlace::End => {
-                let rte = RuleTableEntry { id: self.next_id, hits: 0, rule };
+                let rte =
+                    RuleTableEntry { id: self.next_id, hits: 0.into(), rule };
                 self.rules.push(rte);
             }
 
             RulePlace::Insert(idx) => {
-                let rte = RuleTableEntry { id: self.next_id, hits: 0, rule };
+                let rte =
+                    RuleTableEntry { id: self.next_id, hits: 0.into(), rule };
                 self.rules.insert(idx, rte);
             }
         }
@@ -1624,14 +1631,14 @@ impl RuleTable {
     }
 
     fn find_match(
-        &mut self,
+        &self,
         ifid: &InnerFlowId,
         pmeta: &MblkPacketData,
         ameta: &ActionMeta,
     ) -> Option<&Rule<rule::Finalized>> {
-        for rte in self.rules.iter_mut() {
+        for rte in self.rules.iter() {
             if rte.rule.is_match(pmeta, ameta) {
-                rte.hits += 1;
+                rte.hits.fetch_add(1, Ordering::Relaxed);
                 Self::rule_match_probe(
                     self.port_c.as_c_str(),
                     self.layer_c.as_c_str(),

--- a/lib/opte/src/engine/packet.rs
+++ b/lib/opte/src/engine/packet.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2025 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 //! Types for creating, reading, and writing network packets.
 
@@ -45,6 +45,7 @@ use crate::d_error::DError;
 use crate::ddi::mblk::MsgBlk;
 use crate::ddi::mblk::MsgBlkIterMut;
 use crate::ddi::mblk::MsgBlkNode;
+use crate::engine::flow_table::FlowEntryInfo;
 use crate::engine::geneve::GeneveMeta;
 use alloc::boxed::Box;
 use alloc::string::String;
@@ -790,6 +791,7 @@ where
                 body_modified: false,
                 len,
                 inner_csum_dirty: false,
+                lfts: vec![],
             },
         }
     }
@@ -1387,6 +1389,14 @@ impl<T: Read + Pullup> Packet<FullParsed<T>> {
             l3.compute_checksum();
         }
     }
+
+    pub fn record_lft(&mut self, lft: Arc<dyn FlowEntryInfo>) {
+        self.state.lfts.push(lft);
+    }
+
+    pub fn take_lfts(&mut self) -> Vec<Arc<dyn FlowEntryInfo>> {
+        self.state.lfts.drain(..).collect()
+    }
 }
 
 impl<T: Read + Pullup, M: LightweightMeta<T::Chunk>> PacketState
@@ -1435,6 +1445,9 @@ pub struct FullParsed<T: Read + Pullup> {
     /// Tracks whether any transform has been applied to this packet
     /// which would dirty the inner L3 and/or ULP header checksums.
     inner_csum_dirty: bool,
+    /// The set of all LFTs created or used by this packet as it
+    /// traverses the slow path.
+    lfts: Vec<Arc<dyn FlowEntryInfo>>,
 }
 
 /// Minimum-size zerocopy view onto a parsed packet, sufficient for fast

--- a/lib/opte/src/engine/port/mod.rs
+++ b/lib/opte/src/engine/port/mod.rs
@@ -1476,7 +1476,7 @@ impl<N: NetworkImpl> Port<N> {
                         decision = FastPathDecision::Slow;
                         lock = Some(self.data.write());
                     }
-                    // There is no TCP flow
+                    // There is no TCP flow.
                     None => {}
                 }
             }

--- a/lib/opte/src/engine/port/mod.rs
+++ b/lib/opte/src/engine/port/mod.rs
@@ -3190,7 +3190,7 @@ impl ExpiryPolicy<TcpFlowEntryState> for TcpExpiry {
             end_time_ms: u64,
             delta_ms: u64,
         ) -> Option<NonZeroU16> {
-            assert!(MISBEHAVED_MAX >= MISBEHAVED_MIN);
+            debug_assert!(MISBEHAVED_MAX >= MISBEHAVED_MIN);
 
             if start_time_ms > end_time_ms {
                 return None;
@@ -3208,8 +3208,8 @@ impl ExpiryPolicy<TcpFlowEntryState> for TcpExpiry {
                 const ONE_SCALED: u64 = 1 << SCALE;
                 const FRACTION_MASK: u64 = ONE_SCALED - 1;
 
-                assert_eq!(FRACTION_MASK.count_ones(), SCALE as u32);
-                assert_eq!(
+                debig_assert_eq!(FRACTION_MASK.count_ones(), SCALE as u32);
+                debug_assert_eq!(
                     FRACTION_MASK.leading_zeros(),
                     u64::BITS - (SCALE as u32)
                 );

--- a/lib/opte/src/engine/port/mod.rs
+++ b/lib/opte/src/engine/port/mod.rs
@@ -3156,17 +3156,17 @@ impl ExpiryPolicy<TcpFlowEntryState> for TcpExpiry {
         entry: &FlowEntry<TcpFlowEntryState>,
         now: Moment,
     ) -> Option<EvictionPriority> {
-        // The strategy here for now is to mark a flow as evictable halfway to
-        // the expiry time. Established flows are an exception, where we allow a
-        // such a flow to be evicted when needed, but otherwise aim to keep the
-        // LFTs in place even while the flow is inactive.
         let delta = now.delta_as_millis(entry.last_hit());
         match entry.state().tcp_state() {
             TcpState::TimeWait
             | TcpState::CloseWait
             | TcpState::FinWait1
             | TcpState::FinWait2 => match delta {
-                a if a > self.quiescent_ttl.as_milliseconds() / 2 => {
+                // We can remain in a closing state for quite some time. We need
+                // to be willing to evict such entries from this cache fairly
+                // quickly, but leave them in place for the ~120s when we are
+                // not under pressure.
+                a if a > self.incipient_ttl.as_milliseconds() => {
                     Some(EvictionPriority::Evictable(NonZeroU16::MIN))
                 }
                 _ => Some(EvictionPriority::Protected),
@@ -3175,11 +3175,17 @@ impl ExpiryPolicy<TcpFlowEntryState> for TcpExpiry {
             | TcpState::SynRcvd
             | TcpState::Listen
             | TcpState::LastAck => match delta {
+                // Ordinarily we will expire flows in these states quickly. If
+                // we are under table pressure, we can allow them to be
+                // explicitly selected for removal faster.
                 a if a > self.incipient_ttl.as_milliseconds() / 2 => {
                     Some(EvictionPriority::Evictable(NonZeroU16::MIN))
                 }
                 _ => Some(EvictionPriority::Protected),
             },
+            // Allow established flows to be evicted on the same time scale as
+            // UFT/LFT expiry, but if we are not under pressure then we aim to
+            // keep the LFTs in place even while the flow is inactive.
             TcpState::Established
                 if delta >= FLOW_DEF_TTL.as_milliseconds() =>
             {

--- a/lib/opte/src/engine/port/mod.rs
+++ b/lib/opte/src/engine/port/mod.rs
@@ -3208,7 +3208,7 @@ impl ExpiryPolicy<TcpFlowEntryState> for TcpExpiry {
                 const ONE_SCALED: u64 = 1 << SCALE;
                 const FRACTION_MASK: u64 = ONE_SCALED - 1;
 
-                debig_assert_eq!(FRACTION_MASK.count_ones(), SCALE as u32);
+                debug_assert_eq!(FRACTION_MASK.count_ones(), SCALE as u32);
                 debug_assert_eq!(
                     FRACTION_MASK.leading_zeros(),
                     u64::BITS - (SCALE as u32)

--- a/lib/opte/src/engine/port/mod.rs
+++ b/lib/opte/src/engine/port/mod.rs
@@ -66,7 +66,11 @@ use crate::ddi::mblk::MsgBlkIterMut;
 use crate::ddi::sync::KMutex;
 use crate::ddi::sync::KRwLock;
 use crate::ddi::time::Moment;
+use crate::engine::flow_table::EvictionPriority;
 use crate::engine::flow_table::ExpiryPolicy;
+use crate::engine::flow_table::FLOW_DEF_TTL;
+use crate::engine::flow_table::FlowEntryInfo;
+use crate::engine::flow_table::FlowState;
 use crate::engine::headers::Valid;
 use crate::engine::packet::EmitSpec;
 use crate::engine::packet::PushSpec;
@@ -76,10 +80,12 @@ use alloc::ffi::CString;
 use alloc::string::String;
 use alloc::string::ToString;
 use alloc::sync::Arc;
+use alloc::sync::Weak;
 use alloc::vec::Vec;
 use core::ffi::CStr;
 use core::fmt;
 use core::fmt::Display;
+use core::num::NonZeroU16;
 use core::num::NonZeroU32;
 use core::result;
 use core::str::FromStr;
@@ -335,7 +341,7 @@ impl PortBuilder {
                 &self.name,
                 "tcp_flows",
                 tcp_limit,
-                Some(Box::<TcpExpiry>::default()),
+                Some(Arc::<TcpExpiry>::default()),
             ),
         };
 
@@ -521,8 +527,19 @@ pub enum DumpLayerError {
     LayerNotFound,
 }
 
+/// Operations that the main flow identifier type for a given [`NetworkImpl`]
+/// must support.
+// This should live in `opte::api`, but we don't want to introduce an
+// API version change until this is something that *can* actually be specified
+// on a per-port basis.
+pub trait FlowId:
+    fmt::Debug + Send + Sync + Copy + Eq + Ord + core::hash::Hash
+{
+}
+impl FlowId for InnerFlowId {}
+
 /// An entry in the Unified Flow Table.
-pub struct UftEntry<Id> {
+pub struct UftEntry<Id: FlowId> {
     /// The flow ID for the other side.
     pair: KMutex<Option<Id>>,
 
@@ -537,11 +554,14 @@ pub struct UftEntry<Id> {
     epoch: u64,
 
     /// Cached reference to a flow's TCP state, if applicable.
-    /// This allows us to maintain up-to-date TCP flow table info
-    tcp_flow: Option<Arc<FlowEntry<TcpFlowEntryState>>>,
+    /// This allows us to maintain up-to-date TCP flow table info without
+    /// performing a second lookup on the flowhash.
+    tcp_flow: Option<Weak<FlowEntry<TcpFlowEntryState>>>,
+
+    parents: Vec<Arc<dyn FlowEntryInfo>>,
 }
 
-impl<Id> Dump for UftEntry<Id> {
+impl<Id: FlowId> Dump for UftEntry<Id> {
     type DumpVal = UftEntryDump;
 
     fn dump(&self, hits: u64) -> Self::DumpVal {
@@ -549,7 +569,7 @@ impl<Id> Dump for UftEntry<Id> {
     }
 }
 
-impl<Id> Display for UftEntry<Id> {
+impl<Id: FlowId> Display for UftEntry<Id> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let hdr = self
             .xforms
@@ -569,9 +589,10 @@ impl<Id> Display for UftEntry<Id> {
     }
 }
 
-impl<Id> fmt::Debug for UftEntry<Id> {
+impl<Id: FlowId> fmt::Debug for UftEntry<Id> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let UftEntry { pair: _pair, xforms, l4_hash, epoch, tcp_flow } = self;
+        let UftEntry { pair: _pair, xforms, l4_hash, epoch, tcp_flow, parents } =
+            self;
 
         f.debug_struct("UftEntry")
             .field("pair", &"<lock>")
@@ -579,7 +600,14 @@ impl<Id> fmt::Debug for UftEntry<Id> {
             .field("l4_hash", l4_hash)
             .field("epoch", epoch)
             .field("tcp_flow", tcp_flow)
+            .field("parents", parents)
             .finish()
+    }
+}
+
+impl<Id: FlowId> FlowState for UftEntry<Id> {
+    fn parents(&self) -> impl Iterator<Item = Arc<dyn FlowEntryInfo>> {
+        self.parents.iter().map(Arc::clone)
     }
 }
 
@@ -1077,18 +1105,24 @@ impl<N: NetworkImpl> Port<N> {
         let now = now.unwrap_or_else(Moment::now);
         check_state!(data.state, [PortState::Running])?;
 
-        for l in &mut data.layers {
-            l.expire_flows(now);
-        }
+        // Run expiry in reverse order of dependencies here.
+        //
+        // The presence of a higher-level entry prevents us from using the timer
+        // to expire any entry which it depends upon, and we propagate the
+        // last_hit time of each entry down to its children during expiry.
+        //
+        // A TCP state entry or UFT may in turn reference any number of LFT
+        // hits, so we visit those first to maximise the likelihood that we can
+        // clear up as many entries as possible.
+        let _ = data.tcp_flows.expire_flows(now, |_| FLOW_ID_DEFAULT);
+
         let _ = data.uft_in.expire_flows(now, |_| FLOW_ID_DEFAULT);
         let _ = data.uft_out.expire_flows(now, |_| FLOW_ID_DEFAULT);
 
-        // XXX: TCP state expiry currently runs on a longer time scale than
-        //      UFT entries, so we don't need to expire any extra UFT entries
-        //      using the output Vec<InnerFlowId>. If this changes, i.e., we
-        //      set TIME_WAIT_EXPIRE_TTL or another state-specific timer lower
-        //      than 60s, we'll need to specifically expire the matching UFTs.
-        let _ = data.tcp_flows.expire_flows(now, |_| FLOW_ID_DEFAULT);
+        for l in &mut data.layers {
+            l.expire_flows(now);
+        }
+
         Ok(())
     }
 
@@ -1366,70 +1400,84 @@ impl<N: NetworkImpl> Port<N> {
                 self.uft_hit_probe(dir, &flow_before, epoch, &process_start);
 
                 let tcp = entry.state().tcp_flow.as_ref();
-                if let Some(tcp_flow) = tcp {
-                    tcp_flow.hit_at(process_start);
+                match tcp.map(|v| v.upgrade()) {
+                    // This is a TCP flow, and the flow entry is still active.
+                    Some(Some(tcp_flow)) => {
+                        tcp_flow.hit_at(process_start);
 
-                    let tcp = pkt
-                        .meta()
-                        .inner_tcp()
-                        .expect("failed to find TCP state on known TCP flow");
+                        let tcp = pkt.meta().inner_tcp().expect(
+                            "failed to find TCP state on known TCP flow",
+                        );
 
-                    let ufid_in = match dir {
-                        Direction::In => Some(&flow_before),
-                        Direction::Out => None,
-                    };
+                        let ufid_in = match dir {
+                            Direction::In => Some(&flow_before),
+                            Direction::Out => None,
+                        };
 
-                    let invalidated_tcp = match tcp_flow.state().update(
-                        self.name_cstr.as_c_str(),
-                        tcp,
-                        dir,
-                        pkt.len() as u64,
-                        ufid_in,
-                    ) {
-                        Ok(TcpState::Closed) => Some(Arc::clone(tcp_flow)),
-                        Err(TcpFlowStateError::NewFlow { .. }) => {
-                            let out = Some(Arc::clone(tcp_flow));
-                            decision = FastPathDecision::Slow;
-                            out
-                        }
-                        _ => None,
-                    };
+                        let invalidated_tcp = match tcp_flow.state().update(
+                            self.name_cstr.as_c_str(),
+                            tcp,
+                            dir,
+                            pkt.len() as u64,
+                            ufid_in,
+                        ) {
+                            Ok(TcpState::Closed) => Some(tcp_flow),
+                            Err(TcpFlowStateError::NewFlow { .. }) => {
+                                let out = Some(tcp_flow);
+                                decision = FastPathDecision::Slow;
+                                out
+                            }
+                            _ => None,
+                        };
 
-                    // Reacquire the writer to remove the flow if needed.
-                    // Elevate lock to full scope, if we are reprocessing
-                    // as well.
-                    if let Some(entry) = invalidated_tcp {
-                        let mut local_lock = self.data.write();
+                        // Reacquire the writer to remove the flow if needed.
+                        // Elevate lock to full scope, if we are reprocessing
+                        // as well.
+                        if let Some(entry) = invalidated_tcp {
+                            let mut local_lock = self.data.write();
 
-                        let flow_lock = entry.state().inner.lock();
-                        let ufid_out = &flow_lock.outbound_ufid;
+                            let flow_lock = entry.state().inner.lock();
+                            let ufid_out = &flow_lock.outbound_ufid;
 
-                        let ufid_in = flow_lock.inbound_ufid.as_ref();
+                            let ufid_in = flow_lock.inbound_ufid.as_ref();
 
-                        // Because we've dropped the port lock, another packet could have
-                        // also invalidated this flow and removed the entry. It could even
-                        // install new UFT/TCP entries, depending on lock/process ordering.
-                        //
-                        // Verify that the state we want to remove still exists, and is
-                        // `Arc`-identical.
-                        if let Some(found_entry) =
-                            local_lock.tcp_flows.get(ufid_out)
-                            && Arc::ptr_eq(found_entry, &entry)
-                        {
-                            self.uft_tcp_closed(
-                                &mut local_lock,
-                                ufid_out,
-                                ufid_in,
-                            );
-                            _ = local_lock.tcp_flows.remove(ufid_out);
-                        }
+                            // Because we've dropped the port lock, another
+                            // packet could have also invalidated this flow and
+                            // removed the entry. It could even install new
+                            // UFT/TCP entries, depending on lock/process
+                            // ordering.
+                            //
+                            // Verify that the state we want to remove still
+                            // exists, and is `Arc`-identical.
+                            if let Some(found_entry) =
+                                local_lock.tcp_flows.get(ufid_out)
+                                && Arc::ptr_eq(found_entry, &entry)
+                            {
+                                self.uft_tcp_closed(
+                                    &mut local_lock,
+                                    ufid_out,
+                                    ufid_in,
+                                );
+                                _ = local_lock.tcp_flows.remove(ufid_out);
+                            }
 
-                        // We've determined we're actually starting a new TCP flow (e.g.,
-                        // SYN on any other state) from an existing UFT entry.
-                        if matches!(decision, FastPathDecision::Slow) {
-                            lock = Some(local_lock);
+                            // We've determined we're actually starting a new
+                            // TCP flow (e.g., SYN on any other state) from an
+                            // existing UFT entry.
+                            if matches!(decision, FastPathDecision::Slow) {
+                                lock = Some(local_lock);
+                            }
                         }
                     }
+                    // The TCP flow this UFT is associated with is gone.
+                    // Fallback to the slowpath and regenerate it or acquire a
+                    // new entry if one is present.
+                    Some(None) => {
+                        decision = FastPathDecision::Slow;
+                        lock = Some(self.data.write());
+                    }
+                    // There is no TCP flow
+                    None => {}
                 }
             }
             _ => {}
@@ -2150,7 +2198,7 @@ impl<N: NetworkImpl> Port<N> {
                     TcpFlowEntryState::new_outbound(*ufid_out, tfs, pkt_len),
                 ),
             };
-            match tcp_flows.add_and_return(*ufid_out, tfes) {
+            match tcp_flows.add(*ufid_out, tfes) {
                 Ok(entry) => Ok(TcpMaybeClosed::NewState(tcp_state, entry)),
                 Err(OpteError::MaxCapacity(limit)) => {
                     Err(ProcessError::FlowTableFull { kind: "TCP", limit })
@@ -2350,6 +2398,7 @@ impl<N: NetworkImpl> Port<N> {
             epoch,
             l4_hash: ufid_in.crc32(),
             tcp_flow: None,
+            parents: pkt.take_lfts(),
         };
 
         // Keep around the comment on the `None` arm
@@ -2392,9 +2441,12 @@ impl<N: NetworkImpl> Port<N> {
                 // Found existing TCP flow, or have just created a new one.
                 Ok(TcpMaybeClosed::NewState(_, flow)) => {
                     // We have a good TCP flow, create a new UFT entry.
-                    hte.tcp_flow = Some(flow);
+                    hte.tcp_flow = Some(Arc::downgrade(&flow));
                     match data.uft_in.add(*ufid_in, hte) {
-                        Ok(_) => Ok(InternalProcessResult::Modified),
+                        Ok(v) => {
+                            associate_lfts_upstack(&v, Direction::In);
+                            Ok(InternalProcessResult::Modified)
+                        }
                         Err(OpteError::MaxCapacity(limit)) => {
                             Err(ProcessError::FlowTableFull {
                                 kind: "UFT",
@@ -2431,7 +2483,10 @@ impl<N: NetworkImpl> Port<N> {
             }
         } else {
             match data.uft_in.add(*ufid_in, hte) {
-                Ok(_) => Ok(InternalProcessResult::Modified),
+                Ok(v) => {
+                    associate_lfts_upstack(&v, Direction::In);
+                    Ok(InternalProcessResult::Modified)
+                }
                 Err(OpteError::MaxCapacity(limit)) => {
                     Err(ProcessError::FlowTableFull { kind: "UFT", limit })
                 }
@@ -2529,7 +2584,9 @@ impl<N: NetworkImpl> Port<N> {
                 }
 
                 // Continue with processing.
-                Ok(TcpMaybeClosed::NewState(_, flow)) => Some(flow),
+                Ok(TcpMaybeClosed::NewState(_, flow)) => {
+                    Some(Arc::downgrade(&flow))
+                }
 
                 // Unlike for existing flows, we don't allow through
                 // unexpected packets here for now -- the `TcpState` FSM
@@ -2581,6 +2638,7 @@ impl<N: NetworkImpl> Port<N> {
             epoch,
             l4_hash: flow_before.crc32(),
             tcp_flow,
+            parents: pkt.take_lfts(),
         };
 
         match res {
@@ -2590,7 +2648,10 @@ impl<N: NetworkImpl> Port<N> {
                     return Ok(InternalProcessResult::Modified);
                 }
                 match data.uft_out.add(flow_before, hte) {
-                    Ok(_) => Ok(InternalProcessResult::Modified),
+                    Ok(v) => {
+                        associate_lfts_upstack(&v, Direction::Out);
+                        Ok(InternalProcessResult::Modified)
+                    }
                     Err(OpteError::MaxCapacity(limit)) => {
                         Err(ProcessError::FlowTableFull { kind: "UFT", limit })
                     }
@@ -2858,6 +2919,9 @@ pub struct TcpFlowEntryStateInner {
     segs_out: u64,
     bytes_in: u64,
     bytes_out: u64,
+
+    inbound_parents: Vec<Arc<dyn FlowEntryInfo>>,
+    outbound_parents: Vec<Arc<dyn FlowEntryInfo>>,
 }
 
 pub struct TcpFlowEntryState {
@@ -2880,6 +2944,9 @@ impl TcpFlowEntryState {
                 segs_out: 0,
                 bytes_in,
                 bytes_out: 0,
+
+                inbound_parents: vec![],
+                outbound_parents: vec![],
             }),
         }
     }
@@ -2898,6 +2965,9 @@ impl TcpFlowEntryState {
                 segs_out: 1,
                 bytes_in: 0,
                 bytes_out,
+
+                inbound_parents: vec![],
+                outbound_parents: vec![],
             }),
         }
     }
@@ -2939,6 +3009,47 @@ impl TcpFlowEntryState {
         let tcp_state = &mut tfes.tcp_state;
 
         tcp_state.process(port_name, dir, &ufid_out, tcp)
+    }
+}
+
+/// Install all parent-child links between a UFT entry, the LFT entries which
+/// underpin it, and the TCP flow state entry if present.
+fn associate_lfts_upstack(
+    uft: &Arc<FlowEntry<UftEntry<InnerFlowId>>>,
+    dir: Direction,
+) {
+    // The goal here is to provide each LFT hit with two children where
+    // possible. These are the UFT and, when it exists, the TCP flow entry.
+    // What this means in practice is that while either is present, the LFTs
+    // should be immune to timer-driven expiry. They are *not* immune to
+    // explicit eviction.
+    //
+    // We don't arrange the UFT as a parent of the TCP flow entry because
+    // this would cause the existence of the flow table entry to hold the UFT
+    // entry in place even if the flow is mostly idle. This also sets us up for
+    // being able to have different eviction policies, table sizes, and timers
+    // on the UFT to keep it a small cache without breaking flows.
+    let uft_dyn: Arc<dyn FlowEntryInfo> = Arc::clone(uft) as _;
+    for lft in &uft.state().parents {
+        lft.push_child(&uft_dyn);
+    }
+    if let Some(tcp) = uft.state().tcp_flow.as_ref().and_then(Weak::upgrade) {
+        let tcp_dyn: Arc<dyn FlowEntryInfo> = Arc::clone(&tcp) as _;
+        let mut parents = uft.state().parents.clone();
+        let mut inner = tcp.state().inner.lock();
+        let new_parent_slot = match dir {
+            Direction::In => &mut inner.inbound_parents,
+            Direction::Out => &mut inner.outbound_parents,
+        };
+
+        core::mem::swap(new_parent_slot, &mut parents);
+        let old_parents = parents;
+        for old_lft in old_parents {
+            old_lft.remove_child(&tcp_dyn);
+        }
+        for new_lft in new_parent_slot {
+            new_lft.push_child(&tcp_dyn);
+        }
     }
 }
 
@@ -2990,6 +3101,17 @@ impl Dump for TcpFlowEntryState {
     }
 }
 
+impl FlowState for TcpFlowEntryState {
+    fn parents(&self) -> impl Iterator<Item = Arc<dyn FlowEntryInfo>> {
+        let inner = self.inner.lock();
+        inner
+            .inbound_parents
+            .clone()
+            .into_iter()
+            .chain(inner.outbound_parents.clone())
+    }
+}
+
 /// Expiry behaviour for TCP flows dependent on the connection FSM.
 #[derive(Debug)]
 pub struct TcpExpiry {
@@ -3027,6 +3149,47 @@ impl ExpiryPolicy<TcpFlowEntryState> for TcpExpiry {
             TcpState::Closed => Ttl::new_seconds(0),
         };
         ttl.is_expired(entry.last_hit(), now)
+    }
+
+    fn eviction_priority(
+        &self,
+        entry: &FlowEntry<TcpFlowEntryState>,
+        now: Moment,
+    ) -> Option<EvictionPriority> {
+        // The strategy here for now is to mark a flow as evictable halfway to
+        // the expiry time. Established flows are an exception, where we allow a
+        // such a flow to be evicted when needed, but otherwise aim to keep the
+        // LFTs in place even while the flow is inactive.
+        let delta = now.delta_as_millis(entry.last_hit());
+        match entry.state().tcp_state() {
+            TcpState::TimeWait
+            | TcpState::CloseWait
+            | TcpState::FinWait1
+            | TcpState::FinWait2 => match delta {
+                a if a > self.quiescent_ttl.as_milliseconds() / 2 => {
+                    Some(EvictionPriority::Evictable(NonZeroU16::MIN))
+                }
+                _ => Some(EvictionPriority::Protected),
+            },
+            TcpState::SynSent
+            | TcpState::SynRcvd
+            | TcpState::Listen
+            | TcpState::LastAck => match delta {
+                a if a > self.incipient_ttl.as_milliseconds() / 2 => {
+                    Some(EvictionPriority::Evictable(NonZeroU16::MIN))
+                }
+                _ => Some(EvictionPriority::Protected),
+            },
+            TcpState::Established
+                if delta >= FLOW_DEF_TTL.as_milliseconds() =>
+            {
+                Some(EvictionPriority::Evictable(NonZeroU16::MIN))
+            }
+            TcpState::Established => Some(EvictionPriority::Protected),
+            TcpState::Closed => {
+                Some(EvictionPriority::Evictable(NonZeroU16::MAX))
+            }
+        }
     }
 }
 

--- a/lib/opte/src/engine/port/mod.rs
+++ b/lib/opte/src/engine/port/mod.rs
@@ -71,6 +71,7 @@ use crate::engine::flow_table::ExpiryPolicy;
 use crate::engine::flow_table::FLOW_DEF_TTL;
 use crate::engine::flow_table::FlowEntryInfo;
 use crate::engine::flow_table::FlowState;
+use crate::engine::flow_table::util;
 use crate::engine::headers::Valid;
 use crate::engine::packet::EmitSpec;
 use crate::engine::packet::PushSpec;
@@ -3181,61 +3182,6 @@ impl ExpiryPolicy<TcpFlowEntryState> for TcpExpiry {
         const MISBEHAVED_MAX: NonZeroU16 =
             NonZeroU16::new(NonZeroU16::MAX.get() - 1).unwrap();
 
-        /// Choose a priority value between `MISBEHAVED_MIN..=MISBEHAVED_MAX`
-        /// based on `delta_ms`'s position between two timestamps.
-        ///
-        /// Returns `None` if start > end.
-        fn priority_lerp(
-            start_time_ms: u64,
-            end_time_ms: u64,
-            delta_ms: u64,
-        ) -> Option<NonZeroU16> {
-            debug_assert!(MISBEHAVED_MAX >= MISBEHAVED_MIN);
-
-            if start_time_ms > end_time_ms {
-                return None;
-            }
-
-            Some(if delta_ms <= start_time_ms {
-                MISBEHAVED_MIN
-            } else if delta_ms >= end_time_ms {
-                MISBEHAVED_MAX
-            } else {
-                // Compute our priority using fixed point arithmetic.
-                // Since we're working in terms of 16-bit numbers, we need as
-                // many bits of fractional precision between 0.0 and 1.0.
-                const SCALE: u64 = 16;
-                const ONE_SCALED: u64 = 1 << SCALE;
-                const FRACTION_MASK: u64 = ONE_SCALED - 1;
-
-                debug_assert_eq!(FRACTION_MASK.count_ones(), SCALE as u32);
-                debug_assert_eq!(
-                    FRACTION_MASK.leading_zeros(),
-                    u64::BITS - (SCALE as u32)
-                );
-
-                // Fixed-point division of a real by an integer is fairly
-                // straightforward -- don't convert the denominator into the
-                // target base.
-                let inner_pos = (delta_ms - start_time_ms) << SCALE;
-                let window_len = end_time_ms - start_time_ms;
-
-                let inner_frac = inner_pos / window_len;
-
-                let n_entries =
-                    u64::from(MISBEHAVED_MAX.get() - MISBEHAVED_MIN.get());
-
-                let entry_fixed_pt = n_entries * inner_frac;
-
-                let round_up = entry_fixed_pt & FRACTION_MASK >= ONE_SCALED / 2;
-                let entry = u16::try_from(entry_fixed_pt >> SCALE)
-                    .expect("start and end points of lerp are both u16s")
-                    + u16::from(round_up);
-
-                MISBEHAVED_MIN.saturating_add(entry)
-            })
-        }
-
         let delta = now.delta_as_millis(entry.last_hit());
         match entry.state().tcp_state() {
             TcpState::TimeWait
@@ -3248,9 +3194,11 @@ impl ExpiryPolicy<TcpFlowEntryState> for TcpExpiry {
                 // not under pressure.
                 a if a > self.incipient_ttl.as_milliseconds() => {
                     Some(EvictionPriority::Evictable(
-                        priority_lerp(
+                        util::priority_lerp(
                             self.incipient_ttl.as_milliseconds(),
+                            MISBEHAVED_MIN,
                             self.quiescent_ttl.as_milliseconds(),
+                            MISBEHAVED_MAX,
                             delta,
                         )
                         .expect("start < end"),
@@ -3267,9 +3215,11 @@ impl ExpiryPolicy<TcpFlowEntryState> for TcpExpiry {
                 // explicitly selected for removal faster.
                 a if a > incipient_midpoint => {
                     Some(EvictionPriority::Evictable(
-                        priority_lerp(
+                        util::priority_lerp(
                             incipient_midpoint,
+                            MISBEHAVED_MIN,
                             self.incipient_ttl.as_milliseconds(),
+                            MISBEHAVED_MAX,
                             delta,
                         )
                         .expect("start < end"),

--- a/lib/opte/src/engine/port/mod.rs
+++ b/lib/opte/src/engine/port/mod.rs
@@ -2444,7 +2444,7 @@ impl<N: NetworkImpl> Port<N> {
                     hte.tcp_flow = Some(Arc::downgrade(&flow));
                     match data.uft_in.add(*ufid_in, hte) {
                         Ok(v) => {
-                            associate_lfts_upstack(&v, Direction::In);
+                            associate_lfts_upstack(data, &v, Direction::In);
                             Ok(InternalProcessResult::Modified)
                         }
                         Err(OpteError::MaxCapacity(limit)) => {
@@ -2484,7 +2484,7 @@ impl<N: NetworkImpl> Port<N> {
         } else {
             match data.uft_in.add(*ufid_in, hte) {
                 Ok(v) => {
-                    associate_lfts_upstack(&v, Direction::In);
+                    associate_lfts_upstack(data, &v, Direction::In);
                     Ok(InternalProcessResult::Modified)
                 }
                 Err(OpteError::MaxCapacity(limit)) => {
@@ -2649,7 +2649,7 @@ impl<N: NetworkImpl> Port<N> {
                 }
                 match data.uft_out.add(flow_before, hte) {
                     Ok(v) => {
-                        associate_lfts_upstack(&v, Direction::Out);
+                        associate_lfts_upstack(data, &v, Direction::Out);
                         Ok(InternalProcessResult::Modified)
                     }
                     Err(OpteError::MaxCapacity(limit)) => {
@@ -3015,6 +3015,7 @@ impl TcpFlowEntryState {
 /// Install all parent-child links between a UFT entry, the LFT entries which
 /// underpin it, and the TCP flow state entry if present.
 fn associate_lfts_upstack(
+    _data: &mut PortData,
     uft: &Arc<FlowEntry<UftEntry<InnerFlowId>>>,
     dir: Direction,
 ) {
@@ -3033,6 +3034,12 @@ fn associate_lfts_upstack(
     for lft in &uft.state().parents {
         lft.push_child(&uft_dyn);
     }
+
+    // Currently, we're explicitly holding a write lock on the parent port,
+    // and we ensure we hold this using `_data`. Because of this, there's no
+    // window for any thread (mainly cleanup) to see that an inconsistent
+    // parent/child relationship between the LFTs and TCP entry. We'll need to
+    // be more careful of that when we make these locks more granular.
     if let Some(tcp) = uft.state().tcp_flow.as_ref().and_then(Weak::upgrade) {
         let tcp_dyn: Arc<dyn FlowEntryInfo> = Arc::clone(&tcp) as _;
         let mut parents = uft.state().parents.clone();
@@ -3156,6 +3163,79 @@ impl ExpiryPolicy<TcpFlowEntryState> for TcpExpiry {
         entry: &FlowEntry<TcpFlowEntryState>,
         now: Moment,
     ) -> Option<EvictionPriority> {
+        const MIDPOINT_TO_EXPIRY: u64 = 2;
+        let incipient_midpoint =
+            self.incipient_ttl.as_milliseconds() / MIDPOINT_TO_EXPIRY;
+
+        // We divide evictable non-closed flows into two priority spaces here:
+        //
+        // * Established flows are evictable at the minimum priority after a
+        //   certain age.
+        // * Incipient/quiescent flows scale along
+        //   MISBEHAVED_MIN..MISBEHAVED_MAX according to how long they have been
+        //   in a misbehaved state (up to their expiry time).
+        //
+        // This ensures that we will evict misbehaved flows in non-established
+        // states before well-behaved but inactive flows.
+        const MISBEHAVED_MIN: NonZeroU16 = NonZeroU16::MIN.saturating_add(1);
+        const MISBEHAVED_MAX: NonZeroU16 =
+            NonZeroU16::new(NonZeroU16::MAX.get() - 1).unwrap();
+
+        /// Choose a priority value between `MISBEHAVED_MIN..=MISBEHAVED_MAX`
+        /// based on `delta_ms`'s position between two timestamps.
+        ///
+        /// Returns `None` if start > end.
+        fn priority_lerp(
+            start_time_ms: u64,
+            end_time_ms: u64,
+            delta_ms: u64,
+        ) -> Option<NonZeroU16> {
+            assert!(MISBEHAVED_MAX >= MISBEHAVED_MIN);
+
+            if start_time_ms > end_time_ms {
+                return None;
+            }
+
+            Some(if delta_ms <= start_time_ms {
+                MISBEHAVED_MIN
+            } else if delta_ms >= end_time_ms {
+                MISBEHAVED_MAX
+            } else {
+                // Compute our priority using fixed point arithmetic.
+                // Since we're working in terms of 16-bit numbers, we need as
+                // many bits of fractional precision between 0.0 and 1.0.
+                const SCALE: u64 = 16;
+                const ONE_SCALED: u64 = 1 << SCALE;
+                const FRACTION_MASK: u64 = ONE_SCALED - 1;
+
+                assert_eq!(FRACTION_MASK.count_ones(), SCALE as u32);
+                assert_eq!(
+                    FRACTION_MASK.leading_zeros(),
+                    u64::BITS - (SCALE as u32)
+                );
+
+                // Fixed-point division of a real by an integer is fairly
+                // straightforward -- don't convert the denominator into the
+                // target base.
+                let inner_pos = (delta_ms - start_time_ms) << SCALE;
+                let window_len = end_time_ms - start_time_ms;
+
+                let inner_frac = inner_pos / window_len;
+
+                let n_entries =
+                    u64::from(MISBEHAVED_MAX.get() - MISBEHAVED_MIN.get());
+
+                let entry_fixed_pt = n_entries * inner_frac;
+
+                let round_up = entry_fixed_pt & FRACTION_MASK >= ONE_SCALED / 2;
+                let entry = u16::try_from(entry_fixed_pt >> SCALE)
+                    .expect("start and end points of lerp are both u16s")
+                    + u16::from(round_up);
+
+                MISBEHAVED_MIN.saturating_add(entry)
+            })
+        }
+
         let delta = now.delta_as_millis(entry.last_hit());
         match entry.state().tcp_state() {
             TcpState::TimeWait
@@ -3167,7 +3247,14 @@ impl ExpiryPolicy<TcpFlowEntryState> for TcpExpiry {
                 // quickly, but leave them in place for the ~120s when we are
                 // not under pressure.
                 a if a > self.incipient_ttl.as_milliseconds() => {
-                    Some(EvictionPriority::Evictable(NonZeroU16::MIN))
+                    Some(EvictionPriority::Evictable(
+                        priority_lerp(
+                            self.incipient_ttl.as_milliseconds(),
+                            self.quiescent_ttl.as_milliseconds(),
+                            delta,
+                        )
+                        .expect("start < end"),
+                    ))
                 }
                 _ => Some(EvictionPriority::Protected),
             },
@@ -3178,8 +3265,15 @@ impl ExpiryPolicy<TcpFlowEntryState> for TcpExpiry {
                 // Ordinarily we will expire flows in these states quickly. If
                 // we are under table pressure, we can allow them to be
                 // explicitly selected for removal faster.
-                a if a > self.incipient_ttl.as_milliseconds() / 2 => {
-                    Some(EvictionPriority::Evictable(NonZeroU16::MIN))
+                a if a > incipient_midpoint => {
+                    Some(EvictionPriority::Evictable(
+                        priority_lerp(
+                            incipient_midpoint,
+                            self.incipient_ttl.as_milliseconds(),
+                            delta,
+                        )
+                        .expect("start < end"),
+                    ))
                 }
                 _ => Some(EvictionPriority::Protected),
             },
@@ -3244,4 +3338,128 @@ unsafe extern "C" {
         port: uintptr_t,
         ifid: *const InnerFlowId,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::PortInfo;
+    use crate::engine::packet::AddrPair;
+    use core::time::Duration;
+    use ingot::tcp::TcpFlags;
+
+    #[test]
+    fn opening_tcp_eviction_prio_increases_over_time() {
+        let flowid = InnerFlowId {
+            proto: ingot::ip::IpProtocol::TCP.0,
+            addrs: AddrPair::V4 {
+                src: "192.168.2.10".parse().unwrap(),
+                dst: "76.76.21.21".parse().unwrap(),
+            },
+            proto_info: PortInfo { src_port: 37890, dst_port: 443 }.into(),
+        };
+
+        let dummy_tcp_hdr =
+            ingot::tcp::Tcp { flags: TcpFlags::SYN, ..Default::default() };
+
+        let mut state = TcpFlowState::new();
+        state
+            .process::<&[u8]>(
+                c"myport",
+                Direction::Out,
+                &flowid,
+                &dummy_tcp_hdr,
+            )
+            .unwrap();
+        let tcp_state = TcpFlowEntryState::new_outbound(flowid, state, 52);
+
+        let policy = Arc::<TcpExpiry>::default();
+        let mut ft = FlowTable::new(
+            "myport",
+            "tcp",
+            16.try_into().unwrap(),
+            Some(policy.clone()),
+        );
+
+        let fe = ft.add(flowid, tcp_state).unwrap();
+        let t0 = fe.last_hit();
+        let t_bad = INCIPIENT_EXPIRE_TTL.as_milliseconds() / 2;
+        let t_fullbad = INCIPIENT_EXPIRE_TTL.as_milliseconds();
+
+        let mut prio = policy.eviction_priority(&fe, t0);
+        assert_eq!(prio, Some(EvictionPriority::Protected));
+
+        for ms_inc in (0..=10_000).step_by(50) {
+            let t_curr = t0 + Duration::from_millis(ms_inc);
+            let new_prio = policy.eviction_priority(&fe, t_curr);
+
+            if ms_inc <= t_bad || ms_inc > t_fullbad {
+                assert_eq!(new_prio, prio);
+            } else {
+                assert!(new_prio > prio);
+            }
+
+            prio = new_prio;
+        }
+    }
+
+    #[test]
+    fn established_tcp_eviction_prio_unchanging() {
+        let flowid = InnerFlowId {
+            proto: ingot::ip::IpProtocol::TCP.0,
+            addrs: AddrPair::V4 {
+                src: "192.168.2.10".parse().unwrap(),
+                dst: "76.76.21.21".parse().unwrap(),
+            },
+            proto_info: PortInfo { src_port: 37890, dst_port: 443 }.into(),
+        };
+
+        let dummy_tcp_hdr =
+            ingot::tcp::Tcp { flags: TcpFlags::SYN, ..Default::default() };
+        let dummy_reply_tcp_hdr = ingot::tcp::Tcp {
+            flags: TcpFlags::SYN | TcpFlags::ACK,
+            ..Default::default()
+        };
+
+        let mut state = TcpFlowState::new();
+        state
+            .process::<&[u8]>(
+                c"myport",
+                Direction::Out,
+                &flowid,
+                &dummy_tcp_hdr,
+            )
+            .unwrap();
+        state
+            .process::<&[u8]>(
+                c"myport",
+                Direction::In,
+                &flowid.mirror(),
+                &dummy_reply_tcp_hdr,
+            )
+            .unwrap();
+        let tcp_state = TcpFlowEntryState::new_outbound(flowid, state, 52);
+
+        let policy = Arc::<TcpExpiry>::default();
+        let mut ft = FlowTable::new(
+            "myport",
+            "tcp",
+            16.try_into().unwrap(),
+            Some(policy.clone()),
+        );
+
+        let fe = ft.add(flowid, tcp_state).unwrap();
+        let t0 = fe.last_hit();
+
+        for ms_inc in (0..=1_000_000).step_by(1_000) {
+            let t_curr = t0 + Duration::from_millis(ms_inc);
+
+            let expt = if ms_inc < FLOW_DEF_TTL.as_milliseconds() {
+                Some(EvictionPriority::Protected)
+            } else {
+                Some(EvictionPriority::Evictable(NonZeroU16::MIN))
+            };
+            assert_eq!(policy.eviction_priority(&fe, t_curr), expt);
+        }
+    }
 }

--- a/lib/oxide-vpc/tests/integration_tests.rs
+++ b/lib/oxide-vpc/tests/integration_tests.rs
@@ -3514,22 +3514,31 @@ fn tcp_outbound() {
     // TCP flow expiry behaviour
     // ================================================================
     // - UFTs for individual flows live on the same cadence as other traffic.
+    //   We expect these to expire, as the TCP flow will not pin their
+    //   lifetime.
+    // - The presence of the TCP flow entry will keep the firewall entry alive.
+    //   If the UFT were present, it would serve the same purpose.
     // - TCP state machine info should be cleaned up after an active close.
+    //
     // TimeWait state has a ~2min lifetime before we flush it -- it should still
-    // be present at UFT expiry:
+    // be present at UFT expiry.
     let now = Moment::now();
     g1.port
         .expire_flows_at(now + Duration::new(FLOW_DEF_EXPIRE_SECS + 1, 0))
         .unwrap();
-    zero_flows!(g1);
+    decr!(g1, ["uft.in, uft.out"]);
     assert_eq!(TcpState::TimeWait, g1.port.tcp_state(&flow).unwrap());
 
     // The TCP flow state should then be flushed after 2 mins.
     // Note that this case applies to any active-close initiated by the
     // guest, irrespective of inbound/outbound.
+    //
+    // Once this flow is removed, the LFTs associated with the flow become
+    // eligible for time-based expiry.
     g1.port
         .expire_flows_at(now + Duration::new(TIME_WAIT_EXPIRE_SECS + 1, 0))
         .unwrap();
+    zero_flows!(g1);
     assert_eq!(None, g1.port.tcp_state(&flow));
 }
 


### PR DESCRIPTION
This PR reworks the LFT/UFT lifecycle so that inbound/outbound entries are correctly bound by a single lifetime, and so that a slowpath packet tracks all LFTs which were used in its handling. We then associate this list of LFTs with the flow UFT, and the TCP flow entry if created.

This allows us to correctly keep LFTs alive so long as a UFT/TCP entry refers to them. This has been a longstanding bug. The new and really useful feature is that this allows us to remove all related and dependent entries when we deliberately evict an LFT to make space for a new flow.

An expiry policy for any table can now also specifiy an "eviction priority" for a given flow. Generally speaking most flows are unevictable so long as they are well-behaved, but the main issue is that we need information from elsewhere to *know* when we can make this determination. How we tackle this is by looking at all descendent flows which rely on a given flow. Most will state no preference on the flow lifecycle, but the TCP flow entry can return a non-zero priority when inactive in a given state for too long.

Closes #986.
Closes #788.
Closes #789.