### PR TITLE
[safety] Weaken lifetime in get_xde_state()

### DIFF
--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -569,7 +569,7 @@ struct UnderlayState {
     shared_props: OffloadInfo,
 }
 
-fn get_xde_state() -> &'static XdeState {
+fn get_xde_state<'a>() -> &'a XdeState {
     // Safety: The opte_dip pointer is write-once and is a valid
     // pointer passed to attach(9E). The returned pointer is valid as
     // it was derived from Box::into_raw() during `xde_attach`.


### PR DESCRIPTION
The pointer we get back from ddi_get_driver_private assuredly does not have a static lifetime. In practice, this was unlikely to lead to bugs. But, by weakening the promise we make to the compiler, we can prevent unsound optimizations before the compiler makes them, or before we accidentally induce the compiler to make them.