### PR TITLE
Generate ICMP packet-too-big messages 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,36 +461,12 @@ checksum = "7a949c44fcacbbbb7ada007dc7acb34603dd97cd47de5d054f2b6493ecebb483"
 
 [[package]]
 name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.118",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -508,22 +484,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.118",
 ]
@@ -578,7 +543,7 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 name = "derror-macro"
 version = "0.1.0"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -690,12 +655,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -938,8 +897,9 @@ dependencies = [
 
 [[package]]
 name = "ingot"
-version = "0.1.1"
-source = "git+https://github.com/oxidecomputer/ingot?branch=extra-impls#cd1dfe5358dd6da571c8f1df9785dda1cc541ee4"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a036ae166644bc0d0f287c044d1bccfe7f16318ccaec717fd0f70b7cc66ee1b"
 dependencies = [
  "bitflags 2.13.0",
  "ingot-macros",
@@ -951,11 +911,12 @@ dependencies = [
 
 [[package]]
 name = "ingot-macros"
-version = "0.1.1"
-source = "git+https://github.com/oxidecomputer/ingot?branch=extra-impls#cd1dfe5358dd6da571c8f1df9785dda1cc541ee4"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c6b68cf2c0e9c6c385c8655cd390d861d6fba0e30493ad7e0ab6013a46f61"
 dependencies = [
- "darling 0.21.3",
- "itertools 0.14.0",
+ "darling",
+ "itertools 0.15.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -964,8 +925,9 @@ dependencies = [
 
 [[package]]
 name = "ingot-types"
-version = "0.1.2"
-source = "git+https://github.com/oxidecomputer/ingot?branch=extra-impls#cd1dfe5358dd6da571c8f1df9785dda1cc541ee4"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c38331af4cff022b2ea46b220467d5962973853a47bd6851c54c111b71baa42"
 dependencies = [
  "ingot-macros",
  "macaddr",
@@ -1009,15 +971,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,8 +939,7 @@ dependencies = [
 [[package]]
 name = "ingot"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a17a93829808685f3b6882763901d7489efc1155ad4ae568499d1b303067ca6"
+source = "git+https://github.com/oxidecomputer/ingot?branch=extra-impls#cd1dfe5358dd6da571c8f1df9785dda1cc541ee4"
 dependencies = [
  "bitflags 2.13.0",
  "ingot-macros",
@@ -953,8 +952,7 @@ dependencies = [
 [[package]]
 name = "ingot-macros"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4c94e8b5b5e08b71943d585acdb6062daaeb6b19de82ebb377c7c9cbeff44bb"
+source = "git+https://github.com/oxidecomputer/ingot?branch=extra-impls#cd1dfe5358dd6da571c8f1df9785dda1cc541ee4"
 dependencies = [
  "darling 0.21.3",
  "itertools 0.14.0",
@@ -967,8 +965,7 @@ dependencies = [
 [[package]]
 name = "ingot-types"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0d55db2f1de52564cc3781ffd5a7ebb7f2c6e1888841c2fa54231a9498db5f"
+source = "git+https://github.com/oxidecomputer/ingot?branch=extra-impls#cd1dfe5358dd6da571c8f1df9785dda1cc541ee4"
 dependencies = [
  "ingot-macros",
  "macaddr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,8 @@ ctor = "0.10"
 darling = "0.23"
 dyn-clone = "1.0"
 heapless = "0.8"
-ingot = "0.1.1"
+# ingot = "0.1.1"
+ingot = { git = "https://github.com/oxidecomputer/ingot", branch = "extra-impls" }
 ipnetwork = { version = "0.21", default-features = false }
 itertools = { version = "0.15", default-features = false }
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,7 @@ ctor = "0.10"
 darling = "0.23"
 dyn-clone = "1.0"
 heapless = "0.8"
-# ingot = "0.1.1"
-ingot = { git = "https://github.com/oxidecomputer/ingot", branch = "extra-impls" }
+ingot = "0.2.0"
 ipnetwork = { version = "0.21", default-features = false }
 itertools = { version = "0.15", default-features = false }
 libc = "0.2"

--- a/bench/benches/xde.rs
+++ b/bench/benches/xde.rs
@@ -17,6 +17,7 @@ use opte_bench::kbench::*;
 use std::collections::HashSet;
 use std::net::Ipv6Addr;
 use std::net::TcpListener;
+use std::num::NonZeroU32;
 use std::path::Path;
 use std::process::Command;
 use std::sync::Arc;
@@ -229,6 +230,13 @@ struct OpteCreateParams {
     /// assigned random MAC addresses.
     #[arg(short = 'P', long, default_value_t = 0)]
     passive_ports: u32,
+
+    /// The MTU that should be assigned to the primary OPTE port.
+    ///
+    /// This will default to a value chosen by the `xde` driver (1500)
+    /// if left unspecified.
+    #[arg(short = 'm')]
+    mtu: Option<NonZeroU32>,
 }
 
 #[derive(Parser)]
@@ -443,13 +451,14 @@ fn over_nic(params: &OpteCreateParams, host: &str, pause: bool) -> Result<()> {
     let topol = xde_tests::single_node_over_real_nic(
         (&params.underlay_nics[..2]).try_into().unwrap(),
         xde_tests::ZONE_B_PORT,
+        params.mtu,
         &[xde_tests::ZONE_A_PORT],
         params.passive_ports,
         params.brand.to_str(),
     )?;
     print_banner("Topology built!");
 
-    let target_ip = xde_tests::ZONE_A_PORT.ip;
+    let target_ip = xde_tests::ZONE_A_PORT.priv_ip4;
 
     // Ping for good luck / to verify reachability.
     let _ = &topol.nodes[0].zone.zone.zexec(&format!("ping {}", &target_ip))?;
@@ -561,6 +570,7 @@ fn host_iperf(params: &OpteCreateParams) -> Result<()> {
     let topol = xde_tests::single_node_over_real_nic(
         (&params.underlay_nics[..2]).try_into().unwrap(),
         xde_tests::ZONE_A_PORT,
+        params.mtu,
         &[xde_tests::ZONE_B_PORT],
         params.passive_ports,
         params.brand.to_str(),

--- a/crates/illumos-sys-hdrs/src/mac.rs
+++ b/crates/illumos-sys-hdrs/src/mac.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2025 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 #[cfg(feature = "kernel")]
 use crate::mblk_t;
@@ -111,7 +111,7 @@ bitflags! {
 /// Flags which denote checksum and LSO state for an `mblk_t`.
 ///
 /// These are derived from `#define`s in pattr.h.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 pub struct MblkOffloadFlags: u32 {
     /// Tx: IPv4 header checksum must be computed by hardware.
     const HCK_IPV4_HDRCKSUM = 1 << 0;

--- a/lib/opte-test-utils/src/lib.rs
+++ b/lib/opte-test-utils/src/lib.rs
@@ -274,7 +274,13 @@ fn oxide_net_builder(
     #[allow(clippy::arc_with_non_send_sync)]
     let ectx = Arc::new(ExecCtx { log: Box::new(opte::PrintlnLog {}) });
     let name_cstr = std::ffi::CString::new(name).unwrap();
-    let mut pb = PortBuilder::new(name, name_cstr, cfg.guest_mac, ectx);
+    let mut pb = PortBuilder::new(
+        name,
+        name_cstr,
+        cfg.guest_mac,
+        ectx,
+        NonZeroU32::new(cfg.mtu),
+    );
 
     let fw_limit = NonZeroU32::new(8096).unwrap();
     let snat_limit = NonZeroU32::new(8096).unwrap();
@@ -356,12 +362,14 @@ pub fn oxide_net_setup2(
         }
     };
 
+    let v2b = Arc::new(Virt2Boundary::new());
+    let m2p = Arc::new(Mcast2Phys::new());
+
     let converted_cfg = oxide_vpc::cfg::VpcCfg::with_mtu(cfg.clone(), 1500);
-    let vpc_net = VpcNetwork { cfg: converted_cfg.clone() };
+    let vpc_net = VpcNetwork { cfg: converted_cfg.clone(), v2b: v2b.clone() };
     let uft_limit = flow_table_limits.unwrap_or(UFT_LIMIT.unwrap());
     let tcp_limit = flow_table_limits.unwrap_or(TCP_LIMIT.unwrap());
-    let m2p = Arc::new(Mcast2Phys::new());
-    let v2b = Arc::new(Virt2Boundary::new());
+
     v2b.set(
         "0.0.0.0/0".parse().unwrap(),
         vec![TunnelEndpoint {

--- a/lib/opte/src/ddi/mblk.rs
+++ b/lib/opte/src/ddi/mblk.rs
@@ -102,6 +102,12 @@ pub struct MsgBlkChain(Option<MsgBlkChainInner>);
 unsafe impl Send for MsgBlkChain {}
 unsafe impl Sync for MsgBlkChain {}
 
+impl Default for MsgBlkChain {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
 impl MsgBlkChain {
     /// Create an empty packet chain.
     pub const fn empty() -> Self {

--- a/lib/opte/src/ddi/mblk.rs
+++ b/lib/opte/src/ddi/mblk.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2025 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 use crate::engine::packet::BufferState;
 use crate::engine::packet::Pullup;
@@ -842,27 +842,11 @@ impl MsgBlk {
     }
 
     /// Sets a packet's offload flags, and sets MSS if `HW_LSO` is enabled.
-    #[cfg_attr(any(feature = "std", test), allow(unused))]
     pub fn request_offload(&mut self, flags: MblkOffloadFlags, mss: u32) {
-        let ckflags = flags & MblkOffloadFlags::HCK_FLAGS;
-
-        #[cfg(all(not(feature = "std"), not(test)))]
+        // SAFETY: the inner mblk_t is known to be valid and contain a
+        // valid dblk_t for its buffer.
         unsafe {
-            illumos_sys_hdrs::mac::mac_hcksum_set(
-                self.0.as_ptr(),
-                0,
-                0,
-                0,
-                0,
-                ckflags.bits(),
-            );
-            if flags.contains(MblkOffloadFlags::HW_LSO) {
-                illumos_sys_hdrs::mac::lso_info_set(
-                    self.0.as_ptr(),
-                    mss,
-                    MblkOffloadFlags::HW_LSO.bits(),
-                );
-            }
+            request_mblk_offload(self.0, flags, mss);
         }
     }
 
@@ -892,14 +876,16 @@ impl MsgBlk {
     }
 
     /// Return the offloads currently requested by a packet.
-    #[cfg_attr(any(feature = "std", test), allow(unused))]
     pub fn offload_flags(&self) -> MblkOffloadInfo {
-        let mut cso_out = 0u32;
-        let mut lso_out = 0u32;
-        let mut mss = 0u32;
+        // SAFETY: the inner mblk_t is known to be valid and contain a
+        // valid dblk_t for its buffer.
 
         #[cfg(all(not(feature = "std"), not(test)))]
         unsafe {
+            let mut cso_out = 0u32;
+            let mut lso_out = 0u32;
+            let mut mss = 0u32;
+
             illumos_sys_hdrs::mac::mac_hcksum_get(
                 self.0.as_ptr(),
                 ptr::null_mut(),
@@ -913,15 +899,74 @@ impl MsgBlk {
                 &raw mut mss,
                 &raw mut lso_out,
             );
-        };
 
-        MblkOffloadInfo {
-            flags: MblkOffloadFlags::from_bits_retain(cso_out | lso_out),
-            mss,
+            MblkOffloadInfo {
+                flags: MblkOffloadFlags::from_bits_retain(cso_out | lso_out),
+                mss,
+            }
+        }
+
+        #[cfg(any(feature = "std", test))]
+        unsafe {
+            typed_offload_info(self.0)
         }
     }
 }
 
+/// Representation of dblk-internal checksum validity/offload flags and state.
+///
+/// This matches what is used in illumos, but we only poke at these internals
+/// directly in userland/tests. In driver builds we use the `mac_hcksum_*` and
+/// `mac_lso_*` functions to extract or manipulate this state.
+#[cfg(any(feature = "std", test))]
+#[derive(zerocopy::IntoBytes, zerocopy::FromBytes, zerocopy::Immutable)]
+#[repr(C)]
+struct CksumInternal {
+    cksum: u32,
+    flags: u16,
+    mss: u16,
+}
+
+pub(crate) unsafe fn request_mblk_offload(
+    mp: NonNull<mblk_t>,
+    flags: MblkOffloadFlags,
+    mss: u32,
+) {
+    let ckflags = flags & MblkOffloadFlags::HCK_FLAGS;
+
+    #[cfg(all(not(feature = "std"), not(test)))]
+    unsafe {
+        illumos_sys_hdrs::mac::mac_hcksum_set(
+            mp.as_ptr(),
+            0,
+            0,
+            0,
+            0,
+            ckflags.bits(),
+        );
+        if flags.contains(MblkOffloadFlags::HW_LSO) {
+            illumos_sys_hdrs::mac::lso_info_set(
+                mp.as_ptr(),
+                mss,
+                MblkOffloadFlags::HW_LSO.bits(),
+            );
+        }
+    }
+
+    #[cfg(any(feature = "std", test))]
+    {
+        let before = unsafe { offload_info(mp) };
+        let mut info: CksumInternal = zerocopy::transmute!(before);
+        info.flags = ckflags.bits() as u16;
+        if flags.contains(MblkOffloadFlags::HW_LSO) {
+            info.flags |= MblkOffloadFlags::HW_LSO.bits() as u16;
+            info.mss = mss as u16;
+        }
+        unsafe { set_offload_info(mp, zerocopy::transmute!(info)) };
+    }
+}
+
+#[derive(Default)]
 pub struct MblkOffloadInfo {
     pub flags: MblkOffloadFlags,
     pub mss: u32,
@@ -1155,6 +1200,20 @@ unsafe fn offload_info(head: NonNull<mblk_t>) -> u64 {
     unsafe { (*(*head.as_ptr()).b_datap).db_struioun }
 }
 
+/// Use a userland reimplementation of mblk internals to retrieve
+/// offload flags and sizes.
+#[cfg(any(feature = "std", test))]
+unsafe fn typed_offload_info(head: NonNull<mblk_t>) -> MblkOffloadInfo {
+    let raw = unsafe { offload_info(head) };
+
+    let data: CksumInternal = zerocopy::transmute!(raw);
+
+    MblkOffloadInfo {
+        flags: MblkOffloadFlags::from_bits_retain(u32::from(data.flags)),
+        mss: u32::from(data.mss),
+    }
+}
+
 /// Set the opaque representation of offload flags and sizes
 /// associated with this packet.
 unsafe fn set_offload_info(head: NonNull<mblk_t>, info: u64) {
@@ -1236,8 +1295,46 @@ impl BufferState for MsgBlkIterMut<'_> {
     }
 
     #[inline]
-    fn base_ptr(&self) -> uintptr_t {
-        self.curr.map(|v| v.as_ptr() as uintptr_t).unwrap_or(0)
+    fn base_ptr(&self) -> Option<NonNull<mblk_t>> {
+        self.curr
+    }
+
+    #[inline]
+    fn large_offload(&self) -> bool {
+        // SAFETY: if non-null, the inner mblk_t is known to be valid
+        // and contain a valid dblk_t for its buffer.
+
+        #[cfg(all(not(feature = "std"), not(test)))]
+        let flags = {
+            self.curr
+                .map(|v| {
+                    let mut lso_out = 0u32;
+                    let mut mss = 0u32;
+
+                    unsafe {
+                        illumos_sys_hdrs::mac::mac_lso_get(
+                            v.as_ptr(),
+                            &raw mut mss,
+                            &raw mut lso_out,
+                        );
+                    }
+
+                    lso_out
+                })
+                .unwrap_or(0)
+        };
+
+        #[cfg(any(feature = "std", test))]
+        let flags = {
+            let raw = self
+                .curr
+                .map(|v| unsafe { typed_offload_info(v) })
+                .unwrap_or_default();
+
+            raw.flags.intersection(MblkOffloadFlags::HW_LSO_FLAGS).bits()
+        };
+
+        flags != 0
     }
 }
 

--- a/lib/opte/src/engine/icmp/v4.rs
+++ b/lib/opte/src/engine/icmp/v4.rs
@@ -221,8 +221,6 @@ impl<B: ByteSlice> QueryEcho for ValidIcmpV4<B> {
     }
 }
 
-pub const ICMP_DU_FRAGMENTATION_NEEDED: u8 = 4;
-
 /// Internal structure of an ICMP _Destination Unreachable_'s `rest_of_hdr`.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Ingot)]
 #[ingot(impl_default)]
@@ -237,8 +235,12 @@ pub struct DestinationUnreachable {
     /// over.
     ///
     /// This must be zero for all message types other than
-    /// [`ICMP_DU_FRAGMENTATION_NEEDED`].
+    /// [`Self::FRAGMENTATION_NEEDED`].
     ///
     /// RFC 1191, §4.
     pub mtu: u16be,
+}
+
+impl DestinationUnreachable {
+    pub const FRAGMENTATION_NEEDED: u8 = 4;
 }

--- a/lib/opte/src/engine/icmp/v4.rs
+++ b/lib/opte/src/engine/icmp/v4.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2025 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 //! ICMPv4 headers and processing.
 
@@ -219,4 +219,26 @@ impl<B: ByteSlice> QueryEcho for ValidIcmpV4<B> {
             _ => None,
         }
     }
+}
+
+pub const ICMP_DU_FRAGMENTATION_NEEDED: u8 = 4;
+
+/// Internal structure of an ICMP _Destination Unreachable_'s `rest_of_hdr`.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Ingot)]
+#[ingot(impl_default)]
+pub struct DestinationUnreachable {
+    _rsvd: u8,
+    /// The number of 32-bit words of the original packet included in this
+    /// message's body, after padding to a 4B boundary.
+    ///
+    /// RFC 4884, §4.1.
+    pub length: u8,
+    /// The MTU of the link which this packet was too large to be forwarded
+    /// over.
+    ///
+    /// This must be zero for all message types other than
+    /// [`ICMP_DU_FRAGMENTATION_NEEDED`].
+    ///
+    /// RFC 1191, §4.
+    pub mtu: u16be,
 }

--- a/lib/opte/src/engine/mod.rs
+++ b/lib/opte/src/engine/mod.rs
@@ -253,15 +253,13 @@ pub trait NetworkImpl {
     /// Return the parser for this network implementation.
     fn parser(&self) -> Self::Parser;
 
-    /// Handle a packet which is larget than the underlying [`Port`]'s
+    /// Handle a packet which is larger than the underlying [`port::Port`]'s
     /// MTU. Packets will be caught before applying any existing
     /// UFT transform or applying rule-based processing.
     ///
     /// OPTE will raise this error for any packets larger than the MTU
-    /// without appropriate large send/receive offload flags set by the
-    /// caller.
-    ///
-    /// [`Port`]: port::Port
+    /// which do not have appropriate large send/receive offload flags
+    /// set by the driver.
     // NOTE: we can exchange this in future for a generic `handle_error`,
     // if more use cases become apparent.
     fn handle_oversize<'a, T: Read + Pullup + 'a>(

--- a/lib/opte/src/engine/mod.rs
+++ b/lib/opte/src/engine/mod.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2025 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 //! The engine in OPTE.
 //!
@@ -162,6 +162,27 @@ pub enum HdlPktAction {
 /// processing.
 pub struct HdlPktError(pub &'static str);
 
+/// The action to take on a packet which has raised one or more error
+/// conditions during processing.
+///
+/// OPTE can raise certain errors to the [`NetworkImpl`], so that it
+/// can decide how to respond to certain events such as traffic larger
+/// than the specified MTU.
+///
+/// This differs from [`HdlPktAction`] in that an allow action *does not
+/// short-circuit the remainder of normal packet processing*.
+pub enum HdlErrAction {
+    /// OPTE should continue processing this packet.
+    ContinueProcessing,
+
+    /// The packet raising this error must be dropped.
+    Deny,
+
+    /// The packet should not be processed, and a given reply packet
+    /// should be sent as a reply.
+    Hairpin(MsgBlk),
+}
+
 /// An implementation of a particular type of network.
 ///
 /// OPTE is a generalized engine for processing and transforming
@@ -231,6 +252,25 @@ pub trait NetworkImpl {
 
     /// Return the parser for this network implementation.
     fn parser(&self) -> Self::Parser;
+
+    /// Handle a packet which is larget than the underlying [`Port`]'s
+    /// MTU. Packets will be caught before applying any existing
+    /// UFT transform or applying rule-based processing.
+    ///
+    /// OPTE will raise this error for any packets larger than the MTU
+    /// without appropriate large send/receive offload flags set by the
+    /// caller.
+    ///
+    /// [`Port`]: port::Port
+    // NOTE: we can exchange this in future for a generic `handle_error`,
+    // if more use cases become apparent.
+    fn handle_oversize<'a, T: Read + Pullup + 'a>(
+        &self,
+        dir: Direction,
+        pkt: &mut Packet<FullParsed<T>>,
+    ) -> Result<HdlErrAction, HdlPktError>
+    where
+        T::Chunk: ByteSliceMut + IntoBufPointer<'a>;
 }
 
 /// A packet parser for the network implementation.

--- a/lib/opte/src/engine/packet.rs
+++ b/lib/opte/src/engine/packet.rs
@@ -45,6 +45,7 @@ use crate::d_error::DError;
 use crate::ddi::mblk::MsgBlk;
 use crate::ddi::mblk::MsgBlkIterMut;
 use crate::ddi::mblk::MsgBlkNode;
+use crate::ddi::mblk::request_mblk_offload;
 use crate::engine::flow_table::FlowEntryInfo;
 use crate::engine::geneve::GeneveMeta;
 use alloc::boxed::Box;
@@ -62,18 +63,16 @@ use core::sync::atomic::Ordering;
 use dyn_clone::DynClone;
 use illumos_sys_hdrs::mac::MacEtherOffloadFlags;
 use illumos_sys_hdrs::mac::MacTunType;
+use illumos_sys_hdrs::mac::MblkOffloadFlags;
 use illumos_sys_hdrs::mac::mac_ether_offload_info_t;
 use illumos_sys_hdrs::mblk_t;
 use illumos_sys_hdrs::uintptr_t;
 use ingot::geneve::GeneveOptRef;
 use ingot::geneve::GeneveRef;
-use ingot::icmp::IcmpV4Mut;
 use ingot::icmp::IcmpV4Packet;
 use ingot::icmp::IcmpV4Ref;
-use ingot::icmp::IcmpV6Mut;
 use ingot::icmp::IcmpV6Packet;
 use ingot::icmp::IcmpV6Ref;
-use ingot::tcp::TcpMut;
 use ingot::tcp::TcpPacket;
 use ingot::tcp::TcpRef;
 use ingot::types::BoxedHeader;
@@ -88,13 +87,11 @@ use ingot::types::Parsed as IngotParsed;
 use ingot::types::Read;
 use ingot::types::ToOwnedPacket;
 use ingot::udp::Udp;
-use ingot::udp::UdpMut;
 use ingot::udp::UdpPacket;
 use ingot::udp::UdpRef;
 use opte_api::Vni;
 use zerocopy::ByteSlice;
 use zerocopy::ByteSliceMut;
-use zerocopy::IntoBytes;
 
 pub trait PacketState {}
 
@@ -173,6 +170,7 @@ pub enum WrapError {
 #[derive(Clone, Debug, Eq, PartialEq, DError)]
 #[derror(leaf_data = ParseError::data)]
 pub enum ParseError {
+    NoBuffer,
     IngotError(PacketParseError),
     IllegalValue(MismatchError),
     BadLength(MismatchError),
@@ -733,12 +731,13 @@ where
         net: NP,
     ) -> Result<LiteInPkt<T, NP>, ParseError> {
         let len = pkt.len();
-        let base_ptr = pkt.base_ptr();
+        let base_ptr = pkt.base_ptr().ok_or(ParseError::NoBuffer)?;
+        let large_offload = pkt.large_offload();
 
         let meta = net.parse_inbound(pkt)?;
         meta.headers.validate(len)?;
 
-        Ok(Packet { state: LiteParsed { meta, base_ptr, len } })
+        Ok(Packet { state: LiteParsed { meta, base_ptr, len, large_offload } })
     }
 
     #[inline(always)]
@@ -747,17 +746,18 @@ where
         net: NP,
     ) -> Result<LiteOutPkt<T, NP>, ParseError> {
         let len = pkt.len();
-        let base_ptr = pkt.base_ptr();
+        let base_ptr = pkt.base_ptr().ok_or(ParseError::NoBuffer)?;
+        let large_offload = pkt.large_offload();
 
         let meta = net.parse_outbound(pkt)?;
         meta.headers.validate(len)?;
 
-        Ok(Packet { state: LiteParsed { meta, base_ptr, len } })
+        Ok(Packet { state: LiteParsed { meta, base_ptr, len, large_offload } })
     }
 
     #[inline]
     pub fn to_full_meta(self) -> Packet<FullParsed<T>> {
-        let Packet { state: LiteParsed { len, base_ptr, meta } } = self;
+        let Packet { state: LiteParsed { len, base_ptr, meta, .. } } = self;
         let IngotParsed { headers, data, last_chunk } = meta;
 
         // TODO: we can probably not do this in some cases, but we
@@ -813,12 +813,28 @@ where
 
     #[inline]
     pub fn mblk_addr(&self) -> uintptr_t {
-        self.state.base_ptr
+        self.state.base_ptr.as_ptr() as uintptr_t
+    }
+
+    #[inline]
+    pub fn large_offload(&self) -> bool {
+        self.state.large_offload
     }
 
     #[inline]
     pub fn flow(&self) -> InnerFlowId {
         self.meta().flow()
+    }
+
+    #[inline]
+    pub fn request_offload(&mut self, flags: MblkOffloadFlags, mss: u32) {
+        let large_offload = flags.contains(MblkOffloadFlags::HW_LSO);
+
+        // SAFETY: the inner mblk_t is known to be valid and contain a
+        // valid dblk_t for its buffer.
+        unsafe { request_mblk_offload(self.state.base_ptr, flags, mss) }
+
+        self.state.large_offload = large_offload;
     }
 }
 
@@ -1162,14 +1178,14 @@ impl<T: Read + Pullup> Packet<FullParsed<T>> {
 
     #[inline]
     pub fn mblk_addr(&self) -> uintptr_t {
-        self.state.base_ptr
+        self.state.base_ptr.as_ptr() as uintptr_t
     }
 
     /// Compute ULP and IP header checksum from scratch.
     ///
-    /// This should really only be used for testing, or in the case
-    /// where we have applied body transforms and know that any initial
-    /// body_csum cannot be valid.
+    /// This should really only be used when producing a net-new packet,
+    /// or in the case where we have applied body transforms and know
+    /// that any initial body_csum cannot be valid.
     pub fn compute_checksums(&mut self)
     where
         T::Chunk: ByteSliceMut,
@@ -1180,69 +1196,10 @@ impl<T: Read + Pullup> Packet<FullParsed<T>> {
         self.state.body_csum = Some(body_csum);
 
         if let Some(ulp) = &mut self.state.meta.headers.inner_ulp {
-            let mut csum = body_csum;
-
             // Unwrap: Can't have a ULP without an IP.
             let ip = self.state.meta.headers.inner_l3.as_ref().unwrap();
-            // Add pseudo header checksum.
-            let pseudo_csum = ip.pseudo_header();
-            csum += pseudo_csum;
-            // Determine ULP slice and add its bytes to the
-            // checksum.
-            match ulp {
-                // ICMP4 requires the body_csum *without*
-                // the pseudoheader added back in.
-                Ulp::IcmpV4(i4) => {
-                    let mut bytes = [0u8; 8];
-                    i4.set_checksum(0);
-                    i4.emit_raw(&mut bytes[..]);
-                    body_csum.add_bytes(&bytes[..]);
-                    i4.set_checksum(body_csum.finalize_for_ingot());
-                }
-                Ulp::IcmpV6(i6) => {
-                    let mut bytes = [0u8; 8];
-                    i6.set_checksum(0);
-                    i6.emit_raw(&mut bytes[..]);
-                    csum.add_bytes(&bytes[..]);
-                    i6.set_checksum(csum.finalize_for_ingot());
-                }
-                Ulp::Tcp(tcp) => {
-                    tcp.set_checksum(0);
-                    match tcp {
-                        Header::Repr(tcp) => {
-                            let mut bytes = [0u8; 56];
-                            tcp.emit_raw(&mut bytes[..]);
-                            csum.add_bytes(&bytes[..]);
-                        }
-                        Header::Raw(tcp) => {
-                            csum.add_bytes(tcp.0.as_bytes());
-                            match &tcp.1 {
-                                Header::Repr(opts) => {
-                                    csum.add_bytes(opts);
-                                }
-                                Header::Raw(opts) => {
-                                    csum.add_bytes(opts);
-                                }
-                            }
-                        }
-                    }
-                    tcp.set_checksum(csum.finalize_for_ingot());
-                }
-                Ulp::Udp(udp) => {
-                    udp.set_checksum(0);
-                    match udp {
-                        Header::Repr(udp) => {
-                            let mut bytes = [0u8; 8];
-                            udp.emit_raw(&mut bytes[..]);
-                            csum.add_bytes(&bytes[..]);
-                        }
-                        Header::Raw(udp) => {
-                            csum.add_bytes(udp.0.as_bytes());
-                        }
-                    }
-                    udp.set_checksum(csum.finalize_for_ingot());
-                }
-            }
+
+            ulp.compute_checksum(ip.pseudo_header(), body_csum);
         }
 
         // Compute and fill in the IPv4 header checksum.
@@ -1317,71 +1274,13 @@ impl<T: Read + Pullup> Packet<FullParsed<T>> {
         // start and end processing.
 
         // If a ULP exists and provided a checksum, then update it.
-        if let Some(mut body_csum) = self.body_csum()
+        if let Some(body_csum) = self.body_csum()
             && let Some(ulp) = self.state.meta.headers.inner_ulp.as_mut()
         {
-            let mut csum = body_csum;
             // Unwrap: Can't have a ULP without an IP.
             let ip = self.state.meta.headers.inner_l3.as_ref().unwrap();
-            // Add pseudo header checksum.
-            let pseudo_csum = ip.pseudo_header();
-            csum += pseudo_csum;
-            // Determine ULP slice and add its bytes to the
-            // checksum.
-            match ulp {
-                // ICMP4 requires the body_csum *without*
-                // the pseudoheader added back in.
-                Ulp::IcmpV4(i4) => {
-                    let mut bytes = [0u8; 8];
-                    i4.set_checksum(0);
-                    i4.emit_raw(&mut bytes[..]);
-                    body_csum.add_bytes(&bytes[..]);
-                    i4.set_checksum(body_csum.finalize_for_ingot());
-                }
-                Ulp::IcmpV6(i6) => {
-                    let mut bytes = [0u8; 8];
-                    i6.set_checksum(0);
-                    i6.emit_raw(&mut bytes[..]);
-                    csum.add_bytes(&bytes[..]);
-                    i6.set_checksum(csum.finalize_for_ingot());
-                }
-                Ulp::Tcp(tcp) => {
-                    tcp.set_checksum(0);
-                    match tcp {
-                        Header::Repr(tcp) => {
-                            let mut bytes = [0u8; 56];
-                            tcp.emit_raw(&mut bytes[..]);
-                            csum.add_bytes(&bytes[..]);
-                        }
-                        Header::Raw(tcp) => {
-                            csum.add_bytes(tcp.0.as_bytes());
-                            match &tcp.1 {
-                                Header::Repr(opts) => {
-                                    csum.add_bytes(opts);
-                                }
-                                Header::Raw(opts) => {
-                                    csum.add_bytes(opts);
-                                }
-                            }
-                        }
-                    }
-                    tcp.set_checksum(csum.finalize_for_ingot());
-                }
-                Ulp::Udp(udp) => {
-                    udp.set_checksum(0);
-                    match udp {
-                        Header::Repr(udp) => {
-                            let mut bytes = [0u8; 8];
-                            udp.emit_raw(&mut bytes[..]);
-                            csum.add_bytes(&bytes[..]);
-                        }
-                        Header::Raw(udp) => {
-                            csum.add_bytes(udp.0.as_bytes());
-                        }
-                    }
-                    udp.set_checksum(csum.finalize_for_ingot());
-                }
-            }
+
+            ulp.compute_checksum(ip.pseudo_header(), body_csum);
         }
 
         // Compute and fill in the IPv4 header checksum.
@@ -1414,7 +1313,7 @@ pub struct FullParsed<T: Read + Pullup> {
     len: usize,
     /// Base pointer of the contained T, used in dtrace SDTs and the like
     /// for correlation and inspection of packet events.
-    base_ptr: uintptr_t,
+    base_ptr: NonNull<mblk_t>,
     /// Access to parsed packet headers and the packet body.
     meta: Box<PacketData<T>>,
     /// Current Flow ID of this packet, accountgin for any applied
@@ -1459,7 +1358,11 @@ pub struct LiteParsed<T: Read + Pullup, M: LightweightMeta<T::Chunk>> {
     len: usize,
     /// Base pointer of the contained T, used in dtrace SDTs and the like
     /// for correlation and inspection of packet events.
-    base_ptr: uintptr_t,
+    base_ptr: NonNull<mblk_t>,
+    /// Whether this packet has any offload flags set indicating that
+    /// it is larger than the MTU due to some form of send/receive
+    /// offload.
+    large_offload: bool,
     meta: IngotParsed<M, T>,
 }
 
@@ -1474,7 +1377,8 @@ pub type MblkLiteParsed<'a, M> = LiteParsed<MsgBlkIterMut<'a>, M>;
 
 pub trait BufferState {
     fn len(&self) -> usize;
-    fn base_ptr(&self) -> uintptr_t;
+    fn base_ptr(&self) -> Option<NonNull<mblk_t>>;
+    fn large_offload(&self) -> bool;
 }
 
 pub trait Pullup {

--- a/lib/opte/src/engine/packet.rs
+++ b/lib/opte/src/engine/packet.rs
@@ -813,7 +813,7 @@ where
 
     #[inline]
     pub fn mblk_addr(&self) -> uintptr_t {
-        self.state.base_ptr.as_ptr() as uintptr_t
+        self.state.base_ptr.addr().get()
     }
 
     #[inline]
@@ -1178,7 +1178,7 @@ impl<T: Read + Pullup> Packet<FullParsed<T>> {
 
     #[inline]
     pub fn mblk_addr(&self) -> uintptr_t {
-        self.state.base_ptr.as_ptr() as uintptr_t
+        self.state.base_ptr.addr().get()
     }
 
     /// Compute ULP and IP header checksum from scratch.

--- a/lib/opte/src/engine/parse.rs
+++ b/lib/opte/src/engine/parse.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2025 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 //! Constructs used in packet parsing, such as choices over protocol
 //! and complete packet definitions.
@@ -60,6 +60,7 @@ use ingot::tcp::TcpMut;
 use ingot::tcp::TcpRef;
 use ingot::tcp::ValidTcp;
 use ingot::types::ByteSlice;
+use ingot::types::Emit;
 use ingot::types::Header;
 use ingot::types::HeaderLen;
 use ingot::types::HeaderParse;
@@ -100,6 +101,72 @@ impl<B: ByteSlice + SplitByteSlice> Ulp<B> {
             Ulp::Udp(t) => t.to_owned(None).unwrap().into(),
             Ulp::IcmpV4(t) => t.to_owned(None).unwrap().into(),
             Ulp::IcmpV6(t) => t.to_owned(None).unwrap().into(),
+        }
+    }
+}
+
+impl<B: ByteSliceMut> Ulp<B> {
+    /// Use the L3 pseudoheader checksum and body checksum to derive
+    /// and update the checksum in any upper protocol.
+    pub fn compute_checksum(
+        &mut self,
+        pseudo_csum: Checksum,
+        mut body_csum: Checksum,
+    ) {
+        let mut csum = body_csum + pseudo_csum;
+        match self {
+            // ICMP4 requires the body_csum *without*
+            // the pseudoheader added back in.
+            Ulp::IcmpV4(i4) => {
+                let mut bytes = [0u8; 8];
+                i4.set_checksum(0);
+                i4.emit_raw(&mut bytes[..]);
+                body_csum.add_bytes(&bytes[..]);
+                i4.set_checksum(body_csum.finalize_for_ingot());
+            }
+            Ulp::IcmpV6(i6) => {
+                let mut bytes = [0u8; 8];
+                i6.set_checksum(0);
+                i6.emit_raw(&mut bytes[..]);
+                csum.add_bytes(&bytes[..]);
+                i6.set_checksum(csum.finalize_for_ingot());
+            }
+            Ulp::Tcp(tcp) => {
+                tcp.set_checksum(0);
+                match tcp {
+                    Header::Repr(tcp) => {
+                        let mut bytes = [0u8; 56];
+                        tcp.emit_raw(&mut bytes[..]);
+                        csum.add_bytes(&bytes[..]);
+                    }
+                    Header::Raw(tcp) => {
+                        csum.add_bytes(tcp.0.as_bytes());
+                        match &tcp.1 {
+                            Header::Repr(opts) => {
+                                csum.add_bytes(opts);
+                            }
+                            Header::Raw(opts) => {
+                                csum.add_bytes(opts);
+                            }
+                        }
+                    }
+                }
+                tcp.set_checksum(csum.finalize_for_ingot());
+            }
+            Ulp::Udp(udp) => {
+                udp.set_checksum(0);
+                match udp {
+                    Header::Repr(udp) => {
+                        let mut bytes = [0u8; 8];
+                        udp.emit_raw(&mut bytes[..]);
+                        csum.add_bytes(&bytes[..]);
+                    }
+                    Header::Raw(udp) => {
+                        csum.add_bytes(udp.0.as_bytes());
+                    }
+                }
+                udp.set_checksum(csum.finalize_for_ingot());
+            }
         }
     }
 }

--- a/lib/opte/src/engine/port/mod.rs
+++ b/lib/opte/src/engine/port/mod.rs
@@ -66,6 +66,7 @@ use crate::ddi::mblk::MsgBlkIterMut;
 use crate::ddi::sync::KMutex;
 use crate::ddi::sync::KRwLock;
 use crate::ddi::time::Moment;
+use crate::engine::HdlErrAction;
 use crate::engine::flow_table::EvictionPriority;
 use crate::engine::flow_table::ExpiryPolicy;
 use crate::engine::flow_table::FLOW_DEF_TTL;
@@ -231,6 +232,7 @@ pub struct PortBuilder {
     name_cstr: CString,
     mac: MacAddr,
     layers: KMutex<Vec<Layer>>,
+    mtu: Option<NonZeroU32>,
 }
 
 #[derive(Clone, Debug)]
@@ -355,6 +357,7 @@ impl PortBuilder {
             stats: KStatNamed::new("xde", &self.name, PortStats::new())?,
             net,
             data: KRwLock::new(data),
+            mtu: self.mtu,
         })
     }
 
@@ -400,6 +403,7 @@ impl PortBuilder {
         name_cstr: CString,
         mac: MacAddr,
         ectx: Arc<ExecCtx>,
+        mtu: Option<NonZeroU32>,
     ) -> Self {
         PortBuilder {
             name: name.to_string(),
@@ -407,6 +411,7 @@ impl PortBuilder {
             mac,
             ectx,
             layers: KMutex::new(Vec::new()),
+            mtu,
         }
     }
 
@@ -651,6 +656,10 @@ struct PortStats {
     /// and resulted in rule processing.
     in_uft_miss: KStatU64,
 
+    /// The number of inbound packets which were larger than the MTU
+    /// without valid offload state.
+    in_oversize: KStatU64,
+
     /// The number of outbound packets dropped
     /// ([`ProcessResult::Drop`]), for one reason or another.
     out_drop: KStatU64,
@@ -686,6 +695,10 @@ struct PortStats {
     /// The number of outbound packets which did not match a UFT entry
     /// and resulted in rule processing.
     out_uft_miss: KStatU64,
+
+    /// The number of outbound packets which were larger than the MTU
+    /// without valid offload state.
+    out_oversize: KStatU64,
 }
 
 struct PortData {
@@ -764,6 +777,7 @@ pub struct Port<N: NetworkImpl> {
     stats: KStatNamed<PortStats>,
     net: N,
     data: KRwLock<PortData>,
+    mtu: Option<NonZeroU32>,
 }
 
 // Convert:
@@ -1308,6 +1322,36 @@ impl<N: NetworkImpl> Port<N> {
 
         drop(data);
 
+        // Packets which are larger than the guest is able to receive may
+        // require bespoke handling by the `NetworkImpl`. If this is the case
+        // we make the packet ineligible for path (1). The exception to this is
+        // the presence of LRO/GRO flags, which suggest that multiple sub-MTU
+        // packets have been combined on its behalf and it is willing/able to
+        // resplit these if required.
+        //
+        // This needs to happen for both fast/slow-path traffic.
+        let oversize = self
+            .mtu
+            .map(|mtu| {
+                if pkt.large_offload() {
+                    false
+                } else {
+                    let inner_bytes = pkt
+                        .len()
+                        .saturating_sub(usize::from(pkt.meta().encap_len()))
+                        .saturating_sub(
+                            // OPTE's parser structure requires inner ethernet to be
+                            // present, and we do not support VLANs.
+                            ingot::ethernet::Ethernet::MINIMUM_LENGTH,
+                        );
+
+                    usize::try_from(mtu.get())
+                        .expect("usize is expected to be >= 32b")
+                        < inner_bytes
+                }
+            })
+            .unwrap_or(false);
+
         // If we have a UFT miss or invalid entry, upgrade to a write lock and
         // fetch again. This lets us use an optimistic lookup more often.
         let (uft, mut lock) = match uft {
@@ -1353,7 +1397,7 @@ impl<N: NetworkImpl> Port<N> {
                 // The Fast Path.
                 drop(lock.take());
                 let xforms = &entry.state().xforms;
-                let out = if xforms.compiled.is_some() {
+                let out = if !oversize && xforms.compiled.is_some() {
                     FastPathDecision::CompiledUft(entry)
                 } else {
                     FastPathDecision::Uft(entry)
@@ -1539,6 +1583,61 @@ impl<N: NetworkImpl> Port<N> {
         // (2)/(3) Full-fat metadata is required.
         let mut pkt = pkt.to_full_meta();
         let mut ameta = ActionMeta::new();
+
+        if oversize {
+            (match dir {
+                Direction::In => &self.stats.vals.in_oversize,
+                Direction::Out => &self.stats.vals.out_oversize,
+            })
+            .incr(1);
+
+            match self.net.handle_oversize(dir, &mut pkt)? {
+                HdlErrAction::ContinueProcessing => {}
+                HdlErrAction::Deny => {
+                    let res = Ok(ProcessResult::Drop {
+                        reason: DropReason::HandlePkt,
+                    });
+
+                    (match dir {
+                        Direction::In => &self.stats.vals.in_drop,
+                        Direction::Out => &self.stats.vals.out_drop,
+                    })
+                    .incr(1);
+
+                    self.port_process_return_probe(
+                        dir,
+                        &flow_before,
+                        &flow_before,
+                        epoch,
+                        mblk_addr,
+                        &res,
+                        decision.as_u64(),
+                    );
+
+                    return res;
+                }
+                HdlErrAction::Hairpin(msg_blk) => {
+                    let res = Ok(ProcessResult::Hairpin(msg_blk));
+
+                    (match dir {
+                        Direction::In => &self.stats.vals.in_hairpin,
+                        Direction::Out => &self.stats.vals.out_hairpin,
+                    })
+                    .incr(1);
+
+                    self.port_process_return_probe(
+                        dir,
+                        &flow_before,
+                        &flow_before,
+                        epoch,
+                        mblk_addr,
+                        &res,
+                        decision.as_u64(),
+                    );
+                    return res;
+                }
+            }
+        }
 
         let res = match (&decision, dir) {
             // (2) Apply retrieved transform. Lock is dropped.

--- a/lib/oxide-vpc/.gitignore
+++ b/lib/oxide-vpc/.gitignore
@@ -8,3 +8,5 @@ dhcpv6_solicit_reply.pcap
 guest_to_internet_ipv[46].pcap
 snat-v[46]-echo-id.pcap
 icmp[46]_inner_rewrite.pcap
+firewall_replace_rules.pcap
+packet_too_big.pcap

--- a/lib/oxide-vpc/src/engine/mod.rs
+++ b/lib/oxide-vpc/src/engine/mod.rs
@@ -52,8 +52,8 @@ use opte::engine::geneve::GeneveMeta;
 use opte::engine::geneve::GeneveMetaRef;
 use opte::engine::headers::EncapMeta;
 use opte::engine::headers::SizeHoldingEncap;
+use opte::engine::icmp::v4::DestinationUnreachable;
 use opte::engine::icmp::v4::DestinationUnreachableMut;
-use opte::engine::icmp::v4::ICMP_DU_FRAGMENTATION_NEEDED;
 use opte::engine::icmp::v4::ValidDestinationUnreachable;
 use opte::engine::ip::L3;
 use opte::engine::ip::v4::Ipv4;
@@ -81,6 +81,26 @@ use opte::ingot::types::Parsed as IngotParsed;
 use opte::ingot::types::Read;
 use zerocopy::ByteSlice;
 use zerocopy::ByteSliceMut;
+
+/// The maximum size of a generated ICMPv4 error message (RFC 1812,
+/// §4.3.2.3).
+///
+/// Error messages should contain as many bytes of the the original packet
+/// as possible, keeping the new packet within this limit.
+///
+/// Historically, error messages were clipped to the L3 header followed by
+/// 64 bits of their own payload (RFC 1191). Tunnelled traffic and newer
+/// protocols nested within UDP (e.g., QUIC) require the RFC 1812 value for
+/// PLPMTUD to function (RFC 8899).
+const RFC1812_MAX_ICMP_PACKET_SIZE: usize = 576;
+
+/// The minimum MTU required on any link for carrying IPv6
+/// traffic (RFC 2460, §5).
+///
+/// RFC 4443 §3.1 requires that any ICMPv6 error messages generated
+/// as a reply to a datagram contain as many bytes of the offending
+/// packet as possible, keeping the new packet within this limit.
+const RFC2460_MIN_IPV6_MTU: usize = 1280;
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct VpcParser {}
@@ -304,7 +324,7 @@ impl NetworkImpl for VpcNetwork {
 
                 let new_icmp = IcmpV4 {
                     ty: IcmpV4Type::DESTINATION_UNREACHABLE,
-                    code: ICMP_DU_FRAGMENTATION_NEEDED,
+                    code: DestinationUnreachable::FRAGMENTATION_NEEDED,
                     // MTU and body length are filled in below to require fewer casts
                     // of `rest_of_hdr` to `ValidDestinationUnreachable`.
                     ..Default::default()
@@ -324,12 +344,7 @@ impl NetworkImpl for VpcNetwork {
                         L3::<&mut [u8]>::from(new_v4),
                         Ulp::<&mut [u8]>::from(new_icmp),
                     ),
-                    // RFC 1812, §4.3.2.3
-                    // This is a larger quantity than that recommended in RFC 1191
-                    // (L3 + 64 bits), and can be expected by certain nested protocols
-                    // like QUIC. RFC 8899 (PLPMTUD for QUIC) directly indicates this
-                    // larger value.
-                    576,
+                    RFC1812_MAX_ICMP_PACKET_SIZE,
                 )
             }
             L3::Ipv6(v6) => {
@@ -424,8 +439,7 @@ impl NetworkImpl for VpcNetwork {
                     Ethertype::IPV6,
                     IpAddr::from(remote),
                     (L3::from(new_v6), Ulp::from(new_icmp)),
-                    // RFC 4443, §3.1
-                    1280,
+                    RFC2460_MIN_IPV6_MTU,
                 )
             }
         };

--- a/lib/oxide-vpc/src/engine/mod.rs
+++ b/lib/oxide-vpc/src/engine/mod.rs
@@ -12,9 +12,27 @@ pub mod nat;
 pub mod overlay;
 pub mod router;
 
+use crate::api::BOUNDARY_SERVICES_VNI;
 use crate::cfg::VpcCfg;
+use crate::engine::geneve::OxideOptions;
+use crate::engine::geneve::ValidOxideOption;
+use crate::engine::overlay::TUNNEL_ENDPOINT_MAC;
+use crate::engine::overlay::Virt2Boundary;
+use alloc::sync::Arc;
 use core::ops::Deref;
+use ingot::icmp::IcmpV4;
+use ingot::icmp::IcmpV4Mut;
+use ingot::icmp::IcmpV4Type;
+use ingot::icmp::IcmpV6;
+use ingot::icmp::IcmpV6Ref;
+use ingot::icmp::IcmpV6Type;
+use ingot::ip::IpProtocol;
+use ingot::types::HeaderLen;
+use opte::api::IpAddr;
+use opte::api::Vni;
+use opte::ddi::mblk::MsgBlk;
 use opte::engine::Direction;
+use opte::engine::HdlErrAction;
 use opte::engine::HdlPktAction;
 use opte::engine::HdlPktError;
 use opte::engine::LightweightMeta;
@@ -26,15 +44,31 @@ use opte::engine::arp::ArpEthIpv4Ref;
 use opte::engine::arp::ArpOp;
 use opte::engine::arp::ValidArpEthIpv4;
 use opte::engine::checksum::Checksum;
+use opte::engine::ether::Ethernet;
 use opte::engine::ether::EthernetRef;
 use opte::engine::flow_table::FlowTable;
+use opte::engine::geneve::GeneveMeta;
+use opte::engine::geneve::GeneveMetaRef;
+use opte::engine::headers::EncapMeta;
+use opte::engine::headers::SizeHoldingEncap;
+use opte::engine::icmp::v4::DestinationUnreachableMut;
+use opte::engine::icmp::v4::ICMP_DU_FRAGMENTATION_NEEDED;
+use opte::engine::icmp::v4::ValidDestinationUnreachable;
+use opte::engine::ip::L3;
+use opte::engine::ip::v4::Ipv4;
 use opte::engine::ip::v4::Ipv4Addr;
+use opte::engine::ip::v4::Ipv4Mut;
+use opte::engine::ip::v4::Ipv4Ref;
+use opte::engine::ip::v6::Ipv6;
+use opte::engine::ip::v6::Ipv6Mut;
+use opte::engine::ip::v6::Ipv6Ref;
 use opte::engine::packet::FullParsed;
 use opte::engine::packet::InnerFlowId;
 use opte::engine::packet::OpteMeta;
 use opte::engine::packet::Packet;
 use opte::engine::packet::ParseError;
 use opte::engine::packet::Pullup;
+use opte::engine::parse::Ulp;
 use opte::engine::parse::ValidGeneveOverV6;
 use opte::engine::parse::ValidNoEncap;
 use opte::engine::port::UftEntry;
@@ -56,9 +90,19 @@ impl VpcParser {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct VpcNetwork {
     pub cfg: VpcCfg,
+    pub v2b: Arc<Virt2Boundary>,
+}
+
+impl core::fmt::Debug for VpcNetwork {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("VpcNetwork")
+            .field("cfg", &self.cfg)
+            .field("v2b", &"<opaque>")
+            .finish()
+    }
 }
 
 fn is_arp_req(arp: &impl ArpEthIpv4Ref) -> bool {
@@ -123,6 +167,425 @@ impl NetworkImpl for VpcNetwork {
 
     fn parser(&self) -> Self::Parser {
         VpcParser {}
+    }
+
+    fn handle_oversize<'a, T: Read + Pullup + 'a>(
+        &self,
+        dir: Direction,
+        pkt: &mut Packet<FullParsed<T>>,
+    ) -> Result<HdlErrAction, HdlPktError>
+    where
+        T::Chunk: ByteSliceMut + IntoBufPointer<'a>,
+    {
+        let meta = pkt.meta();
+
+        let Some(l3) = meta.inner_l3() else {
+            // We can't generate an ICMP response without IP present in some
+            // form.
+            return Ok(HdlErrAction::Deny);
+        };
+
+        // If the packet came in encapsulated, then we need to mirror the
+        // encapsulation on our outbound frame.
+        let (is_external, mut encap) = match dir {
+            Direction::In => {
+                let Some(eth) = meta.outer_ether() else {
+                    return Err(HdlPktError(
+                        "inbound oxide-vpc packets must be encapped (l2)",
+                    ));
+                };
+                let Some(L3::Ipv6(v6)) = meta.outer_ip() else {
+                    return Err(HdlPktError(
+                        "inbound oxide-vpc packets must be encapped (l3)",
+                    ));
+                };
+                let Some(encap) = meta.outer_geneve() else {
+                    return Err(HdlPktError(
+                        "inbound oxide-vpc packets must be encapped (l4)",
+                    ));
+                };
+
+                let mut is_external = false;
+                let vni = encap.vni();
+                let entropy = encap.entropy();
+                for opt in OxideOptions::from_meta(encap) {
+                    let Ok(opt) = opt else { break };
+                    if let Some(ValidOxideOption::External) = opt.option.known()
+                    {
+                        is_external = true;
+                        break;
+                    }
+                }
+
+                let new_eth = Ethernet {
+                    destination: eth.source(),
+                    source: eth.destination(),
+                    ethertype: Ethertype::IPV6,
+                };
+
+                // We'll fill in payload lengths once the inner packet is built.
+                let new_v6 = Ipv6 {
+                    source: v6.destination(),
+                    destination: v6.source(),
+                    next_header: ingot::ip::IpProtocol::UDP,
+                    ..Default::default()
+                };
+                let new_geneve = EncapMeta::Geneve(GeneveMeta {
+                    entropy,
+                    vni: if is_external {
+                        Vni::new(BOUNDARY_SERVICES_VNI).unwrap()
+                    } else {
+                        vni
+                    },
+                    options: (&[]).into(),
+                });
+
+                (is_external, Some((new_eth, new_v6, new_geneve)))
+            }
+            Direction::Out => (false, None),
+        };
+
+        let mut truncated_original =
+            MsgBlk::new_ethernet_pkt((meta.inner_l3(), meta.inner_ulp()));
+
+        let body = pkt.body().unwrap_or_default();
+
+        let (ethertype, recipient, mut new_icmp_hdrs, max_sz) = match l3 {
+            L3::Ipv4(v4) => {
+                let Some(cfg) = self.cfg.ipv4_cfg() else {
+                    return Ok(HdlErrAction::Deny);
+                };
+
+                // RFC 792
+                // "To avoid the infinite regress of messages about messages
+                // etc., no ICMP messages are sent about ICMP messages."
+                match meta.inner_ulp() {
+                    Some(Ulp::IcmpV4(_)) => return Ok(HdlErrAction::Deny),
+                    Some(Ulp::IcmpV6(_)) => {
+                        return Err(HdlPktError(
+                            "IPv4 packet should not contain ICMPv6",
+                        ));
+                    }
+                    _ => {}
+                }
+
+                // RFC 1812, §4.3.2.7
+                // An ICMP error message MUST NOT be sent as the result of receiving:
+                // o A packet destined to an IP broadcast or IP multicast address, or
+                // o A packet sent as a Link Layer broadcast or multicast, or
+                // o A packet whose source address has a network prefix of zero or is an
+                //    invalid source address (as defined in Section [5.3.7]), or [...]
+                //
+                // This is to avoid causing any traffic amplification upstream.
+                let remote = v4.source();
+                let rcvd_on = v4.destination();
+                if remote.is_multicast()
+                    || remote.is_unspecified()
+                    || remote.is_broadcast()
+                    || remote.is_loopback()
+                    || rcvd_on.is_multicast()
+                    || rcvd_on.is_broadcast()
+                    || rcvd_on.is_unspecified()
+                {
+                    return Ok(HdlErrAction::Deny);
+                }
+
+                // RFC 1812, §4.3.2.4 governs source address selection. The main
+                // requirements here are that this is an address that we own in some form.
+                //
+                // If this packet has arrived from within the current Oxide cluster (i.e.
+                // this VPC or one which is peered), then OPTE has a valid address to use
+                // as the sender of any ICMP messages. For any external traffic, the best
+                // we can do is use the destination address; the control plane has
+                // programmed sidecar to forward this traffic to us, so we know that it is
+                // owned by the guest in some form.
+                let source = if is_external { rcvd_on } else { cfg.gateway_ip };
+
+                let new_icmp = IcmpV4 {
+                    ty: IcmpV4Type::DESTINATION_UNREACHABLE,
+                    code: ICMP_DU_FRAGMENTATION_NEEDED,
+                    // MTU and body length are filled in below to require fewer casts
+                    // of `rest_of_hdr` to `ValidDestinationUnreachable`.
+                    ..Default::default()
+                };
+
+                let new_v4 = Ipv4 {
+                    source,
+                    destination: remote,
+                    protocol: IpProtocol::ICMP,
+                    ..Default::default()
+                };
+
+                (
+                    Ethertype::IPV4,
+                    IpAddr::from(remote),
+                    (
+                        L3::<&mut [u8]>::from(new_v4),
+                        Ulp::<&mut [u8]>::from(new_icmp),
+                    ),
+                    // RFC 1812, §4.3.2.3
+                    // This is a larger quantity than that recommended in RFC 1191
+                    // (L3 + 64 bits), and can be expected by certain nested protocols
+                    // like QUIC. RFC 8899 (PLPMTUD for QUIC) directly indicates this
+                    // larger value.
+                    576,
+                )
+            }
+            L3::Ipv6(v6) => {
+                let Some(cfg) = self.cfg.ipv6_cfg() else {
+                    return Ok(HdlErrAction::Deny);
+                };
+
+                // RFC4443 §2.4(e)
+                // An ICMPv6 error message MUST NOT be originated as a result of
+                // receiving the following:
+                // (e.1) An ICMPv6 error message.
+                // (e.2) An ICMPv6 redirect message
+                match meta.inner_ulp() {
+                    Some(Ulp::IcmpV6(v6))
+                        if v6.ty().is_error()
+                            || v6.ty() == IcmpV6Type::REDIRECT =>
+                    {
+                        return Ok(HdlErrAction::Deny);
+                    }
+                    Some(Ulp::IcmpV4(_)) => {
+                        return Err(HdlPktError(
+                            "IPv6 packet should not contain ICMPv4",
+                        ));
+                    }
+                    _ => {}
+                }
+
+                // (e.6) A packet whose source address does not uniquely identify a
+                //       single node -- e.g., the IPv6 Unspecified Address, an IPv6
+                //       multicast address, or an address known by the ICMP message
+                //       originator to be an IPv6 anycast address.
+                let remote = v6.source();
+                let rcvd_on = v6.destination();
+                if remote.is_multicast()
+                    || remote.is_unspecified()
+                    || rcvd_on.is_unspecified()
+                {
+                    return Ok(HdlErrAction::Deny);
+                }
+
+                // (e.3)-(e.5) state that ONLY packet too big errors may be generated
+                // when the destination address is not unicast, so we apply no
+                // restriction on the destination address.
+
+                // Source selection here follows the same rubric as IPv4. However,
+                // because we permit broadcast/multicast destinations in the original
+                // packet (§3.2), we need to choose one of our external IPs as a
+                // source when this destination is not unicast if the gateway IP
+                // cannot be used.
+                let source = match (is_external, rcvd_on.is_multicast()) {
+                    (false, _) => cfg.gateway_ip,
+                    (true, false) => rcvd_on,
+                    (true, true) => {
+                        let ext_ips = cfg.external_ips.load();
+                        let attached_subnets = cfg.attached_subnets.load();
+                        let ip = ext_ips
+                            .floating_ips
+                            .first()
+                            .copied()
+                            .or_else(|| {
+                                attached_subnets.iter().find_map(|(k, v)| {
+                                    v.is_external.then_some(k.ip())
+                                })
+                            })
+                            .or(ext_ips.ephemeral_ip)
+                            .or_else(|| {
+                                ext_ips.snat.as_ref().map(|v| v.external_ip)
+                            });
+
+                        ip.ok_or(HdlPktError(
+                            "no valid external source address for non-unicast packet"
+                        ))?
+                    }
+                };
+
+                let new_icmp = IcmpV6 {
+                    ty: IcmpV6Type::PACKET_TOO_BIG,
+                    code: 0,
+                    // RFC 4443, §3.2
+                    rest_of_hdr: self.cfg.mtu.to_be_bytes(),
+                    ..Default::default()
+                };
+
+                let new_v6 = Ipv6 {
+                    source,
+                    destination: remote,
+                    next_header: IpProtocol::ICMP_V6,
+                    ..Default::default()
+                };
+
+                (
+                    Ethertype::IPV6,
+                    IpAddr::from(remote),
+                    (L3::from(new_v6), Ulp::from(new_icmp)),
+                    // RFC 4443, §3.1
+                    1280,
+                )
+            }
+        };
+
+        // We don't have control over the input headers, which may have any
+        // number of extension headers and the like in use. Trunctate that
+        // buffer if needed and then determine how many bytes to take from
+        // the body.
+        //
+        // Since we are pushing no extension headers ourselves, we know that
+        // the new headers fit within the limit by construction.
+        let bytes_used = new_icmp_hdrs.packet_length();
+        let headers_to_take =
+            (max_sz - bytes_used).min(truncated_original.len());
+        let bytes_used = bytes_used + headers_to_take;
+        if headers_to_take != truncated_original.len() {
+            truncated_original.truncate_chain(headers_to_take);
+        }
+
+        let body_to_take = (max_sz - bytes_used).min(body.len());
+        let truncated_body = &body[..body_to_take];
+        let bytes_used = bytes_used + body_to_take;
+
+        let mut body_csum = Checksum::new();
+        body_csum.add_bytes(&truncated_original);
+        body_csum.add_bytes(truncated_body);
+
+        // Now that we have determined the body of our new ICMP packet,
+        // we can fill in the remainder of its packet headers.
+        let pad = match &mut new_icmp_hdrs {
+            (L3::Ipv4(v4), Ulp::IcmpV4(icmp4)) => {
+                v4.set_total_len(
+                    u16::try_from(bytes_used).expect("less than 576B"),
+                );
+
+                let inner_bytes = headers_to_take + body_to_take;
+                let plus_pad = inner_bytes.next_multiple_of(4);
+
+                let (mut du, ..) = ValidDestinationUnreachable::parse(
+                    icmp4.rest_of_hdr_mut().as_mut_slice(),
+                )
+                .expect("fixed-size field has same size as struct");
+
+                du.set_length(
+                    u8::try_from(plus_pad / size_of::<u32>())
+                        .expect("plus_pad is less than 144 words (576B)"),
+                );
+                du.set_mtu(u16::try_from(self.cfg.mtu).unwrap_or(u16::MAX));
+
+                plus_pad - inner_bytes
+            }
+            (L3::Ipv6(v6), Ulp::IcmpV6(_)) => {
+                v6.set_payload_len(
+                    u16::try_from(bytes_used - v6.packet_length())
+                        .expect("less than 1280B"),
+                );
+                // IPv6 MTU is already set.
+                0
+            }
+            _ => unreachable!(),
+        };
+
+        new_icmp_hdrs
+            .1
+            .compute_checksum(new_icmp_hdrs.0.pseudo_header(), body_csum);
+        new_icmp_hdrs.0.compute_checksum();
+
+        let pad_from = [0u8; 3];
+
+        // Swapping the L3 headers is obvious, but the L2 headers need some
+        // explanation for doing the same correctly because of the various
+        // transforms in use during processing. Once a packet is processed
+        // outbound, it will have its destination updated to the target port's MAC.
+        // On the inbound case, we update the source MAC to that of the gateway.
+        //
+        //  - If we're rejecting on outbound, this reply will be gateway
+        //    to guest MAC, which is obviously correct.
+        //
+        //  - In the internal inbound case, because of the above transform the
+        //    gateway MAC is not on the scene and we see the inner MACs of each
+        //    port. This is good, as this prevents us from needing a V2P lookup
+        //    to ensure the packet will be delivered to the right OPTE on the
+        //    original sled. The reply will have the source rewritten to the
+        //    gateway MAC at the end of its own inbound processing.
+        //
+        //  - In the external inbound case, the original source will be zeroed.
+        //    Sidecar is only checking for traffic pointed at a switch address
+        //    and does not care about the inner MACs, but we should be thorough
+        //    in case this contract becomes more strict.
+        let new_eth = Ethernet {
+            destination: if !is_external {
+                meta.inner_ether().source()
+            } else {
+                TUNNEL_ENDPOINT_MAC.into()
+            },
+            source: meta.inner_ether().destination(),
+            ethertype,
+        };
+
+        truncated_original
+            .append(MsgBlk::new_pkt((truncated_body, &pad_from[..pad])));
+        let encapped_len = (&new_eth, &new_icmp_hdrs).packet_length()
+            + truncated_original.byte_len();
+        let encapped_len = u16::try_from(encapped_len)
+            .expect("maximmum inner packet size is below 1300B");
+
+        // Now we can specialise the encap layers with the inner packet size,
+        // and identify a switch address to reach any external sender if required.
+        let encap = encap
+            .as_mut()
+            .map(|(eth, l3, gv)| {
+                // ...Sidecar will give us a zeroed source address on NAT'd
+                // packets. This isn't a great destination for a frame: it must
+                // be a valid switch address to actually be eligible for
+                // decapsulation!
+                if l3.destination.is_unspecified() {
+                    if !is_external {
+                        return Err(HdlPktError(
+                            "cannot reply to null sled address",
+                        ));
+                    }
+
+                    let Some(nhs) =
+                        self.v2b.get(&recipient).filter(|v| !v.is_empty())
+                    else {
+                        return Err(HdlPktError(
+                            "no external nexthop for ICMP reply",
+                        ));
+                    };
+
+                    let hash = pkt.l4_hash() as usize;
+                    let nh = nhs
+                        .iter()
+                        .nth(hash % nhs.len())
+                        .expect("nhs nonempty, index is always less than len");
+
+                    let EncapMeta::Geneve(gv) = gv;
+                    gv.vni = nh.vni;
+
+                    l3.destination = nh.ip;
+
+                    // Clear the ethernet src/dst, since we can't guarantee that
+                    // we will be going out the same NIC we came in on.
+                    eth.destination = Default::default();
+                    eth.source = Default::default();
+                }
+
+                let sized_geneve =
+                    SizeHoldingEncap { encapped_len, meta: &*gv };
+                l3.payload_len = u16::try_from(sized_geneve.packet_length())
+                    .expect("inner packet is at most 1294B")
+                    .saturating_add(encapped_len);
+
+                Ok((&*eth, &*l3, sized_geneve))
+            })
+            .transpose()?;
+
+        let mut out = MsgBlk::new_ethernet_pkt((encap, new_eth, new_icmp_hdrs));
+        out.append(truncated_original);
+
+        Ok(HdlErrAction::Hairpin(out))
     }
 }
 

--- a/lib/oxide-vpc/src/engine/mod.rs
+++ b/lib/oxide-vpc/src/engine/mod.rs
@@ -20,6 +20,7 @@ use crate::engine::overlay::TUNNEL_ENDPOINT_MAC;
 use crate::engine::overlay::Virt2Boundary;
 use alloc::sync::Arc;
 use core::ops::Deref;
+use core::ops::DerefMut;
 use ingot::icmp::IcmpV4;
 use ingot::icmp::IcmpV4Mut;
 use ingot::icmp::IcmpV4Type;
@@ -627,6 +628,12 @@ impl<T: ByteSlice> Deref for OxideGeneve<T> {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl<T: ByteSlice> DerefMut for OxideGeneve<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 

--- a/lib/oxide-vpc/tests/integration_tests.rs
+++ b/lib/oxide-vpc/tests/integration_tests.rs
@@ -15,6 +15,10 @@
 
 use common::icmp::*;
 use common::*;
+use illumos_sys_hdrs::mac::MblkOffloadFlags;
+use ingot::icmp::IcmpV4Ref;
+use ingot::icmp::IcmpV4Type;
+use ingot::icmp::IcmpV6Type;
 use opte::api::L4Info;
 use opte::api::MacAddr;
 use opte::api::OpteError;
@@ -44,6 +48,7 @@ use opte::engine::packet::InnerFlowId;
 use opte::engine::packet::MblkFullParsed;
 use opte::engine::packet::MismatchError;
 use opte::engine::packet::Packet;
+use opte::engine::parse::Ulp;
 use opte::engine::parse::ValidUlp;
 use opte::engine::port::DropReason;
 use opte::engine::port::ProcessError;
@@ -5633,4 +5638,556 @@ fn test_v6_ext_hdr_geneve_offset_ok() {
         geneve::extract_multicast_replication(&parsed.meta().outer_encap)
             .expect("multicast option present");
     assert_eq!(repl, oxide_vpc::api::Replication::External);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_generated_icmp(
+    cfg: &VpcCfg,
+    dir: Direction,
+    is_external: bool,
+    partner_phys: TestIpPhys,
+    partner_ip: IpAddr,
+    partner_mac: MacAddr,
+    mut genned_icmp: MsgBlk,
+    expect_icmp_cksum: u16,
+    raw_src: &[u8],
+) {
+    let guest_phys =
+        TestIpPhys { ip: cfg.phys_ip, mac: cfg.guest_mac, vni: cfg.vni };
+
+    let is_v4 = matches!(partner_ip, IpAddr::Ip4(_));
+    let max_sz = if is_v4 { 576 } else { 1280 };
+
+    let parsed_hp = match dir {
+        Direction::In => {
+            // This parser will assert in its operation that we have
+            // valid Geneve encap.
+            parse_inbound(&mut genned_icmp, VpcParser {})
+                .unwrap()
+                .to_full_meta()
+        }
+        Direction::Out => parse_outbound(&mut genned_icmp, VpcParser {})
+            .unwrap()
+            .to_full_meta(),
+    };
+    let meta = parsed_hp.meta();
+
+    if dir == Direction::In {
+        let eth = meta.outer_ether().unwrap();
+
+        // At present, external packets do not have their source router
+        // known. These addresses are zero as OPTE has identified a
+        // (possibly different) nexthop and we expect xde to fill these in
+        // before transmission.
+        let (want_dst, want_src) = if is_external {
+            (MacAddr::ZERO, MacAddr::ZERO)
+        } else {
+            (partner_phys.mac, guest_phys.mac)
+        };
+        assert_eq!(eth.destination(), want_dst);
+        assert_eq!(eth.source(), want_src);
+
+        let target_payload_len =
+            max_sz + (&meta.outer_encap(), &meta.inner_ether()).packet_length();
+        let Some(L3::Ipv6(v6)) = meta.outer_ip() else {
+            panic!();
+        };
+        assert_eq!(v6.destination(), partner_phys.ip);
+        assert_eq!(v6.source(), guest_phys.ip);
+        assert_eq!(usize::from(v6.payload_len()), target_payload_len);
+        assert_eq!(
+            usize::from(meta.outer_geneve().unwrap().raw().unwrap().0.length()),
+            target_payload_len
+        );
+    } else {
+        assert!(meta.outer_encap().is_none());
+    }
+
+    let (want_dst, want_src) = match dir {
+        Direction::In if is_external => (BS_MAC_ADDR, cfg.guest_mac),
+        Direction::In => (partner_mac, cfg.guest_mac),
+        Direction::Out => (cfg.guest_mac, cfg.gateway_mac),
+    };
+
+    assert_eq!(meta.inner_ether().destination(), want_dst);
+    assert_eq!(meta.inner_ether().source(), want_src);
+
+    if is_v4 {
+        let L3::Ipv4(v4m) = &meta.inner_l3().unwrap() else {
+            panic!();
+        };
+
+        let IpAddr::Ip4(partner_ip) = partner_ip else {
+            panic!();
+        };
+
+        let (want_dst, want_src) = match dir {
+            Direction::In if is_external => {
+                (partner_ip, cfg.ipv4().external_ips.ephemeral_ip.unwrap())
+            }
+            Direction::In => (partner_ip, cfg.ipv4().gateway_ip),
+            Direction::Out => (cfg.ipv4().private_ip, cfg.ipv4().gateway_ip),
+        };
+
+        assert_eq!(v4m.destination(), want_dst);
+        assert_eq!(v4m.source(), want_src);
+
+        let Ulp::IcmpV4(ic4m) = &meta.inner_ulp().unwrap() else {
+            panic!();
+        };
+        assert_eq!(ic4m.ty(), IcmpV4Type::DESTINATION_UNREACHABLE);
+        assert_eq!(ic4m.code(), 4);
+        assert_eq!(ic4m.checksum(), expect_icmp_cksum);
+        let roh = ic4m.rest_of_hdr();
+        assert_eq!(roh[0], 0);
+        assert_eq!(
+            usize::from(roh[1]) * 4,
+            max_sz - (&v4m, &ic4m).packet_length()
+        );
+        assert_eq!(u16::from_be_bytes([roh[2], roh[3]]), 1500);
+    } else {
+        let L3::Ipv6(v6m) = &meta.inner_l3().unwrap() else {
+            panic!();
+        };
+
+        let IpAddr::Ip6(partner_ip) = partner_ip else {
+            panic!();
+        };
+
+        let (want_dst, want_src) = match dir {
+            Direction::In if is_external => {
+                (partner_ip, cfg.ipv6().external_ips.ephemeral_ip.unwrap())
+            }
+            Direction::In => (partner_ip, cfg.ipv6().gateway_ip),
+            Direction::Out => (cfg.ipv6().private_ip, cfg.ipv6().gateway_ip),
+        };
+
+        assert_eq!(v6m.destination(), want_dst);
+        assert_eq!(v6m.source(), want_src);
+
+        let Ulp::IcmpV6(ic6m) = &meta.inner_ulp().unwrap() else {
+            panic!();
+        };
+        assert_eq!(ic6m.ty(), IcmpV6Type::PACKET_TOO_BIG);
+        assert_eq!(ic6m.code(), 0);
+        assert_eq!(ic6m.checksum(), expect_icmp_cksum);
+        assert_eq!(u32::from_be_bytes(ic6m.rest_of_hdr()), 1500);
+    }
+
+    let Some(trunc_body) = parsed_hp.body() else {
+        panic!();
+    };
+    assert!(raw_src[Ethernet::MINIMUM_LENGTH..].starts_with(trunc_body));
+}
+
+// Ports which specify an MTU will ask the `NetworkImpl` how these packets
+// should be handled. For the Oxide VPC all such packets (barring certain ICMP
+// or source addresses) should generate ICMP(v6) error messages carrying the MTU.
+#[test]
+fn packet_too_big_generation() {
+    // The checksums we're enforcing here are sourced from what wireshark
+    // tells us is correct, when investigated in this pcap. This is pretty
+    // important since we're building these packets from scratch!
+    let mut pcap = PcapBuilder::new("packet_too_big.pcap");
+
+    let (mut g1, g1_cfg, ..) = multi_external_ip_setup(1, true);
+    let g2_cfg = g2_cfg();
+    let guest_phys = TestIpPhys {
+        ip: g1_cfg.phys_ip,
+        mac: g1_cfg.guest_mac,
+        vni: g1_cfg.vni,
+    };
+    let partner_phys = TestIpPhys {
+        ip: g2_cfg.phys_ip,
+        mac: g2_cfg.guest_mac,
+        vni: g1_cfg.vni,
+    };
+
+    // Allow incoming TCP connection from anyone.
+    let rule = "dir=in action=allow priority=10 protocol=TCP";
+    firewall::add_fw_rule(
+        &g1.port,
+        &AddFwRuleReq {
+            port_name: g1.port.name().to_string(),
+            rule: rule.parse().unwrap(),
+        },
+    )
+    .unwrap();
+    incr!(g1, ["epoch", "firewall.rules.in"]);
+
+    // Construct a reasonable enough (though large!) inner packet for each
+    // IP version, sent from another node who has a higher MTU.
+    //
+    // We're not simulating its outbound processing at the partner, but roughly
+    // the flow here would be that the partner sends an ethernet frame from
+    // `partner_mac` to the gateway MAC. Once processed the destination MAC
+    // is rewritten to our port's MAC.
+    let partner_v4 = "172.30.0.6".parse().unwrap();
+    let partner_v6 = "fd00::6".parse().unwrap();
+    let partner_mac = ox_vpc_mac([0xa, 0xb, 0xc]);
+
+    let body: Vec<u8> = (0..2000u32).map(|i| i as u8).collect();
+    let inner_tcp = Tcp {
+        source: 1234,
+        destination: 5678,
+        flags: IngotTcpFlags::ACK,
+        ..Default::default()
+    };
+    let inner_v4 = Ipv4 {
+        source: partner_v4,
+        destination: g1_cfg.ipv4().private_ip,
+        protocol: IpProtocol::TCP,
+        total_len: u16::try_from(
+            Ipv4::MINIMUM_LENGTH + (&inner_tcp, &body).packet_length(),
+        )
+        .unwrap(),
+        ..Default::default()
+    };
+    let inner_v6 = Ipv6 {
+        source: partner_v6,
+        destination: g1_cfg.ipv6().private_ip,
+        next_header: IpProtocol::TCP,
+        payload_len: u16::try_from((&inner_tcp, &body).packet_length())
+            .unwrap(),
+        ..Default::default()
+    };
+
+    // --------
+    // Inbound, internal.
+    // --------
+    //
+    // On inbound receipt of each (cast as rack-local delivery),
+    // we generate an ICMP packet. These should be encapsulated, and
+    // we expect to see that almost all src/dst fields are mirrored.
+    // However, the inner IP source should be the port's gateway address:
+    // this is a sensible choice since we're still in our private
+    // network space.
+    let v4_in = ulp_pkt(
+        Ethernet {
+            destination: g1_cfg.guest_mac,
+            source: partner_mac,
+            ethertype: Ethertype::IPV4,
+        },
+        &inner_v4,
+        &inner_tcp,
+        &body,
+    );
+    let v4_in_raw = v4_in.copy_all();
+    let mut v4_in_e = encap(v4_in, partner_phys, guest_phys);
+    let v6_in = ulp_pkt(
+        Ethernet {
+            destination: g1_cfg.guest_mac,
+            source: partner_mac,
+            ethertype: Ethertype::IPV6,
+        },
+        &inner_v6,
+        &inner_tcp,
+        &body,
+    );
+    let v6_in_raw = v6_in.copy_all();
+    let mut v6_in_e = encap(v6_in, partner_phys, guest_phys);
+
+    let parsed = parse_inbound(&mut v4_in_e, VpcParser {}).unwrap();
+    let res = g1.port.process(Direction::In, parsed);
+    let Ok(Hairpin(hp)) = res else { panic!("expected Hairpin, got {res:?}") };
+    pcap.add_pkt(&hp);
+    validate_generated_icmp(
+        &g1_cfg,
+        Direction::In,
+        false,
+        partner_phys,
+        partner_v4.into(),
+        partner_mac,
+        hp,
+        0x1670,
+        &v4_in_raw,
+    );
+
+    let parsed = parse_inbound(&mut v6_in_e, VpcParser {}).unwrap();
+    let res = g1.port.process(Direction::In, parsed);
+    let Ok(Hairpin(hp)) = res else { panic!("expected Hairpin, got {res:?}") };
+    pcap.add_pkt(&hp);
+    validate_generated_icmp(
+        &g1_cfg,
+        Direction::In,
+        false,
+        partner_phys,
+        partner_v6.into(),
+        partner_mac,
+        hp,
+        0xa63e,
+        &v6_in_raw,
+    );
+
+    // --------
+    // Inbound, external.
+    // --------
+    //
+    // OPTE's gateway address, being a private IP, is not something we can
+    // meaningfully use as a source. Fall back to the target's address in this
+    // case.
+    //
+    // Encapsulation here needs to choose a route through the V2B if
+    // sidecar does not provide us a usable encap source address.
+    let ext_inbound_phys = TestIpPhys {
+        ip: Ipv6Addr::default(),
+        mac: MacAddr::default(),
+        vni: g1_cfg.vni,
+    };
+
+    let ext_partner_v4 = "1.1.1.1".parse().unwrap();
+    let ext_partner_v6 = "2606:2800:220:1:248:1893:25c8:1946".parse().unwrap();
+    let mut inner_v4_ex = inner_v4.clone();
+    inner_v4_ex.source = ext_partner_v4;
+    inner_v4_ex.destination = g1_cfg.ipv4().external_ips.ephemeral_ip.unwrap();
+
+    let mut inner_v6_ex = inner_v6.clone();
+    inner_v6_ex.source = ext_partner_v6;
+    inner_v6_ex.destination = g1_cfg.ipv6().external_ips.ephemeral_ip.unwrap();
+
+    let v4_in_ext = ulp_pkt(
+        Ethernet {
+            destination: g1_cfg.guest_mac,
+            source: Default::default(),
+            ethertype: Ethertype::IPV4,
+        },
+        &inner_v4_ex,
+        &inner_tcp,
+        &body,
+    );
+    let v4_in_ext_raw = v4_in_ext.copy_all();
+    let mut v4_in_ext = encap_external(v4_in_ext, ext_inbound_phys, guest_phys);
+
+    // These packets rely on the V2B entries installed during initialisation.
+
+    let v6_in_ext = ulp_pkt(
+        Ethernet {
+            destination: g1_cfg.guest_mac,
+            source: Default::default(),
+            ethertype: Ethertype::IPV6,
+        },
+        &inner_v6_ex,
+        &inner_tcp,
+        &body,
+    );
+    let v6_in_ext_raw = v6_in_ext.copy_all();
+    let mut v6_in_ext = encap_external(v6_in_ext, ext_inbound_phys, guest_phys);
+
+    let parsed = parse_inbound(&mut v4_in_ext, VpcParser {}).unwrap();
+    let res = g1.port.process(Direction::In, parsed);
+    let Ok(Hairpin(hp)) = res else { panic!("expected Hairpin, got {res:?}") };
+    pcap.add_pkt(&hp);
+    validate_generated_icmp(
+        &g1_cfg,
+        Direction::In,
+        true,
+        *BSVC_PHYS,
+        ext_partner_v4.into(),
+        partner_mac,
+        hp,
+        0xcb66,
+        &v4_in_ext_raw,
+    );
+
+    let parsed = parse_inbound(&mut v6_in_ext, VpcParser {}).unwrap();
+    let res = g1.port.process(Direction::In, parsed);
+    let Ok(Hairpin(hp)) = res else { panic!("expected Hairpin, got {res:?}") };
+    pcap.add_pkt(&hp);
+    validate_generated_icmp(
+        &g1_cfg,
+        Direction::In,
+        true,
+        *BSVC_PHYS,
+        ext_partner_v6.into(),
+        partner_mac,
+        hp,
+        0xc87c,
+        &v6_in_ext_raw,
+    );
+
+    // --------
+    // Outbound
+    // --------
+    //
+    // We expect in the replies that OPTE sets its gateway addresses as the
+    // source for L2/L3, and that we're not encapsulated.
+    let mut inner_v4_out = inner_v4;
+    std::mem::swap(&mut inner_v4_out.source, &mut inner_v4_out.destination);
+    let mut inner_v6_out = inner_v6;
+    std::mem::swap(&mut inner_v6_out.source, &mut inner_v6_out.destination);
+    let mut v4_out = ulp_pkt(
+        Ethernet {
+            destination: g1_cfg.gateway_mac,
+            source: g1_cfg.guest_mac,
+            ethertype: Ethertype::IPV4,
+        },
+        &inner_v4_out,
+        &inner_tcp,
+        &body,
+    );
+    let v4_out_raw = v4_out.copy_all();
+    let mut v6_out = ulp_pkt(
+        Ethernet {
+            destination: g1_cfg.gateway_mac,
+            source: g1_cfg.guest_mac,
+            ethertype: Ethertype::IPV6,
+        },
+        &inner_v6_out,
+        &inner_tcp,
+        &body,
+    );
+    let v6_out_raw = v6_out.copy_all();
+
+    let parsed = parse_outbound(&mut v4_out, VpcParser {}).unwrap();
+    let res = g1.port.process(Direction::Out, parsed);
+    let Ok(Hairpin(hp)) = res else { panic!("expected Hairpin, got {res:?}") };
+    pcap.add_pkt(&hp);
+    validate_generated_icmp(
+        &g1_cfg,
+        Direction::Out,
+        false,
+        partner_phys,
+        partner_v4.into(),
+        partner_mac,
+        hp,
+        0x1670,
+        &v4_out_raw,
+    );
+
+    let parsed = parse_outbound(&mut v6_out, VpcParser {}).unwrap();
+    let res = g1.port.process(Direction::Out, parsed);
+    let Ok(Hairpin(hp)) = res else { panic!("expected Hairpin, got {res:?}") };
+    pcap.add_pkt(&hp);
+    validate_generated_icmp(
+        &g1_cfg,
+        Direction::Out,
+        false,
+        partner_phys,
+        partner_v6.into(),
+        partner_mac,
+        hp,
+        0xa63f,
+        &v6_out_raw,
+    );
+}
+
+// Offload flags pushed into a packet by the driver itself should be
+// preserved. Inclusion of LSO flags and MSS should flag the packet as being
+// allowed for oversize handling: the mblk contains enough data for
+// the recipient OS to carve the packet up again into a form which
+// respects the negotiated MSS, if needed.
+#[test]
+fn offload_info_preserved() {
+    let (mut g1, g1_cfg, ..) = multi_external_ip_setup(1, true);
+    let g2_cfg = g2_cfg();
+    let guest_phys = TestIpPhys {
+        ip: g1_cfg.phys_ip,
+        mac: g1_cfg.guest_mac,
+        vni: g1_cfg.vni,
+    };
+    let partner_phys = TestIpPhys {
+        ip: g2_cfg.phys_ip,
+        mac: g2_cfg.guest_mac,
+        vni: g1_cfg.vni,
+    };
+
+    // Allow incoming TCP connection from anyone.
+    let rule = "dir=in action=allow priority=10 protocol=TCP";
+    firewall::add_fw_rule(
+        &g1.port,
+        &AddFwRuleReq {
+            port_name: g1.port.name().to_string(),
+            rule: rule.parse().unwrap(),
+        },
+    )
+    .unwrap();
+    incr!(g1, ["epoch", "firewall.rules.in"]);
+
+    // As above, construct a single large inbound packet.
+    // Give it a reasonable MSS and mark it as LSO-eligible.
+    let partner_v4 = "172.30.0.6".parse().unwrap();
+    let partner_mac = ox_vpc_mac([0xa, 0xb, 0xc]);
+    g1.vpc_map.add(IpAddr::from(partner_v4), g2_cfg.phys_addr());
+
+    let body: Vec<u8> = (0..9000u32).map(|i| i as u8).collect();
+    let inner_tcp = Tcp {
+        source: 1234,
+        destination: 5678,
+        flags: IngotTcpFlags::ACK,
+        ..Default::default()
+    };
+    let inner_v4 = Ipv4 {
+        source: partner_v4,
+        destination: g1_cfg.ipv4().private_ip,
+        protocol: IpProtocol::TCP,
+        total_len: u16::try_from(
+            Ipv4::MINIMUM_LENGTH + (&inner_tcp, &body).packet_length(),
+        )
+        .unwrap(),
+        ..Default::default()
+    };
+
+    let v4_in = ulp_pkt(
+        Ethernet {
+            destination: g1_cfg.guest_mac,
+            source: partner_mac,
+            ethertype: Ethertype::IPV4,
+        },
+        &inner_v4,
+        &inner_tcp,
+        &body,
+    );
+
+    // This encapsulation *deliberately* pushes the new headers as
+    // a separate mblk. We need OPTE to preserve these once the emit spec
+    // is fully applied.
+    let mut v4_in_e = encap(v4_in, partner_phys, guest_phys);
+    let mut parsed = parse_inbound(&mut v4_in_e, VpcParser {}).unwrap();
+    parsed.request_offload(MblkOffloadFlags::HW_LSO, 1448);
+    let res = g1.port.process(Direction::In, parsed);
+    expect_modified!(res, v4_in_e);
+    incr!(
+        g1,
+        [
+            "firewall.flows.out, firewall.flows.in",
+            "uft.in",
+            "stats.port.in_modified, stats.port.in_uft_miss",
+        ]
+    );
+    let offload = v4_in_e.offload_flags();
+    assert!(offload.flags.contains(MblkOffloadFlags::HW_LSO));
+    assert_eq!(offload.mss, 1448);
+
+    // Ensure the same behaviour holds outbound: guests will set these
+    // flags.
+    let mut inner_v4_out = inner_v4;
+    std::mem::swap(&mut inner_v4_out.source, &mut inner_v4_out.destination);
+    let mut v4_out = ulp_pkt(
+        Ethernet {
+            destination: g1_cfg.gateway_mac,
+            source: g1_cfg.guest_mac,
+            ethertype: Ethertype::IPV4,
+        },
+        &inner_v4_out,
+        &inner_tcp,
+        &body,
+    );
+    // Set offload flags *before* parsing this time, to ensure both cases are
+    // handled correctly.
+    v4_out.request_offload(MblkOffloadFlags::HW_LSO, 1448);
+    let mut parsed = parse_outbound(&mut v4_out, VpcParser {}).unwrap();
+    parsed.request_offload(MblkOffloadFlags::HW_LSO, 1448);
+    let res = g1.port.process(Direction::Out, parsed);
+    expect_modified!(res, v4_out);
+    incr!(
+        g1,
+        [
+            "firewall.flows.out, firewall.flows.in",
+            "uft.out",
+            "stats.port.out_modified, stats.port.out_uft_miss",
+        ]
+    );
+    let offload = v4_in_e.offload_flags();
+    assert!(offload.flags.contains(MblkOffloadFlags::HW_LSO));
+    assert_eq!(offload.mss, 1448);
 }

--- a/xde-tests/src/lib.rs
+++ b/xde-tests/src/lib.rs
@@ -24,8 +24,12 @@ use oxide_vpc::api::IpCfg;
 use oxide_vpc::api::IpCidr;
 use oxide_vpc::api::Ipv4Addr;
 use oxide_vpc::api::Ipv4Cfg;
+use oxide_vpc::api::Ipv4Cidr;
+use oxide_vpc::api::Ipv4PrefixLen;
 use oxide_vpc::api::Ipv6Addr;
 use oxide_vpc::api::Ipv6Cfg;
+use oxide_vpc::api::Ipv6Cidr;
+use oxide_vpc::api::Ipv6PrefixLen;
 use oxide_vpc::api::MacAddr;
 use oxide_vpc::api::McastForwardingNextHop;
 use oxide_vpc::api::McastSubscribeReq;
@@ -47,6 +51,7 @@ use rand::RngExt;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::collections::HashSet;
+use std::num::NonZeroU32;
 use std::process::Child;
 use std::process::Command;
 use std::process::Stdio;
@@ -292,6 +297,7 @@ impl OptePort {
         private_ip: &str,
         guest_mac: &str,
         phys_ip: &str,
+        mtu: Option<NonZeroU32>,
     ) -> Result<Self> {
         let cfg = VpcCfg {
             ip_cfg: IpCfg::Ipv4(Ipv4Cfg {
@@ -316,7 +322,7 @@ impl OptePort {
             dhcp: DhcpCfg::default(),
         };
         let adm = OpteHdl::open()?;
-        adm.create_xde(name, cfg.clone(), None)?;
+        adm.create_xde(name, cfg.clone(), mtu.map(NonZeroU32::get))?;
         Ok(OptePort {
             name: name.into(),
             cfg,
@@ -331,6 +337,7 @@ impl OptePort {
         private_ip_v6: &str,
         guest_mac: &str,
         phys_ip: &str,
+        mtu: Option<NonZeroU32>,
     ) -> Result<Self> {
         let cfg = VpcCfg {
             ip_cfg: IpCfg::DualStack {
@@ -372,7 +379,7 @@ impl OptePort {
             dhcp: DhcpCfg::default(),
         };
         let adm = OpteHdl::open()?;
-        adm.create_xde(name, cfg.clone(), None)?;
+        adm.create_xde(name, cfg.clone(), mtu.map(NonZeroU32::get))?;
         Ok(OptePort {
             name: name.into(),
             cfg,
@@ -385,7 +392,14 @@ impl OptePort {
         let adm = OpteHdl::open()?;
         adm.add_router_entry(&AddRouterEntryReq {
             port_name: self.name.clone(),
-            dest: IpCidr::Ip4(format!("{dest}/32").parse().unwrap()),
+            dest: match dest.parse::<IpAddr>().unwrap() {
+                IpAddr::Ip4(ip) => {
+                    IpCidr::Ip4(Ipv4Cidr::new(ip, Ipv4PrefixLen::NETMASK_ALL))
+                }
+                IpAddr::Ip6(ip) => {
+                    IpCidr::Ip6(Ipv6Cidr::new(ip, Ipv6PrefixLen::NETMASK_ALL))
+                }
+            },
             target: RouterTarget::Ip(dest.parse().unwrap()),
             class: RouterClass::System,
         })?;
@@ -888,8 +902,13 @@ pub fn two_node_topology() -> Result<Topology> {
     Xde::set_v2p("10.0.0.2", "a8:40:25:ff:00:02", "fd77::1")?;
 
     // Create the first OPTE port with the provided overlay/underlay parameters.
-    let opte0 =
-        OptePort::new("opte0", "10.0.0.1", "a8:40:25:ff:00:01", "fd44::1")?;
+    let opte0 = OptePort::new(
+        "opte0",
+        "10.0.0.1",
+        "a8:40:25:ff:00:01",
+        "fd44::1",
+        None,
+    )?;
     opte0.add_router_entry("10.0.0.2")?;
     opte0.fw_allow_all()?;
 
@@ -909,8 +928,13 @@ pub fn two_node_topology() -> Result<Topology> {
         RouteV6::new(opte0.underlay_ip(), 64, ll0.ip, Some(vn1.name.clone()))?;
 
     // Create the second OPTE port with the provided overlay/underlay parameters.
-    let opte1 =
-        OptePort::new("opte1", "10.0.0.2", "a8:40:25:ff:00:02", "fd77::1")?;
+    let opte1 = OptePort::new(
+        "opte1",
+        "10.0.0.2",
+        "a8:40:25:ff:00:02",
+        "fd77::1",
+        None,
+    )?;
     opte1.add_router_entry("10.0.0.1")?;
     opte1.fw_allow_all()?;
 
@@ -993,6 +1017,7 @@ pub fn two_node_topology_dualstack() -> Result<Topology> {
         "fd00::1",
         "a8:40:25:ff:00:01",
         "fd44::1",
+        None,
     )?;
     opte0.add_router_entry("10.0.0.2")?;
     opte0.fw_allow_all()?;
@@ -1007,6 +1032,7 @@ pub fn two_node_topology_dualstack() -> Result<Topology> {
         "fd00::2",
         "a8:40:25:ff:00:02",
         "fd77::1",
+        None,
     )?;
     opte1.add_router_entry("10.0.0.1")?;
     opte1.fw_allow_all()?;
@@ -1080,20 +1106,35 @@ pub fn three_node_topology() -> Result<Topology> {
     Xde::set_v2p("10.0.0.3", "a8:40:25:ff:00:03", "fd88::1")?;
 
     // Create three OPTE ports
-    let opte0 =
-        OptePort::new("opte0", "10.0.0.1", "a8:40:25:ff:00:01", "fd44::1")?;
+    let opte0 = OptePort::new(
+        "opte0",
+        "10.0.0.1",
+        "a8:40:25:ff:00:01",
+        "fd44::1",
+        None,
+    )?;
     opte0.add_router_entry("10.0.0.2")?;
     opte0.add_router_entry("10.0.0.3")?;
     opte0.fw_allow_all()?;
 
-    let opte1 =
-        OptePort::new("opte1", "10.0.0.2", "a8:40:25:ff:00:02", "fd77::1")?;
+    let opte1 = OptePort::new(
+        "opte1",
+        "10.0.0.2",
+        "a8:40:25:ff:00:02",
+        "fd77::1",
+        None,
+    )?;
     opte1.add_router_entry("10.0.0.1")?;
     opte1.add_router_entry("10.0.0.3")?;
     opte1.fw_allow_all()?;
 
-    let opte2 =
-        OptePort::new("opte2", "10.0.0.3", "a8:40:25:ff:00:03", "fd88::1")?;
+    let opte2 = OptePort::new(
+        "opte2",
+        "10.0.0.3",
+        "a8:40:25:ff:00:03",
+        "fd88::1",
+        None,
+    )?;
     opte2.add_router_entry("10.0.0.1")?;
     opte2.add_router_entry("10.0.0.2")?;
     opte2.fw_allow_all()?;
@@ -1189,6 +1230,7 @@ pub fn three_node_topology_dualstack() -> Result<Topology> {
         "fd00::1",
         "a8:40:25:ff:00:01",
         "fd44::1",
+        None,
     )?;
     opte0.add_router_entry("10.0.0.2")?;
     opte0.add_router_entry("10.0.0.3")?;
@@ -1200,6 +1242,7 @@ pub fn three_node_topology_dualstack() -> Result<Topology> {
         "fd00::2",
         "a8:40:25:ff:00:02",
         "fd77::1",
+        None,
     )?;
     opte1.add_router_entry("10.0.0.1")?;
     opte1.add_router_entry("10.0.0.3")?;
@@ -1211,6 +1254,7 @@ pub fn three_node_topology_dualstack() -> Result<Topology> {
         "fd00::3",
         "a8:40:25:ff:00:03",
         "fd88::1",
+        None,
     )?;
     opte2.add_router_entry("10.0.0.1")?;
     opte2.add_router_entry("10.0.0.2")?;
@@ -1284,13 +1328,15 @@ pub fn three_node_topology_dualstack() -> Result<Topology> {
 
 #[derive(Copy, Clone)]
 pub struct PortInfo {
-    pub ip: IpAddr,
+    pub priv_ip4: Ipv4Addr,
+    pub priv_ip6: Ipv6Addr,
     pub mac: MacAddr,
     pub underlay_addr: Ipv6Addr,
 }
 
 pub const ZONE_A_PORT: PortInfo = PortInfo {
-    ip: IpAddr::Ip4(Ipv4Addr::from_const([10, 0, 0, 1])),
+    priv_ip4: Ipv4Addr::from_const([10, 0, 0, 1]),
+    priv_ip6: Ipv6Addr::from_const([0xfd00, 0, 0, 0, 0, 0, 0, 1]),
     mac: MacAddr::from_const([0xa8, 0x40, 0x25, 0xff, 0x00, 0x01]),
     underlay_addr: Ipv6Addr::from_const([
         0xfd44, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0001,
@@ -1298,7 +1344,8 @@ pub const ZONE_A_PORT: PortInfo = PortInfo {
 };
 
 pub const ZONE_B_PORT: PortInfo = PortInfo {
-    ip: IpAddr::Ip4(Ipv4Addr::from_const([10, 0, 0, 2])),
+    priv_ip4: Ipv4Addr::from_const([10, 0, 0, 2]),
+    priv_ip6: Ipv6Addr::from_const([0xfd00, 0, 0, 0, 0, 0, 0, 2]),
     mac: MacAddr::from_const([0xa8, 0x40, 0x25, 0xff, 0x00, 0x02]),
     underlay_addr: Ipv6Addr::from_const([
         0xfd77, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0001,
@@ -1341,6 +1388,7 @@ pub fn get_linklocal_addr(link_name: &str) -> Result<std::net::Ipv6Addr> {
 pub fn single_node_over_real_nic(
     underlay: &[String; 2],
     my_info: PortInfo,
+    mtu: Option<NonZeroU32>,
     peers: &[PortInfo],
     null_port_count: u32,
     brand: &str,
@@ -1392,27 +1440,35 @@ pub fn single_node_over_real_nic(
             "172.20.0.1",
             &taken_mac,
             &underlay_addr,
+            None,
         )?);
     }
 
-    let ip = my_info.ip.to_string();
+    let ip4 = my_info.priv_ip4.to_string();
+    let ip6 = my_info.priv_ip6.to_string();
     let mac = my_info.mac.to_string();
-    Xde::set_v2p(&ip, &mac, &underlay_addr)?;
+    Xde::set_v2p(&ip4, &mac, &underlay_addr)?;
+    Xde::set_v2p(&ip6, &mac, &underlay_addr)?;
 
-    let opte = OptePort::new(
+    let opte = OptePort::new_dualstack(
         &format!("opte{}", null_ports.len()),
-        &ip,
+        &ip4,
+        &ip6,
         &mac,
         &underlay_addr,
+        mtu,
     )?;
 
     let v6_routes = vec![];
     for peer in peers {
-        let ip = peer.ip.to_string();
+        let ip4 = peer.priv_ip4.to_string();
+        let ip6 = peer.priv_ip6.to_string();
         let mac = peer.mac.to_string();
         let underlay_addr = peer.underlay_addr.to_string();
-        Xde::set_v2p(&ip, &mac, &underlay_addr)?;
-        opte.add_router_entry(&ip)?;
+        Xde::set_v2p(&ip4, &mac, &underlay_addr)?;
+        Xde::set_v2p(&ip6, &mac, &underlay_addr)?;
+        opte.add_router_entry(&ip4)?;
+        opte.add_router_entry(&ip6)?;
     }
 
     opte.fw_allow_all()?;
@@ -1424,7 +1480,7 @@ pub fn single_node_over_real_nic(
     let a = OpteZone::new("a", &zfs, &[&opte.name], brand)?;
 
     println!("setup zone");
-    a.setup(&opte.name, opte.ip())?;
+    a.setup_dualstack(&opte.name, opte.ip(), opte.ipv6().unwrap())?;
 
     Ok(Topology {
         nodes: vec![TestNode { zone: a, port: opte }],

--- a/xde/src/postbox.rs
+++ b/xde/src/postbox.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2025 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 use crate::dev_map::VniMac;
 use crate::mac::TxHint;
@@ -61,6 +61,26 @@ impl Postbox {
     #[inline]
     pub fn drain(self) -> impl Iterator<Item = (VniMac, MsgBlkChain)> {
         self.boxes.into_iter()
+    }
+
+    #[inline]
+    pub fn take(&mut self, key: VniMac) -> MsgBlkChain {
+        match &mut self.boxes {
+            Boxes::One(vni_mac, ..) if *vni_mac == key => {
+                let mut swap_state = Boxes::None;
+                core::mem::swap(&mut self.boxes, &mut swap_state);
+
+                let Boxes::One(.., chain) = swap_state else {
+                    unreachable!()
+                };
+
+                chain
+            },
+            Boxes::Many(map) => {
+                map.remove(&key).unwrap_or_default()
+            },
+            Boxes::None | Boxes::One(..) => MsgBlkChain::empty(),
+        }
     }
 
     /// Returns true if there are no queued deliveries.

--- a/xde/src/postbox.rs
+++ b/xde/src/postbox.rs
@@ -70,15 +70,11 @@ impl Postbox {
                 let mut swap_state = Boxes::None;
                 core::mem::swap(&mut self.boxes, &mut swap_state);
 
-                let Boxes::One(.., chain) = swap_state else {
-                    unreachable!()
-                };
+                let Boxes::One(.., chain) = swap_state else { unreachable!() };
 
                 chain
-            },
-            Boxes::Many(map) => {
-                map.remove(&key).unwrap_or_default()
-            },
+            }
+            Boxes::Many(map) => map.remove(&key).unwrap_or_default(),
             Boxes::None | Boxes::One(..) => MsgBlkChain::empty(),
         }
     }

--- a/xde/src/postbox.rs
+++ b/xde/src/postbox.rs
@@ -46,8 +46,8 @@ impl Postbox {
             //    unconditionally update this pointer after the insert is made
             //    (even if an existing chain was selected).
             // b) chain pkt append will not add a new `MsgBlkChain` to `boxes`.
-            // c) `drain` (the only public way to remove entries from `boxes`)
-            //    sets `last_caller` to `None`.
+            // c) `drain` and `take` (the only public ways to remove entries
+            //    from `boxes`) set `last_caller` to `None`.
             unsafe { chain_ptr.as_mut() }
         } else {
             let chain = self.boxes.get_chain(key);
@@ -65,6 +65,7 @@ impl Postbox {
 
     #[inline]
     pub fn take(&mut self, key: VniMac) -> MsgBlkChain {
+        self.last_caller = None;
         match &mut self.boxes {
             Boxes::One(vni_mac, ..) if *vni_mac == key => {
                 let mut swap_state = Boxes::None;

--- a/xde/src/stats.rs
+++ b/xde/src/stats.rs
@@ -175,6 +175,7 @@ impl XdeStats {
             (In, ParseError::UnrecognisedTunnelOpt { .. }) => {
                 &self.in_drop_bad_tun_opt
             }
+            (In, _) => &self.in_drop_misc,
 
             (Out, ParseError::IngotError(e)) => match e.error() {
                 IngotError::Unwanted => &self.out_drop_unwanted_proto,

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -253,6 +253,7 @@ use opte::engine::ether::EtherAddr;
 use opte::engine::ether::Ethernet;
 use opte::engine::ether::EthernetMut;
 use opte::engine::ether::EthernetRef;
+use opte::engine::ether::ValidEthernet;
 use opte::engine::geneve::Vni;
 use opte::engine::geneve::WalkOptions;
 use opte::engine::headers::IpAddr;
@@ -3615,22 +3616,21 @@ fn xde_rx_one(
             // switch for generated ICMP traffic. In this case our source and
             // destination MAC will be zeroed out. If this is the case, then
             // we need to redetermine which underlay port to use.
-            if hppkt.len() < Ethernet::MINIMUM_LENGTH {
+            let Ok((hp_eth, ..)) = ValidEthernet::parse(&mut hppkt[..]) else {
                 // We failed to return a packet with enough bytes to hold
                 // Ethernet in the first layer.
                 return None;
-            }
+            };
 
-            let stream = if hppkt[0..ETHER_ADDR_LEN] == [0u8; ETHER_ADDR_LEN]
-                || hppkt[ETHER_ADDR_LEN..][..ETHER_ADDR_LEN]
-                    == [0u8; ETHER_ADDR_LEN]
+            let stream = if hp_eth.destination() == MacAddr::ZERO
+                || hp_eth.source() == MacAddr::ZERO
             {
                 let mut parsed_hppkt =
                     match Packet::parse_inbound(hppkt.iter_mut(), parser) {
                         Ok(p) => p,
                         Err(e) => {
-                            // In this case OPTE has generated an encapsulated packet that we,
-                            // ourselves, could not parse.
+                            // In this case OPTE has generated an encapsulated
+                            // packet that we, ourselves, could not parse.
                             opte::engine::err!(
                                 "oxide-vpc generated illegal packet: {:?}",
                                 e

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -246,6 +246,7 @@ use opte::ddi::sync::TokenGuard;
 use opte::ddi::sync::TokenLock;
 use opte::ddi::time::Interval;
 use opte::ddi::time::Periodic;
+use opte::engine::LightweightMeta;
 use opte::engine::NetworkImpl;
 use opte::engine::ether::ETHER_ADDR_LEN;
 use opte::engine::ether::EtherAddr;
@@ -3255,7 +3256,13 @@ fn new_port(
     // have at least one IP stack (v4 and/or v6).
     let nat_ft_limit = NonZeroU32::new(cfg.required_nat_space()).unwrap();
 
-    let mut pb = PortBuilder::new(name, name_cstr, cfg.guest_mac, ectx);
+    let mut pb = PortBuilder::new(
+        name,
+        name_cstr,
+        cfg.guest_mac,
+        ectx,
+        NonZeroU32::new(cfg.mtu),
+    );
     firewall::setup(&mut pb, NonZeroU32::max(FW_FT_LIMIT, nat_ft_limit))?;
 
     // XXX some layers have no need for LFT, perhaps have two types
@@ -3263,7 +3270,7 @@ fn new_port(
     gateway::setup(&pb, &cfg, vpc_map, FT_LIMIT_ONE)?;
     router::setup(&pb, &cfg, FT_LIMIT_ONE)?;
     nat::setup(&mut pb, &cfg, nat_ft_limit)?;
-    overlay::setup(&pb, &cfg, v2p, m2p, v2b, FT_LIMIT_ONE)?;
+    overlay::setup(&pb, &cfg, v2p, m2p, v2b.clone(), FT_LIMIT_ONE)?;
 
     // Set the overall unified flow and TCP flow table limits based on the total
     // configuration above, by taking the maximum of size of the individual
@@ -3274,7 +3281,7 @@ fn new_port(
     // construct a new one, so the unwrap is safe.
     let limit =
         NonZeroU32::new(FW_FT_LIMIT.get().max(nat_ft_limit.get())).unwrap();
-    let net = VpcNetwork { cfg };
+    let net = VpcNetwork { cfg, v2b };
     let port = Arc::new(pb.create(net, limit, limit)?);
     Ok(port)
 }
@@ -3392,7 +3399,7 @@ fn xde_rx_one(
     // We must first parse the packet in order to determine where it
     // is to be delivered.
     let parser = VpcParser {};
-    let parsed_pkt = match Packet::parse_inbound(pkt.iter_mut(), parser) {
+    let mut parsed_pkt = match Packet::parse_inbound(pkt.iter_mut(), parser) {
         Ok(pkt) => pkt,
         Err(e) => {
             stat_parse_error(Direction::In, &e);
@@ -3511,22 +3518,42 @@ fn xde_rx_one(
     // this to correctly process frames which have been given split into
     // larger chunks.
     //
+    // Due to pseudo-GRO from OPTE or actual GRO provided by illumos, we need
+    // to inform mac/viona on how it can split up this packet, if the guest
+    // cannot receive it (e.g., no GRO/large frame support).
+    // HW_LSO will cause viona to treat this packet as though it were
+    // a locally delivered segment making use of LSO. OPTE will carry flags
+    // forward from dropped segments when applying the emit spec later.
+    //
     // This will be set to a nonzero value when TSO has been asked of the
-    // source packet.
-    let is_tcp = matches!(meta.inner_ulp, ValidUlp::Tcp(_));
-    let recovered_mss = if is_tcp {
-        let mut out = None;
+    // source packet. It is imperative that we set this on the packet *before*
+    // OPTE processes it, so that we do not treat the packet as oversized and
+    // erroneously hairpin it into an ICMP packet-too-big message.
+    if matches!(meta.inner_ulp, ValidUlp::Tcp(_)) {
+        let mut mss = None;
         for opt in WalkOptions::from_raw(&meta.outer_encap) {
             let Ok(opt) = opt else { break };
             if let Some(ValidOxideOption::Mss(el)) = opt.option.known() {
-                out = NonZeroU32::new(el.mss());
+                mss = NonZeroU32::new(el.mss());
                 break;
             }
         }
-        out
-    } else {
-        None
-    };
+        let pay_len = old_len
+            - usize::try_from(non_payl_bytes).expect("usize > 32b on x86_64")
+            - usize::from(meta.encap_len());
+
+        // This packet could be the last segment of a split frame at
+        // which point it could be smaller than the original MSS.
+        // Don't re-tag the MSS if so, as guests may be confused and
+        // MAC emulation will reject the packet if the guest does not
+        // support GRO.
+        if let Some(mss) = mss
+            && pay_len
+                > usize::try_from(mss.get()).expect("usize > 32b on x86_64")
+        {
+            parsed_pkt.request_offload(MblkOffloadFlags::HW_LSO, mss.get());
+        }
+    }
 
     let port = &dev.port;
 
@@ -3535,26 +3562,6 @@ fn xde_rx_one(
     match res {
         Ok(ProcessResult::Modified(emit_spec)) => {
             let mut npkt = emit_spec.apply(pkt);
-            let len = npkt.byte_len();
-            let pay_len = len
-                - usize::try_from(non_payl_bytes)
-                    .expect("usize > 32b on x86_64");
-
-            // Due to possible pseudo-GRO, we need to inform mac/viona on how
-            // it can split up this packet, if the guest cannot receive it
-            // (e.g., no GRO/large frame support).
-            // HW_LSO will cause viona to treat this packet as though it were
-            // a locally delivered segment making use of LSO.
-            if let Some(mss) = recovered_mss
-                // This packet could be the last segment of a split frame at
-                // which point it could be smaller than the original MSS.
-                // Don't re-tag the MSS if so, as guests may be confused and
-                // MAC emulation will reject the packet if the guest does not
-                // support GRO.
-                && pay_len > usize::try_from(mss.get()).expect("usize > 32b on x86_64")
-            {
-                npkt.request_offload(MblkOffloadFlags::HW_LSO, mss.get());
-            }
 
             if let Err(e) = npkt.fill_parse_info(&ulp_meoi, None) {
                 opte::engine::err!("failed to set offload info: {}", e);
@@ -3563,6 +3570,8 @@ fn xde_rx_one(
             postbox.post(port_key, npkt);
         }
         Ok(ProcessResult::Hairpin(hppkt)) => {
+            // TODO: need to do a full TxCache lookup if dstmac is null or
+            // src mac is nonequal to the link.
             stream.tx_drop_on_no_desc(
                 hppkt,
                 TxHint::NoneOrMixed,
@@ -3595,7 +3604,7 @@ fn xde_rx_one_direct(
     // to plumb that through `NetworkParser`. I can't say that I *like*
     // doing this reparse here post-replication.
     let parser = VpcParser {};
-    let parsed_pkt = Packet::parse_inbound(pkt.iter_mut(), parser)
+    let mut parsed_pkt = Packet::parse_inbound(pkt.iter_mut(), parser)
         .expect("this is a reparse of a known-valid packet");
 
     let meta = parsed_pkt.meta();
@@ -3617,22 +3626,42 @@ fn xde_rx_one_direct(
     // this to correctly process frames which have been given split into
     // larger chunks.
     //
+    // Due to pseudo-GRO from OPTE or actual GRO provided by illumos, we need
+    // to inform mac/viona on how it can split up this packet, if the guest
+    // cannot receive it (e.g., no GRO/large frame support).
+    // HW_LSO will cause viona to treat this packet as though it were
+    // a locally delivered segment making use of LSO. OPTE will carry flags
+    // forward from dropped segments when applying the emit spec later.
+    //
     // This will be set to a nonzero value when TSO has been asked of the
-    // source packet.
-    let is_tcp = matches!(meta.inner_ulp, ValidUlp::Tcp(_));
-    let recovered_mss = if is_tcp {
-        let mut out = None;
+    // source packet. It is imperative that we set this on the packet *before*
+    // OPTE processes it, so that we do not treat the packet as oversized and
+    // erroneously hairpin it into an ICMP packet-too-big message.
+    if matches!(meta.inner_ulp, ValidUlp::Tcp(_)) {
+        let mut mss = None;
         for opt in WalkOptions::from_raw(&meta.outer_encap) {
             let Ok(opt) = opt else { break };
             if let Some(ValidOxideOption::Mss(el)) = opt.option.known() {
-                out = NonZeroU32::new(el.mss());
+                mss = NonZeroU32::new(el.mss());
                 break;
             }
         }
-        out
-    } else {
-        None
-    };
+        let pay_len = old_len
+            - usize::try_from(non_payl_bytes).expect("usize > 32b on x86_64")
+            - usize::from(meta.encap_len());
+
+        // This packet could be the last segment of a split frame at
+        // which point it could be smaller than the original MSS.
+        // Don't re-tag the MSS if so, as guests may be confused and
+        // MAC emulation will reject the packet if the guest does not
+        // support GRO.
+        if let Some(mss) = mss
+            && pay_len
+                > usize::try_from(mss.get()).expect("usize > 32b on x86_64")
+        {
+            parsed_pkt.request_offload(MblkOffloadFlags::HW_LSO, mss.get());
+        }
+    }
 
     let port = &dev.port;
 
@@ -3641,26 +3670,6 @@ fn xde_rx_one_direct(
     match res {
         Ok(ProcessResult::Modified(emit_spec)) => {
             let mut npkt = emit_spec.apply(pkt);
-            let len = npkt.byte_len();
-            let pay_len = len
-                - usize::try_from(non_payl_bytes)
-                    .expect("usize > 32b on x86_64");
-
-            // Due to possible pseudo-GRO, we need to inform mac/viona on how
-            // it can split up this packet, if the guest cannot receive it
-            // (e.g., no GRO/large frame support).
-            // HW_LSO will cause viona to treat this packet as though it were
-            // a locally delivered segment making use of LSO.
-            if let Some(mss) = recovered_mss
-                // This packet could be the last segment of a split frame at
-                // which point it could be smaller than the original MSS.
-                // Don't re-tag the MSS if so, as guests may be confused and
-                // MAC emulation will reject the packet if the guest does not
-                // support GRO.
-                && pay_len > usize::try_from(mss.get()).expect("usize > 32b on x86_64")
-            {
-                npkt.request_offload(MblkOffloadFlags::HW_LSO, mss.get());
-            }
 
             if let Err(e) = npkt.fill_parse_info(&ulp_meoi, None) {
                 opte::engine::err!("failed to set offload info: {}", e);

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -2411,12 +2411,20 @@ fn handle_mcast_tx<'a>(
                 ctx.vni.as_u32() as uintptr_t,
                 dev.port.name_cstr().as_ptr() as uintptr_t,
             );
-            if let Some(hp) = guest_loopback(src_dev, dev, *key, my_pkt, postbox) {
+            if let Some(hp) =
+                guest_loopback(src_dev, dev, *key, my_pkt, postbox)
+            {
                 // As in the unicast case below, each destination device may
                 // generate a hairpin packet. In this case we only expect this to
                 // be possible for IPv6 multicast traffic, and we limit the depth
                 // to one such reply.
-                _ = guest_loopback(dev, src_dev, src_dev.postbox_key, hp, postbox)
+                _ = guest_loopback(
+                    dev,
+                    src_dev,
+                    src_dev.postbox_key,
+                    hp,
+                    postbox,
+                )
             }
             let xde = get_xde_state();
             xde.stats.vals.mcast_tx_local().incr(1);
@@ -2931,12 +2939,20 @@ fn xde_mc_tx_one<'a>(
                     // We have found a matching Port on this host; "loop back"
                     // the packet into the inbound processing path of the
                     // destination Port.
-                    if let Some(hp) = guest_loopback(src_dev, dst_dev, key, out_pkt, postbox) {
+                    if let Some(hp) =
+                        guest_loopback(src_dev, dst_dev, key, out_pkt, postbox)
+                    {
                         // The recipient *could* generate its own hairpin, which
                         // will almost certainly be an ICMP error packet. We only allow
                         // ourselves to recurse like this once, since ICMP should
                         // never generate further ICMP errors.
-                        _ = guest_loopback(dst_dev, src_dev, src_dev.postbox_key, hp, postbox)
+                        _ = guest_loopback(
+                            dst_dev,
+                            src_dev,
+                            src_dev.postbox_key,
+                            hp,
+                            postbox,
+                        )
                     }
                 } else {
                     opte::engine::dbg!(

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -251,6 +251,7 @@ use opte::engine::NetworkImpl;
 use opte::engine::ether::ETHER_ADDR_LEN;
 use opte::engine::ether::EtherAddr;
 use opte::engine::ether::Ethernet;
+use opte::engine::ether::EthernetMut;
 use opte::engine::ether::EthernetRef;
 use opte::engine::geneve::Vni;
 use opte::engine::geneve::WalkOptions;
@@ -632,6 +633,8 @@ pub struct XdeDev {
     port_igw_map: KMutex<Option<InternetGatewayMap>>,
 
     pub vni: Vni,
+
+    postbox_key: VniMac,
 
     // These are clones of the underlay ports initialized by the
     // driver.
@@ -1173,6 +1176,7 @@ fn create_xde(req: &CreateXdeReq) -> Result<NoResp, OpteError> {
 
     let mtu = req.mtu.unwrap_or(u32::from(ETHERNET_MTU));
     let cfg = VpcCfg::with_mtu(req.cfg.clone(), mtu);
+    let postbox_key = VniMac::new(cfg.vni, cfg.guest_mac);
 
     // Because we hold the token, no one else will add to/remove from
     // the XdeDev map in parallel. Quickly check that there is no
@@ -1183,7 +1187,7 @@ fn create_xde(req: &CreateXdeReq) -> Result<NoResp, OpteError> {
         if devs.get_by_name(&req.xde_devname).is_some() {
             return Err(OpteError::PortExists(req.xde_devname.clone()));
         }
-        if devs.get_by_key(VniMac::new(cfg.vni, cfg.guest_mac)).is_some() {
+        if devs.get_by_key(postbox_key).is_some() {
             return Err(OpteError::MacExists {
                 port: req.xde_devname.clone(),
                 vni: cfg.vni,
@@ -1232,6 +1236,7 @@ fn create_xde(req: &CreateXdeReq) -> Result<NoResp, OpteError> {
         )?,
         port_v2p,
         vni: cfg.vni,
+        postbox_key,
         port_igw_map: KMutex::new(None),
         u1,
         u2,
@@ -2097,13 +2102,14 @@ fn guest_loopback_probe(
     );
 }
 
+#[must_use]
 fn guest_loopback(
     src_dev: &XdeDev,
     dst_dev: &XdeDev,
     port_key: VniMac,
     mut pkt: MsgBlk,
     postbox: &mut TxPostbox,
-) {
+) -> Option<MsgBlk> {
     use Direction::*;
 
     let mblk_addr = pkt.mblk_addr();
@@ -2118,7 +2124,7 @@ fn guest_loopback(
             opte::engine::dbg!("Loopback bad packet: {:?}", e);
             bad_packet_parse_probe(None, Direction::In, mblk_addr, &e);
 
-            return;
+            return None;
         }
     };
 
@@ -2129,7 +2135,7 @@ fn guest_loopback(
         Ok(ulp_meoi) => ulp_meoi,
         Err(e) => {
             opte::engine::dbg!("{}", e);
-            return;
+            return None;
         }
     };
 
@@ -2166,17 +2172,20 @@ fn guest_loopback(
             if let Some(pkt) = pkt {
                 postbox.post_local(port_key, pkt);
             }
+
+            None
         }
 
         Ok(ProcessResult::Drop { reason }) => {
             opte::engine::dbg!("loopback rx drop: {:?}", reason);
+            None
         }
 
-        Ok(ProcessResult::Hairpin(_hppkt)) => {
-            // There should be no reason for an loopback
-            // inbound packet to generate a hairpin response
-            // from the destination port.
-            opte::engine::dbg!("unexpected loopback rx hairpin");
+        Ok(ProcessResult::Hairpin(hppkt)) => {
+            // A port can generate a message like an ICMP
+            // packet-too-big, which we must feed back to the
+            // original port.
+            Some(hppkt)
         }
 
         Err(e) => {
@@ -2186,6 +2195,7 @@ fn guest_loopback(
                 dst_dev.port.name(),
                 e
             );
+            None
         }
     }
 }
@@ -2401,7 +2411,13 @@ fn handle_mcast_tx<'a>(
                 ctx.vni.as_u32() as uintptr_t,
                 dev.port.name_cstr().as_ptr() as uintptr_t,
             );
-            guest_loopback(src_dev, dev, *key, my_pkt, postbox);
+            if let Some(hp) = guest_loopback(src_dev, dev, *key, my_pkt, postbox) {
+                // As in the unicast case below, each destination device may
+                // generate a hairpin packet. In this case we only expect this to
+                // be possible for IPv6 multicast traffic, and we limit the depth
+                // to one such reply.
+                _ = guest_loopback(dev, src_dev, src_dev.postbox_key, hp, postbox)
+            }
             let xde = get_xde_state();
             xde.stats.vals.mcast_tx_local().incr(1);
         }
@@ -2738,7 +2754,6 @@ unsafe extern "C" fn xde_mc_tx(
         return ptr::null_mut();
     };
 
-    let mut hairpin_chain = MsgBlkChain::empty();
     let mut tx_postbox = TxPostbox::new();
 
     // We don't need to read-lock port_map or mcast_fwd unless we actually need them.
@@ -2755,11 +2770,16 @@ unsafe extern "C" fn xde_mc_tx(
             &mut tx_postbox,
             &mut port_map,
             &mut mcast_fwd,
-            &mut hairpin_chain,
         );
     }
 
-    let (local_pkts, [u1_pkts, u2_pkts]) = tx_postbox.deconstruct();
+    let (mut local_pkts, [u1_pkts, u2_pkts]) = tx_postbox.deconstruct();
+
+    // Remove any packets which have been hairpinned back to us.
+    // If we attempt to deliver them while holding a readlock in
+    // `port_map`, then if re-enter XDE in the same stack we could
+    // take a re-entrant read lock and panic.
+    let hairpin_chain = local_pkts.take(src_dev.postbox_key);
 
     // Local same-sled delivery (via mac_rx to guest ports).
     if let Some(port_map) = port_map {
@@ -2767,7 +2787,7 @@ unsafe extern "C" fn xde_mc_tx(
     }
 
     // `port_map` has been moved, making it safe to deliver hairpin
-    // packets (which may cause us to re-enter XDE in the same stack).
+    // packets.
     src_dev.deliver(hairpin_chain);
 
     src_dev.u1.stream.stream.tx_drop_on_no_desc(
@@ -2793,7 +2813,6 @@ fn xde_mc_tx_one<'a>(
     postbox: &mut TxPostbox,
     port_map: &mut Option<KRwLockReadGuard<'a, Arc<DevMap>>>,
     mcast_fwd: &mut Option<KRwLockReadGuard<'a, Arc<McastForwardingTable>>>,
-    hairpin_chain: &mut MsgBlkChain,
 ) {
     let parser = src_dev.port.network().parser();
     let mblk_addr = pkt.mblk_addr();
@@ -2912,7 +2931,13 @@ fn xde_mc_tx_one<'a>(
                     // We have found a matching Port on this host; "loop back"
                     // the packet into the inbound processing path of the
                     // destination Port.
-                    guest_loopback(src_dev, dst_dev, key, out_pkt, postbox);
+                    if let Some(hp) = guest_loopback(src_dev, dst_dev, key, out_pkt, postbox) {
+                        // The recipient *could* generate its own hairpin, which
+                        // will almost certainly be an ICMP error packet. We only allow
+                        // ourselves to recurse like this once, since ICMP should
+                        // never generate further ICMP errors.
+                        _ = guest_loopback(dst_dev, src_dev, src_dev.postbox_key, hp, postbox)
+                    }
                 } else {
                     opte::engine::dbg!(
                         "underlay dest is same as src but the Port was not found \
@@ -3093,7 +3118,7 @@ fn xde_mc_tx_one<'a>(
             // packet chain containing both hairpin and local deliveries
             // (via `guest_loopback`), we defer hairpin delivery until after
             // local delivery completes to avoid potential re-entrancy issues.
-            hairpin_chain.append(hpkt);
+            postbox.post_local(src_dev.postbox_key, hpkt);
         }
 
         Err(_) => {}
@@ -3569,9 +3594,52 @@ fn xde_rx_one(
 
             postbox.post(port_key, npkt);
         }
-        Ok(ProcessResult::Hairpin(hppkt)) => {
-            // TODO: need to do a full TxCache lookup if dstmac is null or
-            // src mac is nonequal to the link.
+        Ok(ProcessResult::Hairpin(mut hppkt)) => {
+            // In this case, we may unfortunately choose a new destination
+            // switch for generated ICMP traffic. In this case our source and
+            // destination MAC will be zeroed out. If this is the case, then
+            // we need to redetermine which underlay port to use.
+            if hppkt.len() < Ethernet::MINIMUM_LENGTH {
+                // We failed to return a packet with enough bytes to hold
+                // Ethernet in the first layer.
+                return None;
+            }
+
+            let stream = if hppkt[0..ETHER_ADDR_LEN] == [0u8; ETHER_ADDR_LEN]
+                || hppkt[ETHER_ADDR_LEN..][..ETHER_ADDR_LEN]
+                    == [0u8; ETHER_ADDR_LEN]
+            {
+                let mut parsed_hppkt =
+                    match Packet::parse_inbound(hppkt.iter_mut(), parser) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            // In this case OPTE has generated an encapsulated packet that we,
+                            // ourselves, could not parse.
+                            opte::engine::err!(
+                                "oxide-vpc generated illegal packet: {:?}",
+                                e
+                            );
+                            return None;
+                        }
+                    };
+
+                let dst = parsed_hppkt.meta().outer_v6.destination();
+                let my_key = RouteKey { dst, l4_hash: None };
+                let Route { src, dst, underlay_idx } =
+                    dev.routes.next_hop(my_key, dev);
+                let meta = parsed_hppkt.meta_mut();
+                meta.outer_eth.set_destination(dst.into());
+                meta.outer_eth.set_source(src.into());
+
+                match underlay_idx {
+                    UnderlayIndex::U1 => &dev.u1.stream.stream,
+                    UnderlayIndex::U2 => &dev.u2.stream.stream,
+                }
+            } else {
+                stream
+            };
+
+            // We don't have dedicated postbox chains as these are rare paths.
             stream.tx_drop_on_no_desc(
                 hppkt,
                 TxHint::NoneOrMixed,


### PR DESCRIPTION
This PR introduces a new error handler to `NetworkImpl` to respond to oversized packets without explicit GRO flags present. There are a couple of reasons that this is a new method on the trait:

* We can't have this handled in the standard rule/layer form because we need to catch packets *irrespective of whether they take the fast or slow path*.
* Source-address selection semantics, choice of encapsulation etc. are all defined by the VPC in question, so this cannot be a global OPTE behaviour.
* `NetworkImpl::handle_pkt()` is the wrong place to coerce into handling this, since it's a *terminal* state for any packet, whereas we want, as a possibility, the `NetworkImpl` to just allow through a packet if desired. We'd also need to provide the handler some context on what layer of OPTE called into it.

I think in future we could extend this callback to a `handle_error` function or similar, but since this is the only case I'd rather treat it as YAGNI until a use comes up.

From my testing so far this correctly hairpins packets which have originated from the NIC, and successfully re-encapsulates when doing so. Checksums *look* correct according to `overwatch`. Some packet manipulation before `Port::process` was needed to make sure that packet LSO flags are in place ahead-of-time, but the existing work from the initial ingot rewrite keeps that state in place after the packet is rewritten.

Closes #999.