### PR TITLE
[fix, multicast] wire up missing mcast-tx-no-inner-ip SDT probe

### DIFF
--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -435,6 +435,9 @@ unsafe extern "C" {
     // Multicast dataplane problem probes
     pub safe fn __dtrace_probe_mcast__tx__pullup__fail(len: uintptr_t);
     pub safe fn __dtrace_probe_mcast__rx__pullup__fail(len: uintptr_t);
+    /// Fires when a multicast packet has no inner L3 header available for
+    /// source-filter evaluation, so the packet is dropped at TX.
+    pub safe fn __dtrace_probe_mcast__tx__no__inner__ip(mblk: uintptr_t);
     pub safe fn __dtrace_probe_mcast__no__fwd__entry(
         underlay: *const oxide_vpc::api::Ipv6Addr,
         vni: uintptr_t,
@@ -2955,6 +2958,7 @@ fn xde_mc_tx_one<'a>(
                         opte::engine::dbg!(
                             "mcast Tx: no inner L3 for source filtering"
                         );
+                        __dtrace_probe_mcast__tx__no__inner__ip(mblk_addr);
                         return;
                     }
                 };


### PR DESCRIPTION
The DTrace script `opte/dtrace/opte-mcast-delivery.d` had carried a clause for `mcast-tx-no-inner-ip` since #924, but the corresponding SDT probe was never added on the Rust side, which I (@zeeshanlakhani) introduced.

This fix wires the probe up at the existing fallback path in `handle_mcast_tx` that drops a packet when the inner L3 header is unavailable for source-filter evaluation. The probe takes the `mblk_addr` so the DTrace consumer can inspect the failing packet, matching the pattern established by similar probes: `mcast-tx-pullup-fail`, `mcast-no-fwd-entry`, etc.

Note: no behavior change.