### PR TITLE
Fill out cache occupancy and eviction stats

### DIFF
--- a/lib/opte/src/engine/layer.rs
+++ b/lib/opte/src/engine/layer.rs
@@ -489,6 +489,10 @@ struct LayerStats {
     /// The current number of flows (entries in LFT).
     flows: KStatU64,
 
+    /// The number of times that in in/out LFT pair has been evicted
+    /// to make space for a new entry.
+    evictions: KStatU64,
+
     /// The Time To Live for all flows, in seconds. When a flow is
     /// inactive for longer than the TTL, it is considered expired.
     flow_ttl: KStatU64,
@@ -830,6 +834,7 @@ impl Layer {
 
     fn complete_eviction(&mut self, entry: SpaceCreated) {
         if let SpaceCreated::Evict { in_key, out_key } = entry {
+            self.stats.vals.evictions.incr(1);
             self.ft.ft_out.expire(&out_key);
             self.ft.ft_in.expire(&in_key);
             self.ft.count = self.ft.ft_out.num_flows();

--- a/lib/opte/src/engine/port/mod.rs
+++ b/lib/opte/src/engine/port/mod.rs
@@ -346,13 +346,18 @@ impl PortBuilder {
             ),
         };
 
+        let stats = PortStats::new();
+        stats.in_uft_capacity.set(u64::from(data.uft_in.get_limit().get()));
+        stats.out_uft_capacity.set(u64::from(data.uft_out.get_limit().get()));
+        stats.tcp_capacity.set(u64::from(data.tcp_flows.get_limit().get()));
+
         Ok(Port {
             name: self.name.clone(),
             name_cstr: self.name_cstr,
             mac: self.mac,
             ectx: self.ectx,
             epoch: AtomicU64::new(1),
-            stats: KStatNamed::new("xde", &self.name, PortStats::new())?,
+            stats: KStatNamed::new("xde", &self.name, stats)?,
             net,
             data: KRwLock::new(data),
         })
@@ -651,6 +656,16 @@ struct PortStats {
     /// and resulted in rule processing.
     in_uft_miss: KStatU64,
 
+    /// The number of flows currently contained in the inbound UFT.
+    in_uft_flows: KStatU64,
+
+    /// The maximum number of flows the inbound UFT can hold.
+    in_uft_capacity: KStatU64,
+
+    /// The number of entries in the inbound UFT which have been evicted
+    /// in favour of a new entry.
+    in_uft_evictions: KStatU64,
+
     /// The number of outbound packets dropped
     /// ([`ProcessResult::Drop`]), for one reason or another.
     out_drop: KStatU64,
@@ -686,6 +701,26 @@ struct PortStats {
     /// The number of outbound packets which did not match a UFT entry
     /// and resulted in rule processing.
     out_uft_miss: KStatU64,
+
+    /// The number of flows currently contained in the outbound UFT.
+    out_uft_flows: KStatU64,
+
+    /// The maximum number of flows the outbound UFT can hold.
+    out_uft_capacity: KStatU64,
+
+    /// The number of entries in the outbound UFT which have been evicted
+    /// in favour of a new entry.
+    out_uft_evictions: KStatU64,
+
+    /// The number of flows currently contained in the TCP state table.
+    tcp_flows: KStatU64,
+
+    /// The maximum number of flows the TCP state table can hold.
+    tcp_capacity: KStatU64,
+
+    /// The number of entries in the TCP state table which have been evicted
+    /// in favour of a new entry.
+    tcp_evictions: KStatU64,
 }
 
 struct PortData {
@@ -862,6 +897,10 @@ impl<N: NetworkImpl> Port<N> {
         data.uft_in.clear();
         data.uft_out.clear();
         data.tcp_flows.clear();
+
+        self.stats.vals.out_uft_flows.set(0);
+        self.stats.vals.in_uft_flows.set(0);
+        self.stats.vals.tcp_flows.set(0);
     }
 
     /// Get the current [`PortState`].
@@ -1019,6 +1058,8 @@ impl<N: NetworkImpl> Port<N> {
         check_state!(data.state, [PortState::Running])?;
         data.uft_in.clear();
         data.uft_out.clear();
+        self.stats.vals.out_uft_flows.set(0);
+        self.stats.vals.in_uft_flows.set(0);
         Ok(())
     }
 
@@ -1116,9 +1157,13 @@ impl<N: NetworkImpl> Port<N> {
         // hits, so we visit those first to maximise the likelihood that we can
         // clear up as many entries as possible.
         let _ = data.tcp_flows.expire_flows(now, |_| FLOW_ID_DEFAULT);
+        self.stats.vals.tcp_flows.set(u64::from(data.tcp_flows.num_flows()));
 
         let _ = data.uft_in.expire_flows(now, |_| FLOW_ID_DEFAULT);
+        self.stats.vals.in_uft_flows.set(u64::from(data.uft_in.num_flows()));
+
         let _ = data.uft_out.expire_flows(now, |_| FLOW_ID_DEFAULT);
+        self.stats.vals.out_uft_flows.set(u64::from(data.uft_out.num_flows()));
 
         for l in &mut data.layers {
             l.expire_flows(now);
@@ -1460,6 +1505,9 @@ impl<N: NetworkImpl> Port<N> {
                                     ufid_in,
                                 );
                                 _ = local_lock.tcp_flows.remove(ufid_out);
+                                self.stats.vals.tcp_flows.set(u64::from(
+                                    local_lock.tcp_flows.num_flows(),
+                                ));
                             }
 
                             // We've determined we're actually starting a new
@@ -2200,7 +2248,14 @@ impl<N: NetworkImpl> Port<N> {
                 ),
             };
             match tcp_flows.add(*ufid_out, tfes) {
-                Ok(entry) => Ok(TcpMaybeClosed::NewState(tcp_state, entry)),
+                Ok(entry) => {
+                    let n_flows = tcp_flows.num_flows();
+                    self.stats.vals.tcp_flows.set(u64::from(n_flows));
+                    if n_flows == tcp_flows.get_limit().get() {
+                        self.stats.vals.tcp_evictions.incr(1);
+                    }
+                    Ok(TcpMaybeClosed::NewState(tcp_state, entry))
+                }
                 Err(OpteError::MaxCapacity(limit)) => {
                     Err(ProcessError::FlowTableFull { kind: "TCP", limit })
                 }
@@ -2268,6 +2323,10 @@ impl<N: NetworkImpl> Port<N> {
             // Due to order of operations, out_tcp_existing must
             // call uft_tcp_closed separately.
             let entry = data.tcp_flows.remove(ufid_out).unwrap();
+            self.stats
+                .vals
+                .tcp_flows
+                .set(u64::from(data.tcp_flows.num_flows()));
             let lock = entry.state().inner.lock();
             let state_ufid = lock.inbound_ufid;
 
@@ -2445,6 +2504,7 @@ impl<N: NetworkImpl> Port<N> {
                     hte.tcp_flow = Some(Arc::downgrade(&flow));
                     match data.uft_in.add(*ufid_in, hte) {
                         Ok(v) => {
+                            self.new_uft_kstat(In, data);
                             associate_lfts_upstack(data, &v, Direction::In);
                             Ok(InternalProcessResult::Modified)
                         }
@@ -2485,6 +2545,7 @@ impl<N: NetworkImpl> Port<N> {
         } else {
             match data.uft_in.add(*ufid_in, hte) {
                 Ok(v) => {
+                    self.new_uft_kstat(In, data);
                     associate_lfts_upstack(data, &v, Direction::In);
                     Ok(InternalProcessResult::Modified)
                 }
@@ -2650,6 +2711,7 @@ impl<N: NetworkImpl> Port<N> {
                 }
                 match data.uft_out.add(flow_before, hte) {
                     Ok(v) => {
+                        self.new_uft_kstat(Out, data);
                         associate_lfts_upstack(data, &v, Direction::Out);
                         Ok(InternalProcessResult::Modified)
                     }
@@ -2680,6 +2742,23 @@ impl<N: NetworkImpl> Port<N> {
         }
     }
 
+    fn new_uft_kstat(&self, dir: Direction, data: &mut PortData) {
+        let vals = &self.stats.vals;
+        let (uft, flow_stat, evict_stat) = match dir {
+            Direction::In => {
+                (&data.uft_in, &vals.in_uft_flows, &vals.in_uft_evictions)
+            }
+            Direction::Out => {
+                (&data.uft_out, &vals.out_uft_flows, &vals.out_uft_evictions)
+            }
+        };
+        let n_flows = uft.num_flows();
+        flow_stat.set(u64::from(n_flows));
+        if n_flows == uft.get_limit().get() {
+            evict_stat.incr(1);
+        }
+    }
+
     fn uft_invalidate(
         &self,
         data: &mut PortData,
@@ -2689,11 +2768,13 @@ impl<N: NetworkImpl> Port<N> {
     ) {
         if let Some(ufid_in) = ufid_in {
             data.uft_in.remove(ufid_in);
+            self.stats.vals.in_uft_flows.decr(1);
             self.uft_invalidate_probe(Direction::In, ufid_in, epoch);
         }
 
         if let Some(ufid_out) = ufid_out {
             data.uft_out.remove(ufid_out);
+            self.stats.vals.out_uft_flows.decr(1);
             self.uft_invalidate_probe(Direction::Out, ufid_out, epoch);
         }
     }
@@ -2732,9 +2813,11 @@ impl<N: NetworkImpl> Port<N> {
     ) {
         if let Some(ufid_in) = ufid_in {
             data.uft_in.remove(ufid_in);
+            self.stats.vals.in_uft_flows.decr(1);
             self.uft_tcp_closed_probe(Direction::In, ufid_in);
         }
         data.uft_out.remove(ufid_out);
+        self.stats.vals.out_uft_flows.decr(1);
         self.uft_tcp_closed_probe(Direction::Out, ufid_out);
     }
 

--- a/lib/opte/src/engine/port/mod.rs
+++ b/lib/opte/src/engine/port/mod.rs
@@ -2249,11 +2249,18 @@ impl<N: NetworkImpl> Port<N> {
             };
             match tcp_flows.add(*ufid_out, tfes) {
                 Ok(entry) => {
-                    let n_flows = tcp_flows.num_flows();
-                    self.stats.vals.tcp_flows.set(u64::from(n_flows));
-                    if n_flows == tcp_flows.get_limit().get() {
+                    // Evictions are detected in the same manner as in
+                    // `new_uft_kstat`: if the flow count has not changed
+                    // in response to a successful add, then `entry` has
+                    // evicted another flow.
+                    let n_flows = u64::from(tcp_flows.num_flows());
+                    let old_count = self.stats.vals.tcp_flows.val();
+                    self.stats.vals.tcp_flows.set(n_flows);
+
+                    if n_flows == old_count {
                         self.stats.vals.tcp_evictions.incr(1);
                     }
+
                     Ok(TcpMaybeClosed::NewState(tcp_state, entry))
                 }
                 Err(OpteError::MaxCapacity(limit)) => {
@@ -2752,9 +2759,18 @@ impl<N: NetworkImpl> Port<N> {
                 (&data.uft_out, &vals.out_uft_flows, &vals.out_uft_evictions)
             }
         };
-        let n_flows = uft.num_flows();
-        flow_stat.set(u64::from(n_flows));
-        if n_flows == uft.get_limit().get() {
+
+        // This function is called in response to a successful addition of a UFT.
+        // If the flow count is unchanged, then we know another entry was evicted
+        // in favour of the new one.
+        //
+        // Because we hold the PortData write lock, no one else will alter this
+        // value.
+        let n_flows = u64::from(uft.num_flows());
+        let old_count = flow_stat.val();
+        flow_stat.set(n_flows);
+
+        if n_flows == old_count {
             evict_stat.incr(1);
         }
     }

--- a/xde/src/route.rs
+++ b/xde/src/route.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2025 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 use crate::ip;
 use crate::sys;
@@ -16,10 +16,14 @@ use core::ffi::CStr;
 use core::ptr;
 use core::time::Duration;
 use illumos_sys_hdrs::*;
+use opte::ddi::kstat::KStatNamed;
+use opte::ddi::kstat::KStatProvider;
+use opte::ddi::kstat::KStatU64;
 use opte::ddi::sync::KRwLock;
 use opte::ddi::time::Moment;
 use opte::engine::ether::EtherAddr;
 use opte::engine::ip::v6::Ipv6Addr;
+use opte::engine::port::PortCreateError;
 
 // XXX: completely arbitrary timeouts.
 /// The duration a cached route remains valid for before it must be
@@ -502,16 +506,26 @@ fn get_os_next_hop(
 ///
 /// Note, this uses a `BTreeMap`, but we would prefer the more consistent
 /// (faster) add/remove costs of a `HashMap`.
-#[derive(Clone)]
-pub struct RouteCache(Arc<KRwLock<BTreeMap<RouteKey, CachedRoute>>>);
-
-impl Default for RouteCache {
-    fn default() -> Self {
-        Self(KRwLock::new(BTreeMap::new()).into())
-    }
+pub struct RouteCache {
+    cache: Arc<KRwLock<BTreeMap<RouteKey, CachedRoute>>>,
+    stats: KStatNamed<RouteCacheStats>,
 }
 
 impl RouteCache {
+    pub fn new(port_name: &str) -> Result<Self, PortCreateError> {
+        let stats = RouteCacheStats::new();
+        stats
+            .capacity
+            .set(u64::try_from(MAX_CACHE_ENTRIES).expect("usize is u64"));
+
+        let name = format!("{port_name}_route_cache");
+
+        Ok(Self {
+            cache: KRwLock::new(BTreeMap::new()).into(),
+            stats: KStatNamed::new("xde", &name, stats)?,
+        })
+    }
+
     /// Retrieve a [`Route`] (device and L2 information) for a given `key`.
     ///
     /// This will retrieve an existing entry, if one exists from a recent
@@ -521,7 +535,7 @@ impl RouteCache {
         let t = Moment::now();
 
         let (maybe_route, map_ptr_int, full) = {
-            let route_cache = self.0.read();
+            let route_cache = self.cache.read();
             (
                 route_cache.get(&key).copied(),
                 &*route_cache as *const BTreeMap<_, _> as uintptr_t,
@@ -532,6 +546,7 @@ impl RouteCache {
         let probably_space_remaining = match maybe_route {
             Some(route) if route.is_valid(t) => {
                 route_hit_probe(map_ptr_int, &key);
+                self.stats.vals.hit.incr(1);
                 return route.into();
             }
             Some(_) => true,
@@ -544,18 +559,22 @@ impl RouteCache {
         // will place traffic from any flow onto the same tx queue.
         //
         // If someone *did* write in before us, we still have a valid route.
+        self.stats.vals.miss.incr(1);
         let route = match get_os_next_hop(&key, xde) {
             Ok(route) => route,
             Err(dev) => {
                 // `next_hop` might fail for myriad reasons, but we still
                 // send the packet on an underlay device depending on our
                 // progress. However, we do not want to cache bad mappings.
+                self.stats.vals.error.incr(1);
                 return Route::zero_addr(dev);
             }
         };
 
         if probably_space_remaining {
             self.update_cache(key, &route, t, map_ptr_int);
+        } else {
+            self.stats.vals.table_full.incr(1);
         }
 
         route
@@ -582,13 +601,16 @@ impl RouteCache {
         match route_cache.entry(key) {
             Entry::Occupied(mut slot) => {
                 route_refresh_probe(map_ptr_int, &key);
+                self.stats.vals.refresh.incr(1);
                 slot.insert(route.cached(time));
             }
             Entry::Vacant(slot) if space_remaining => {
                 route_insert_probe(map_ptr_int, &key);
+                self.stats.vals.occupancy.incr(1);
                 slot.insert(route.cached(time));
             }
             Entry::Vacant(_) => {
+                self.stats.vals.table_full.incr(1);
                 route_full_probe(map_ptr_int, &key);
             }
         }
@@ -597,7 +619,7 @@ impl RouteCache {
     /// Discards any cached route entries which have been present
     /// for longer than `REMOVE_ROUTE_LIFETIME`.
     pub fn remove_routes(&self) {
-        let mut route_cache = self.0.write();
+        let mut route_cache = self.cache.write();
 
         let t = Moment::now();
         let ptr: *const BTreeMap<_, _> = &*route_cache;
@@ -611,6 +633,11 @@ impl RouteCache {
                 false
             }
         });
+
+        self.stats
+            .vals
+            .occupancy
+            .set(u64::try_from(route_cache.len()).expect("u64 is usize"));
     }
 }
 
@@ -670,4 +697,24 @@ impl Route {
     fn zero_addr(underlay_idx: UnderlayIndex) -> Route {
         Self { src: EtherAddr::zero(), dst: EtherAddr::zero(), underlay_idx }
     }
+}
+
+#[derive(KStatProvider)]
+struct RouteCacheStats {
+    /// The maximum number of entries the route cache can hold.
+    capacity: KStatU64,
+    /// The current number of entries in the route cache.
+    occupancy: KStatU64,
+    /// The number of outbound packets which have reused a cached nexthop.
+    hit: KStatU64,
+    /// The number of outbound packets which have asked the OS for a valid
+    /// nexthop.
+    miss: KStatU64,
+    /// The number of times an expired nexthop was updated in-place with a new one.
+    refresh: KStatU64,
+    /// The number of misses which could not be stored in the cache due to being
+    /// at capacity.
+    table_full: KStatU64,
+    /// The number of times a nexthop lookup failed.
+    error: KStatU64,
 }

--- a/xde/src/route.rs
+++ b/xde/src/route.rs
@@ -587,7 +587,7 @@ impl RouteCache {
         time: Moment,
         map_ptr_int: uintptr_t,
     ) {
-        let mut route_cache = self.0.write();
+        let mut route_cache = self.cache.write();
         let space_remaining = route_cache.len() < MAX_CACHE_ENTRIES;
 
         // We've had a definitive flow miss, but we need to cap the cache

--- a/xde/src/xde.rs
+++ b/xde/src/xde.rs
@@ -1235,7 +1235,7 @@ fn create_xde(req: &CreateXdeReq) -> Result<NoResp, OpteError> {
         u1,
         u2,
         underlay_capab,
-        routes: RouteCache::default(),
+        routes: RouteCache::new(&req.xde_devname)?,
         port_map: KRwLock::new(Default::default()),
         mcast_fwd: KRwLock::new(Arc::new(token.mcast_fwd.read().clone())),
     });


### PR DESCRIPTION
This PR adds in aditional kstats on each OPTE port corresponding to UFT, LFT, TCP table, and route cache state. I've tried to keep them broadly consistent and make sure that we're surfacing the same information consistently, with the exception of the Tx route cache which has different eviction/replacement semantics.

One thing this has made clear to me is that there are some deficiencies around kstat management. Ideally I'd want to make better use of `ks_update`, and allow `xde` to define the base `KStatNamed` and then the `Port` to push its own keys via `kstat_named_init`. That would also let us wrap `FlowTable` in a kstat-handling layer and cut out a bunch of the internal duplication that `Port` has to take on. I'll write up some thoughts here.

Closes #1032.