### PR TITLE
Add non-default feature flag 'profiling' to xde

### DIFF
--- a/xde/Cargo.toml
+++ b/xde/Cargo.toml
@@ -23,3 +23,6 @@ zerocopy.workspace = true
 crate-type = ["staticlib"]
 name = "xde"
 
+[features]
+default = []
+profiling = []

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -2784,7 +2784,8 @@ unsafe extern "C" fn xde_mc_tx(
     ptr::null_mut()
 }
 
-#[inline]
+#[cfg_attr(feature = "profiling", inline(never), unsafe(no_mangle))]
+#[cfg_attr(not(feature = "profiling"), inline)]
 fn xde_mc_tx_one<'a>(
     src_dev: &'a XdeDev,
     mut pkt: MsgBlk,
@@ -3378,7 +3379,8 @@ unsafe extern "C" fn xde_rx(
 /// `DoMcastCheck(&DevMap)`, `DeliverDirect(&XdeDev, VniMac)`) but we'd be
 /// really reliant on rustc interpreting these as static choices and inlining
 /// accordingly.
-#[inline]
+#[cfg_attr(feature = "profiling", inline(never), unsafe(no_mangle))]
+#[cfg_attr(not(feature = "profiling"), inline)]
 fn xde_rx_one(
     stream: &DlsStream,
     mut pkt: MsgBlk,


### PR DESCRIPTION
This feature flag is off by default, and can only be enabled by manually editing xde/Cargo.toml. It makes it possible to conditionally disable inlining and name mangling on functions of interest. In particular, it has been applied to xde_rx_one and xde_mc_tx_one. While there are probes that serve as proxies for these functions, it is still valuable to be able to probe them directly while working locally.
```
$ dtrace -l | grep "xde_.*x_one entry"
fbt               xde                        xde_rx_one entry
fbt               xde                     xde_mc_tx_one entry
```
Should this workflow become frequently used, it can be made available in the build xtask, but this is a larger project for later, if at all.