### PR TITLE
Set flow count stats to current values rather than decrementing

### DIFF
--- a/lib/opte/src/engine/port/mod.rs
+++ b/lib/opte/src/engine/port/mod.rs
@@ -2883,13 +2883,19 @@ impl<N: NetworkImpl> Port<N> {
     ) {
         if let Some(ufid_in) = ufid_in {
             data.uft_in.remove(ufid_in);
-            self.stats.vals.in_uft_flows.decr(1);
+            self.stats
+                .vals
+                .in_uft_flows
+                .set(u64::from(data.uft_in.num_flows()));
             self.uft_invalidate_probe(Direction::In, ufid_in, epoch);
         }
 
         if let Some(ufid_out) = ufid_out {
             data.uft_out.remove(ufid_out);
-            self.stats.vals.out_uft_flows.decr(1);
+            self.stats
+                .vals
+                .out_uft_flows
+                .set(u64::from(data.uft_out.num_flows()));
             self.uft_invalidate_probe(Direction::Out, ufid_out, epoch);
         }
     }
@@ -2928,11 +2934,14 @@ impl<N: NetworkImpl> Port<N> {
     ) {
         if let Some(ufid_in) = ufid_in {
             data.uft_in.remove(ufid_in);
-            self.stats.vals.in_uft_flows.decr(1);
+            self.stats
+                .vals
+                .in_uft_flows
+                .set(u64::from(data.uft_in.num_flows()));
             self.uft_tcp_closed_probe(Direction::In, ufid_in);
         }
         data.uft_out.remove(ufid_out);
-        self.stats.vals.out_uft_flows.decr(1);
+        self.stats.vals.out_uft_flows.set(u64::from(data.uft_out.num_flows()));
         self.uft_tcp_closed_probe(Direction::Out, ufid_out);
     }
 


### PR DESCRIPTION
Sometimes flow count kstats are suspiciously large. From dogfood:

```
xde:0:opte0:out_uft_flows       18446744073709551615
```

This isn't just implausibly large. It's also u64::MAX. And it turns out that we can underflow the flow counters when `.remove()`-ing a flow returns `None`, which we don't check before calling `decr()` on the counter.

To fix, this patch sets the counter value to the current `num_flows()` after attempting to `remove()` the flow, rather than using `decr()`.

Note: I noticed this while testing the new opte kstats-based metrics in oximeter, on dogfood. Fun fact: we don't actually return values like u64::MAX. Instead, we error, because oximeter wants to represent those values as i64, and can't.

Another note: we might want a regression test for this, but I'm not familiar with the codebase and didn't want to botch it.