### PR TITLE
Limit the number of LFT->UFT references allowed

### DIFF
--- a/bench/benches/userland.rs
+++ b/bench/benches/userland.rs
@@ -336,7 +336,32 @@ fn source_filter_allows(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(wall, parse_and_process, source_filter_allows);
+fn periodic_cleanup<M: MeasurementInfo>(c: &mut Criterion<M>) {
+    let expt = SlowpathEvict;
+    for case in expt.test_cases() {
+        let port = case.create_port().unwrap();
+        let mut c = c.benchmark_group(format!("cleanup/{}", M::label()));
+
+        c.bench_with_input(
+            BenchmarkId::from_parameter(case.instance_name()),
+            &case,
+            |b, _i| {
+                b.iter_batched(
+                    || case.pre_handle(&port),
+                    |_| black_box(port.port.expire_flows()),
+                    criterion::BatchSize::LargeInput,
+                )
+            },
+        );
+    }
+}
+
+criterion_group!(
+    wall,
+    parse_and_process,
+    source_filter_allows,
+    periodic_cleanup
+);
 criterion_group!(
     name = alloc;
     config = new_crit(Allocs);

--- a/bench/benches/userland.rs
+++ b/bench/benches/userland.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 //! Userland packet parsing and processing microbenchmarks.
 
@@ -30,6 +30,9 @@ use oxide_vpc::api::IpAddr;
 use oxide_vpc::api::Ipv4Addr;
 use oxide_vpc::api::Ipv6Addr;
 use oxide_vpc::api::SourceFilter;
+use rand::SeedableRng;
+use rand::distr::Bernoulli;
+use rand::distr::Distribution;
 use std::collections::BTreeSet;
 use std::hint::black_box;
 
@@ -340,19 +343,31 @@ fn periodic_cleanup<M: MeasurementInfo>(c: &mut Criterion<M>) {
     let expt = SlowpathEvict;
     for case in expt.test_cases() {
         let port = case.create_port().unwrap();
-        let mut c = c.benchmark_group(format!("cleanup/{}", M::label()));
+        for p_expire in [0.0, 0.1, 0.25, 0.5] {
+            let mut c = c.benchmark_group(format!(
+                "cleanup/{}/P{}",
+                M::label(),
+                p_expire
+            ));
+            let mut rng =
+                rand::rngs::StdRng::seed_from_u64(0x01de_097e_7e57_0712);
+            let dist = Bernoulli::new(p_expire).unwrap();
 
-        c.bench_with_input(
-            BenchmarkId::from_parameter(case.instance_name()),
-            &case,
-            |b, _i| {
-                b.iter_batched(
-                    || case.pre_handle(&port),
-                    |_| black_box(port.port.expire_flows()),
-                    criterion::BatchSize::LargeInput,
-                )
-            },
-        );
+            c.bench_with_input(
+                BenchmarkId::from_parameter(case.instance_name()),
+                &case,
+                |b, _i| {
+                    b.iter_batched(
+                        || {
+                            case.pre_handle(&port);
+                            port.port.inject_expiry(|| dist.sample(&mut rng));
+                        },
+                        |_| black_box(port.port.expire_flows()),
+                        criterion::BatchSize::LargeInput,
+                    )
+                },
+            );
+        }
     }
 }
 

--- a/bench/benches/userland.rs
+++ b/bench/benches/userland.rs
@@ -21,6 +21,7 @@ use opte_bench::packet::Dhcp6;
 use opte_bench::packet::Icmp4;
 use opte_bench::packet::Icmp6;
 use opte_bench::packet::ParserKind;
+use opte_bench::packet::SlowpathEvict;
 use opte_bench::packet::TestCase;
 use opte_bench::packet::ULP_FAST_PATH;
 use opte_bench::packet::ULP_SLOW_PATH;
@@ -44,11 +45,12 @@ pub fn block<M: MeasurementInfo>(c: &mut Criterion<M>, do_parse: bool) {
         Box::new(Icmp6),
         Box::new(ULP_FAST_PATH),
         Box::new(ULP_SLOW_PATH),
+        Box::new(SlowpathEvict),
     ];
 
     for experiment in all_tests {
         for case in experiment.test_cases() {
-            if do_parse {
+            if experiment.do_parse_benchmark() && do_parse {
                 test_parse(c, &**experiment, &*case);
             }
             test_handle(c, &**experiment, &*case);
@@ -151,6 +153,7 @@ pub fn test_handle<M: MeasurementInfo>(
     ));
 
     let parser = case.parse_with();
+    let can_fail = experiment.allow_failure();
     c.bench_with_input(
         BenchmarkId::from_parameter(case.instance_name()),
         &case,
@@ -174,7 +177,7 @@ pub fn test_handle<M: MeasurementInfo>(
                                     GenericUlp {},
                                 )
                                 .unwrap();
-                                port.port.process(dir, black_box(pkt)).unwrap()
+                                port.port.process(dir, black_box(pkt))
                             }
                             Out => {
                                 let pkt = Packet::parse_outbound(
@@ -182,11 +185,15 @@ pub fn test_handle<M: MeasurementInfo>(
                                     GenericUlp {},
                                 )
                                 .unwrap();
-                                port.port.process(dir, black_box(pkt)).unwrap()
+                                port.port.process(dir, black_box(pkt))
                             }
                         };
-                        assert!(!matches!(res, ProcessResult::Drop { .. }));
-                        if let Modified(spec) = res {
+
+                        if !can_fail {
+                            assert!(res.is_ok());
+                        }
+
+                        if let Ok(Modified(spec)) = res {
                             black_box(spec.apply(pkt_m));
                         }
                     }
@@ -198,7 +205,7 @@ pub fn test_handle<M: MeasurementInfo>(
                                     VpcParser {},
                                 )
                                 .unwrap();
-                                port.port.process(dir, black_box(pkt)).unwrap()
+                                port.port.process(dir, black_box(pkt))
                             }
                             Out => {
                                 let pkt = Packet::parse_outbound(
@@ -206,11 +213,15 @@ pub fn test_handle<M: MeasurementInfo>(
                                     VpcParser {},
                                 )
                                 .unwrap();
-                                port.port.process(dir, black_box(pkt)).unwrap()
+                                port.port.process(dir, black_box(pkt))
                             }
                         };
-                        assert!(!matches!(res, ProcessResult::Drop { .. }));
-                        if let Modified(spec) = res {
+
+                        if !can_fail {
+                            assert!(res.is_ok());
+                        }
+
+                        if let Ok(Modified(spec)) = res {
                             black_box(spec.apply(pkt_m));
                         }
                     }

--- a/bench/src/kbench/workload.rs
+++ b/bench/src/kbench/workload.rs
@@ -8,8 +8,9 @@ use super::*;
 use measurement::Instrumentation;
 
 #[allow(dead_code)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum IperfMode {
+    #[default]
     ClientSend,
     ServerSend,
     // TODO: need an updated illumos package.
@@ -28,15 +29,10 @@ impl std::fmt::Display for IperfMode {
     }
 }
 
-impl Default for IperfMode {
-    fn default() -> Self {
-        Self::ClientSend
-    }
-}
-
 #[allow(dead_code)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum IperfProto {
+    #[default]
     Tcp,
     Udp {
         /// Target bandwidth in MiB/s.
@@ -56,12 +52,6 @@ impl std::fmt::Display for IperfProto {
                 write!(f, "UDP({pkt_sz}B, {bw}MiB/s)")
             }
         }
-    }
-}
-
-impl Default for IperfProto {
-    fn default() -> Self {
-        Self::Tcp
     }
 }
 

--- a/bench/src/packet.rs
+++ b/bench/src/packet.rs
@@ -359,7 +359,7 @@ impl BenchPacket for SlowpathEvict {
 
     fn test_cases(&self) -> Vec<Box<dyn BenchPacketInstance>> {
         let cfg = g1_cfg2(UlpProcess::cfg());
-        [1 << 10, 1 << 15, 1 << 19, 1 << 20, 1 << 21, 1 << 22]
+        [1 << 10, 1 << 15, 1 << 19, 1 << 20]
             .into_iter()
             .map(|n| {
                 Box::new(AllSynInstance {

--- a/bench/src/packet.rs
+++ b/bench/src/packet.rs
@@ -27,6 +27,8 @@ use opte_test_utils::icmp::gen_icmpv6_echo;
 use opte_test_utils::icmp::generate_ndisc;
 use opte_test_utils::*;
 use std::collections::BTreeMap;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 
 pub type TestCase = (MsgBlk, Direction);
 
@@ -42,6 +44,16 @@ pub trait BenchPacket {
 
     /// Return a list of discrete scenarios
     fn test_cases(&self) -> Vec<Box<dyn BenchPacketInstance>>;
+
+    /// Are `generate`d packets worth benchmarking for parser performance?
+    fn do_parse_benchmark(&self) -> bool {
+        true
+    }
+
+    /// Is packet processing allowed to fail due to table size constraints?
+    fn allow_failure(&self) -> bool {
+        false
+    }
 }
 
 /// An individual packet to time the parse/process timing of.
@@ -73,13 +85,9 @@ pub struct UlpProcess {
 pub const ULP_FAST_PATH: UlpProcess = UlpProcess { fast_path: true };
 pub const ULP_SLOW_PATH: UlpProcess = UlpProcess { fast_path: false };
 
-impl BenchPacket for UlpProcess {
-    fn packet_label(&self) -> &'static str {
-        if self.fast_path { "ULP-FastPath" } else { "ULP-SlowPath" }
-    }
-
-    fn test_cases(&self) -> Vec<Box<dyn BenchPacketInstance>> {
-        let ip_cfg = IpCfg::DualStack {
+impl UlpProcess {
+    fn cfg() -> IpCfg {
+        IpCfg::DualStack {
             ipv4: Ipv4Cfg {
                 vpc_subnet: "172.30.0.0/22".parse().unwrap(),
                 private_ip: "172.30.0.5".parse().unwrap(),
@@ -110,9 +118,17 @@ impl BenchPacket for UlpProcess {
                 attached_subnets: BTreeMap::default(),
                 transit_ips: BTreeMap::default(),
             },
-        };
+        }
+    }
+}
 
-        let cfg = g1_cfg2(ip_cfg);
+impl BenchPacket for UlpProcess {
+    fn packet_label(&self) -> &'static str {
+        if self.fast_path { "ULP-FastPath" } else { "ULP-SlowPath" }
+    }
+
+    fn test_cases(&self) -> Vec<Box<dyn BenchPacketInstance>> {
+        let cfg = g1_cfg2(UlpProcess::cfg());
 
         itertools::iproduct!(
             [IpVariant::V4, IpVariant::V6],
@@ -331,6 +347,137 @@ impl BenchPacketInstance for UlpProcessInstance {
         }
 
         Some(g1)
+    }
+}
+
+pub struct SlowpathEvict;
+
+impl BenchPacket for SlowpathEvict {
+    fn packet_label(&self) -> &'static str {
+        "Eviction"
+    }
+
+    fn test_cases(&self) -> Vec<Box<dyn BenchPacketInstance>> {
+        let cfg = g1_cfg2(UlpProcess::cfg());
+        [1 << 10, 1 << 15, 1 << 19, 1 << 20, 1 << 21, 1 << 22]
+            .into_iter()
+            .map(|n| {
+                Box::new(AllSynInstance {
+                    index: 0.into(),
+                    capacity: n.try_into().unwrap(),
+                    cfg: cfg.clone(),
+                }) as Box<dyn BenchPacketInstance>
+            })
+            .collect()
+    }
+
+    fn do_parse_benchmark(&self) -> bool {
+        false
+    }
+
+    fn allow_failure(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Debug)]
+pub struct AllSynInstance {
+    index: AtomicU64,
+    capacity: NonZeroU32,
+
+    cfg: VpcCfg,
+}
+
+impl BenchPacketInstance for AllSynInstance {
+    fn create_port(&self) -> Option<PortAndVps> {
+        let mut g1 =
+            oxide_net_setup("g1_port", &self.cfg, None, Some(self.capacity));
+        g1.port.start();
+        set!(g1, "port_state=running");
+
+        Some(g1)
+    }
+
+    fn parse_with(&self) -> ParserKind {
+        ParserKind::OxideVpc
+    }
+
+    fn pre_handle(&self, port: &PortAndVps) {
+        while port.port.num_flows("firewall", Direction::In)
+            < self.capacity.get() - 1
+        {
+            let (mut pkt, dir) = self.generate();
+            let pkt = parse_inbound(&mut pkt, VpcParser {}).unwrap();
+            match port.port.process(dir, pkt) {
+                Ok(_) => {}
+                Err(opte::engine::port::ProcessError::Layer(
+                    opte::engine::layer::LayerError::FlowTableFull { .. },
+                ))
+                | Err(opte::engine::port::ProcessError::FlowTableFull {
+                    ..
+                }) => break,
+                e => panic!("unexpected err condition {e:?}"),
+            }
+        }
+    }
+
+    fn instance_name(&self) -> String {
+        format!("{}", self.capacity)
+    }
+
+    fn generate(&self) -> (MsgBlk, Direction) {
+        let my_index = self.index.fetch_add(1, Ordering::Relaxed);
+
+        // SYN packets (or small UDP) are the easiest way to prod at
+        // UFT expiry behaviour.
+        let src_port = (my_index / u64::from(u16::MAX)) as u16;
+        let dst_port = (my_index % u64::from(u16::MAX)) as u16;
+
+        let body = &[][..];
+
+        let eth = Ethernet {
+            destination: self.cfg.guest_mac,
+            source: BS_MAC_ADDR,
+            ethertype: Ethertype::IPV4,
+        };
+
+        let tcp = UlpRepr::Tcp(Tcp {
+            source: src_port,
+            destination: dst_port,
+            flags: TcpFlags::SYN,
+            sequence: 1234,
+            acknowledgement: 3456,
+            window_size: 1,
+            ..Default::default()
+        });
+
+        let ip = L3Repr::Ipv4(Ipv4 {
+            source: Ipv4Addr::from_const([172, 30, 0, 6]),
+            destination: self.cfg.ipv4().private_ip,
+            protocol: IngotIpProto::TCP,
+            total_len: (Ipv4::MINIMUM_LENGTH + (&tcp, &body).packet_length())
+                as u16,
+            ..Default::default()
+        });
+
+        let guest_phys = TestIpPhys {
+            ip: self.cfg.phys_ip,
+            mac: self.cfg.guest_mac,
+            vni: self.cfg.vni,
+        };
+
+        let partner_phys = TestIpPhys {
+            ip: Ipv6Addr::from([
+                0xFD00, 0x0000, 0x00F7, 0x0116, 0x0000, 0x0000, 0x0000, 0x0001,
+            ]),
+            mac: ox_vpc_mac([0xF0, 0x00, 0x66]),
+            vni: self.cfg.vni,
+        };
+
+        (
+            encap(ulp_pkt(eth, ip, tcp, body), partner_phys, guest_phys),
+            Direction::In,
+        )
     }
 }
 

--- a/lib/opte-test-utils/src/lib.rs
+++ b/lib/opte-test-utils/src/lib.rs
@@ -270,6 +270,7 @@ fn oxide_net_builder(
     v2p: Arc<Virt2Phys>,
     m2p: Arc<Mcast2Phys>,
     v2b: Arc<Virt2Boundary>,
+    flow_table_limits: Option<NonZeroU32>,
 ) -> PortBuilder {
     #[allow(clippy::arc_with_non_send_sync)]
     let ectx = Arc::new(ExecCtx { log: Box::new(opte::PrintlnLog {}) });
@@ -282,12 +283,13 @@ fn oxide_net_builder(
         NonZeroU32::new(cfg.mtu),
     );
 
-    let fw_limit = NonZeroU32::new(8096).unwrap();
-    let snat_limit = NonZeroU32::new(8096).unwrap();
+    let fw_limit = flow_table_limits.unwrap_or(NonZeroU32::new(8096).unwrap());
+    let snat_limit =
+        flow_table_limits.unwrap_or(NonZeroU32::new(8096).unwrap());
     let one_limit = NonZeroU32::new(1).unwrap();
 
     firewall::setup(&mut pb, fw_limit).expect("failed to add firewall layer");
-    gateway::setup(&pb, cfg, vpc_map, fw_limit)
+    gateway::setup(&pb, cfg, vpc_map, one_limit)
         .expect("failed to setup gateway layer");
     router::setup(&pb, cfg, one_limit).expect("failed to add router layer");
     nat::setup(&mut pb, cfg, snat_limit).expect("failed to add nat layer");
@@ -392,6 +394,7 @@ pub fn oxide_net_setup2(
         port_v2p,
         m2p.clone(),
         v2b,
+        flow_table_limits,
     )
     .create(vpc_net, uft_limit, tcp_limit)
     .unwrap();

--- a/lib/opte/src/ddi/time.rs
+++ b/lib/opte/src/ddi/time.rs
@@ -6,6 +6,7 @@
 
 //! Moments, periodics, etc.
 use core::ops::Add;
+use core::ops::Sub;
 use core::time::Duration;
 
 cfg_if! {
@@ -58,6 +59,23 @@ impl Add<Duration> for Moment {
     }
 }
 
+impl Sub<Duration> for Moment {
+    type Output = Self;
+
+    fn sub(self, rhs: Duration) -> Self::Output {
+        cfg_if! {
+            if #[cfg(all(not(feature = "std"), not(test)))] {
+                let new = self.inner - ((rhs.as_secs() * NANOS) +
+                    rhs.subsec_nanos()) as i64;
+                Moment { inner: new }
+            } else {
+                let new = self.inner - rhs;
+                Moment { inner: new }
+            }
+        }
+    }
+}
+
 impl Moment {
     /// Compute the delta between `now - self` and return as
     /// milliseconds.
@@ -81,7 +99,9 @@ impl Moment {
             } else {
                 static FIRST_TS: OnceLock<Instant> = OnceLock::new();
 
-                let first_ts = *FIRST_TS.get_or_init(Instant::now);
+                let first_ts = *FIRST_TS.get_or_init(||
+                    Instant::now() - Duration::from_mins(5)
+                );
                 Self { inner: Instant::now().saturating_duration_since(first_ts) }
             }
         }

--- a/lib/opte/src/ddi/time.rs
+++ b/lib/opte/src/ddi/time.rs
@@ -65,8 +65,8 @@ impl Sub<Duration> for Moment {
     fn sub(self, rhs: Duration) -> Self::Output {
         cfg_if! {
             if #[cfg(all(not(feature = "std"), not(test)))] {
-                let new = self.inner - ((rhs.as_secs() * NANOS) +
-                    rhs.subsec_nanos()) as i64;
+                let new = self.inner - ((rhs.as_secs() * NANOS) as i64 +
+                    rhs.subsec_nanos() as i64);
                 Moment { inner: new }
             } else {
                 let new = self.inner - rhs;

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -218,7 +218,7 @@ impl<S: FlowState> FlowEntryInfo for FlowEntry<S> {
         let can_insert =
             children.len() < Self::MAX_CHILDREN || children.contains(&to_place);
         if can_insert {
-            children.insert(ByAddr(Arc::downgrade(child)));
+            children.insert(to_place);
             Ok(())
         } else {
             Err(OpteError::MaxCapacity(

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -857,7 +857,6 @@ mod test {
     use crate::api::PortInfo;
     use crate::engine::ip::v4::Protocol;
     use crate::engine::packet::AddrPair;
-    use crate::engine::packet::FLOW_ID_DEFAULT;
     use core::time::Duration;
 
     impl Dump for () {

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -66,6 +66,12 @@ impl Ttl {
     }
 }
 
+/// An eviction policy table which makes TCP flow entries without live flowstate
+/// parents trivially evictable. When present, the TCP flow state will signal
+/// a value to be used in its place.
+#[derive(Clone, Copy, Debug)]
+pub struct TtlDelegateTcp(pub Ttl);
+
 /// A metric of how stale a flow entry is, used to determine whether
 /// any existing entry can be evicted to make room for a new one.
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Default)]
@@ -100,6 +106,20 @@ pub trait ExpiryPolicy<S: FlowState>: fmt::Debug + Send + Sync {
 impl<S: FlowState> ExpiryPolicy<S> for Ttl {
     fn is_expired(&self, entry: &FlowEntry<S>, now: Moment) -> bool {
         self.is_expired(entry.last_hit(), now)
+    }
+
+    fn eviction_priority(
+        &self,
+        _entry: &FlowEntry<S>,
+        _now: Moment,
+    ) -> Option<EvictionPriority> {
+        None
+    }
+}
+
+impl<S: FlowState> ExpiryPolicy<S> for TtlDelegateTcp {
+    fn is_expired(&self, entry: &FlowEntry<S>, now: Moment) -> bool {
+        self.0.is_expired(entry.last_hit(), now)
     }
 
     fn eviction_priority(
@@ -139,7 +159,7 @@ pub trait FlowEntryInfo: fmt::Debug + Send + Sync {
     fn eviction_priority(&self, now: Moment) -> Option<EvictionPriority>;
 
     /// Set `self` as a parent node to `child`.
-    fn push_child(&self, child: &Arc<dyn FlowEntryInfo>);
+    fn push_child(&self, child: &Arc<dyn FlowEntryInfo>) -> Result<()>;
 
     /// Remove `child` from this entry's list of children.
     fn remove_child(&self, child: &Arc<dyn FlowEntryInfo>);
@@ -190,9 +210,21 @@ impl<S: FlowState> FlowEntryInfo for FlowEntry<S> {
         best_prio
     }
 
-    fn push_child(&self, child: &Arc<dyn FlowEntryInfo>) {
+    fn push_child(&self, child: &Arc<dyn FlowEntryInfo>) -> Result<()> {
         let mut children = self.lifetime.children.write();
-        children.insert(ByAddr(Arc::downgrade(child)));
+
+        // Sadly, BTreeSet::entry remains a nightly API.
+        let to_place = ByAddr(Arc::downgrade(child));
+        let can_insert =
+            children.len() < Self::MAX_CHILDREN || children.contains(&to_place);
+        if can_insert {
+            children.insert(ByAddr(Arc::downgrade(child)));
+            Ok(())
+        } else {
+            Err(OpteError::MaxCapacity(
+                u64::try_from(Self::MAX_CHILDREN).expect("usize is u64"),
+            ))
+        }
     }
 
     fn remove_child(&self, child: &Arc<dyn FlowEntryInfo>) {
@@ -293,7 +325,7 @@ impl<S: FlowState> FlowTable<S> {
     pub fn expire(&mut self, flowid: &InnerFlowId) {
         flow_expired_probe(&self.port_c, &self.name_c, flowid, None, None);
         if let Some(entry) = self.map.remove(flowid) {
-            entry.propagate_last_hit();
+            entry.expiry_cleanup();
             entry.mark_evicted();
         }
     }
@@ -310,6 +342,9 @@ impl<S: FlowState> FlowTable<S> {
             // A flow cannot be expired by the timer while it still has children
             // relying upon its existence. Check whether any remain, and remove
             // dangling references to child entries which have expired.
+            //
+            // The dangling entries here will have been left by `expire_flows`
+            // called on other layers.
             {
                 // We have a write lock on the port, so there shouldn't be
                 // contention here.
@@ -328,7 +363,7 @@ impl<S: FlowState> FlowTable<S> {
                     Some(my_time.raw_millis()),
                     Some(now.raw_millis()),
                 );
-                entry.propagate_last_hit();
+                entry.expiry_cleanup();
                 expired.push(f(entry.state()));
                 return false;
             }
@@ -503,7 +538,7 @@ pub trait Dump: fmt::Debug + Send + Sync {
 }
 
 /// Common functions needed from the interior state of a flow table entry.
-pub trait FlowState: Dump {
+pub trait FlowState: Dump + 'static {
     /// Return an iterator containing references to all flow entries from other
     /// tables which underpin `self`.
     fn parents(&self) -> impl Iterator<Item = Arc<dyn FlowEntryInfo>>;
@@ -584,6 +619,12 @@ pub struct FlowEntry<S: FlowState> {
 }
 
 impl<S: FlowState> FlowEntry<S> {
+    /// In OPTE, we generally expect at most two children per LFT entry: the
+    /// UFT entry and TCP entry. We can keep some extra space for now to allow
+    /// for this to change in future, as well as to provide some breathing room
+    /// if we need to replace one of those relationships.
+    const MAX_CHILDREN: usize = 16;
+
     fn dump(&self) -> S::DumpVal {
         self.state.dump(self.hits.load(Ordering::Relaxed))
     }
@@ -652,11 +693,13 @@ impl<S: FlowState> FlowEntry<S> {
     }
 
     /// Update the last hit time of this flow entry's parents if it has been
-    /// used more recently.
-    fn propagate_last_hit(&self) {
+    /// used more recently, and remove any of their references to `self`.
+    fn expiry_cleanup(self: &Arc<Self>) {
         let my_time = self.last_hit();
+        let dyn_entry = Arc::clone(self) as Arc<dyn FlowEntryInfo>;
         for parent in self.state.parents() {
             parent.inherit_last_hit(my_time);
+            parent.remove_child(&dyn_entry);
         }
     }
 
@@ -888,7 +931,7 @@ mod test {
         let fe2 = ft2.add(flowid, ()).unwrap();
 
         let now = fe2.last_hit();
-        fe1.push_child(&(fe2 as Arc<dyn FlowEntryInfo>));
+        fe1.push_child(&(fe2 as Arc<dyn FlowEntryInfo>)).unwrap();
 
         // A flow entry cannot be removed by the timer until all its children
         // have been evicted or expired.
@@ -925,7 +968,7 @@ mod test {
             ft2.add(flowid, ParentSet(vec![fe1.clone() as Arc<_>])).unwrap();
 
         let t1 = fe2.last_hit();
-        fe1.push_child(&(fe2.clone() as Arc<dyn FlowEntryInfo>));
+        fe1.push_child(&(fe2.clone() as Arc<dyn FlowEntryInfo>)).unwrap();
 
         // Updating the last-hit time of a flow won't immediately propagate to
         // its children.
@@ -1078,9 +1121,11 @@ mod test {
         let fe_out_of_chain = ft2_2.add(flowid, ()).unwrap();
         let fe3 = ft3.add(flowid, ()).unwrap();
 
-        fe1.push_child(&(fe2.clone() as Arc<dyn FlowEntryInfo>));
-        fe2.push_child(&(fe3.clone() as Arc<dyn FlowEntryInfo>));
-        fe_out_of_chain.push_child(&(fe3.clone() as Arc<dyn FlowEntryInfo>));
+        fe1.push_child(&(fe2.clone() as Arc<dyn FlowEntryInfo>)).unwrap();
+        fe2.push_child(&(fe3.clone() as Arc<dyn FlowEntryInfo>)).unwrap();
+        fe_out_of_chain
+            .push_child(&(fe3.clone() as Arc<dyn FlowEntryInfo>))
+            .unwrap();
 
         // If we invalidate fe1, then all of its *direct descendants* will also
         // be invalid.
@@ -1147,19 +1192,19 @@ mod test {
         // When an explicit priority is requested by any descendent, we choose the
         // strongest requirement that the flow remain in place. Each flow we push
         // here makes the flow less likely for eviction.
-        fe1.push_child(&(fe2.clone() as Arc<dyn FlowEntryInfo>));
+        fe1.push_child(&(fe2.clone() as Arc<dyn FlowEntryInfo>)).unwrap();
         assert_eq!(
             fe1.eviction_priority(now),
             Some(EvictionPriority::Evictable(NonZeroU16::MAX)),
         );
 
-        fe1.push_child(&(fe2_2.clone() as Arc<dyn FlowEntryInfo>));
+        fe1.push_child(&(fe2_2.clone() as Arc<dyn FlowEntryInfo>)).unwrap();
         assert_eq!(
             fe1.eviction_priority(now),
             Some(EvictionPriority::Evictable(NonZeroU16::MIN)),
         );
 
-        fe1.push_child(&(fe2_3.clone() as Arc<dyn FlowEntryInfo>));
+        fe1.push_child(&(fe2_3.clone() as Arc<dyn FlowEntryInfo>)).unwrap();
         assert_eq!(
             fe1.eviction_priority(now),
             Some(EvictionPriority::Protected),

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -25,6 +25,7 @@ use core::num::NonZeroU16;
 use core::num::NonZeroU32;
 use core::sync::atomic::AtomicBool;
 use core::sync::atomic::AtomicU64;
+use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering;
 #[cfg(all(not(feature = "std"), not(test)))]
 use illumos_sys_hdrs::uintptr_t;
@@ -197,12 +198,14 @@ impl<S: FlowState> FlowEntryInfo for FlowEntry<S> {
         // If we have an explicit priority, we keep the most-protected (lowest)
         // priority which we know of.
         let mut best_prio = own_prio;
-        for maybe_child in &*self.lifetime.children.read() {
-            if let Some(child) = maybe_child.0.upgrade() {
-                match (best_prio, child.eviction_priority(now)) {
-                    (None, a) => best_prio = a,
-                    (Some(_), None) => {}
-                    (Some(old), Some(new)) => best_prio = Some(new.min(old)),
+        if self.lifetime.n_children.load(Ordering::Relaxed) > 0 {
+            for maybe_child in &*self.lifetime.children.read() {
+                if let Some(child) = maybe_child.0.upgrade() {
+                    match (best_prio, child.eviction_priority(now)) {
+                        (None, a) => best_prio = a,
+                        (Some(_), None) => {}
+                        (Some(old), Some(new)) => best_prio = Some(new.min(old)),
+                    }
                 }
             }
         }
@@ -219,6 +222,7 @@ impl<S: FlowState> FlowEntryInfo for FlowEntry<S> {
             children.len() < Self::MAX_CHILDREN || children.contains(&to_place);
         if can_insert {
             children.insert(to_place);
+            self.lifetime.n_children.store(children.len(), Ordering::Relaxed);
             Ok(())
         } else {
             Err(OpteError::MaxCapacity(
@@ -230,6 +234,7 @@ impl<S: FlowState> FlowEntryInfo for FlowEntry<S> {
     fn remove_child(&self, child: &Arc<dyn FlowEntryInfo>) {
         let mut children = self.lifetime.children.write();
         children.remove(&ByAddr(Arc::downgrade(child)));
+        self.lifetime.n_children.store(children.len(), Ordering::Relaxed);
     }
 
     fn mark_evicted(&self) {
@@ -350,6 +355,7 @@ impl<S: FlowState> FlowTable<S> {
                 // contention here.
                 let mut children = entry.lifetime.children.write();
                 children.retain(|el| el.0.upgrade().is_some());
+                entry.lifetime.n_children.store(children.len(), Ordering::Relaxed);
                 if !children.is_empty() {
                     return true;
                 }
@@ -555,6 +561,8 @@ struct FlowLifetime {
     /// Whether this flow entry has been explicitly removed.
     killed: AtomicBool,
 
+    n_children: AtomicUsize,
+
     /// Entries in remote tables which rely on the continued existence of
     /// this flow.
     ///
@@ -565,10 +573,11 @@ struct FlowLifetime {
 
 impl fmt::Debug for FlowLifetime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let FlowLifetime { last_hit, killed, children: _ } = self;
+        let FlowLifetime { last_hit, killed, n_children, children: _ } = self;
         f.debug_struct("FlowEntry")
             .field("last_hit", last_hit)
             .field("killed", killed)
+            .field("n_children", n_children)
             .field("children", &"<lock>")
             .finish()
     }
@@ -713,6 +722,7 @@ impl<S: FlowState> FlowEntry<S> {
             lifetime: Arc::new(FlowLifetime {
                 last_hit: Moment::now().raw().into(),
                 killed: false.into(),
+                n_children: 0.into(),
                 children: KRwLock::new(BTreeSet::new()),
             }),
         }

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -337,13 +337,24 @@ impl<S: FlowState> FlowTable<S> {
         }
     }
 
-    pub fn expire_flows<F>(&mut self, now: Moment, f: F) -> Vec<InnerFlowId>
+    pub fn expire_flows(&mut self, now: Moment) {
+        fn a<S>(val: &S) -> InnerFlowId { unreachable!() }
+
+        let p: Option<(&mut Self, _)> = if false {
+            Some((unreachable!(), a))
+        } else {
+            None
+        };
+        self.expire_flows_partner(p, now);
+    }
+
+    pub fn expire_flows_partner<F, T>(&mut self, mut partner: Option<(&mut FlowTable<T>, F)>, now: Moment)
     where
         F: Fn(&S) -> InnerFlowId,
+        T: FlowState
     {
         let name_c = &self.name_c;
         let port_c = &self.port_c;
-        let mut expired = vec![];
 
         self.map.retain(|flowid, entry| {
             // A flow cannot be expired by the timer while it still has children
@@ -375,14 +386,15 @@ impl<S: FlowState> FlowTable<S> {
                     Some(now.raw_millis()),
                 );
                 entry.expiry_cleanup();
-                expired.push(f(entry.state()));
+                if let Some((partner, extractor)) = &mut partner {
+                    partner.expire(&extractor(entry.state()));
+                }
+
                 return false;
             }
 
             !entry.is_killed()
         });
-
-        expired
     }
 
     /// Determine whether there is currently space for a new entry to be
@@ -899,11 +911,9 @@ mod test {
         ft.add(flowid, ()).unwrap();
         let now = Moment::now();
         assert_eq!(ft.num_flows(), 1);
-        ft.expire_flows(now, |_| FLOW_ID_DEFAULT);
+        ft.expire_flows(now);
         assert_eq!(ft.num_flows(), 1);
-        ft.expire_flows(now + Duration::new(FLOW_DEF_EXPIRE_SECS, 0), |_| {
-            FLOW_ID_DEFAULT
-        });
+        ft.expire_flows(now + Duration::new(FLOW_DEF_EXPIRE_SECS, 0));
         assert_eq!(ft.num_flows(), 0);
     }
 
@@ -951,15 +961,15 @@ mod test {
         // A flow entry cannot be removed by the timer until all its children
         // have been evicted or expired.
         let t2 = now + Duration::new(FLOW_DEF_EXPIRE_SECS, 0);
-        ft1.expire_flows(t2, |_| FLOW_ID_DEFAULT);
+        ft1.expire_flows(t2);
         assert_eq!(ft1.num_flows(), 1);
 
         // If we go via ft2 first, we will be able to remove its entries (which
         // have no children), which in turn makes ft1's entries available for
         // eviction.
-        ft2.expire_flows(t2, |_| FLOW_ID_DEFAULT);
+        ft2.expire_flows(t2);
         assert_eq!(ft2.num_flows(), 0);
-        ft1.expire_flows(t2, |_| FLOW_ID_DEFAULT);
+        ft1.expire_flows(t2);
         assert_eq!(ft1.num_flows(), 0);
     }
 
@@ -993,7 +1003,7 @@ mod test {
 
         // When fe2 is expired, it should pass on its expiry time to fe1.
         let t3 = t2 + Duration::new(FLOW_DEF_EXPIRE_SECS, 0);
-        ft2.expire_flows(t3, |_| FLOW_ID_DEFAULT);
+        ft2.expire_flows(t3);
         assert_eq!(ft2.num_flows(), 0);
         assert_eq!(fe1.last_hit(), t2);
     }

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -155,6 +155,11 @@ pub trait FlowEntryInfo: fmt::Debug + Send + Sync {
     /// than the stored value.
     fn inherit_last_hit(&self, new_time: Moment);
 
+    /// Forcibly set the last hit time on this entry to `new_time`, when
+    /// required by some tests/benchmarks.
+    #[cfg(any(feature = "std", test))]
+    fn inherit_last_hit_force(&self, new_time: Moment);
+
     /// Determine whether this flow entry can be evicted to make room for
     /// another, recursively checking all children when needed.
     fn eviction_priority(&self, now: Moment) -> Option<EvictionPriority>;
@@ -181,6 +186,11 @@ impl<S: FlowState> FlowEntryInfo for FlowEntry<S> {
             Ordering::Relaxed,
             |prior| (prior < new).then_some(new),
         );
+    }
+
+    #[cfg(any(feature = "std", test))]
+    fn inherit_last_hit_force(&self, new_time: Moment) {
+        self.lifetime.last_hit.store(new_time.raw(), Ordering::Relaxed);
     }
 
     fn eviction_priority(&self, now: Moment) -> Option<EvictionPriority> {
@@ -338,20 +348,27 @@ impl<S: FlowState> FlowTable<S> {
     }
 
     pub fn expire_flows(&mut self, now: Moment) {
-        fn a<S>(val: &S) -> InnerFlowId { unreachable!() }
+        // The below collection of unreachable functions, types etc. is needed
+        // because we can't otherwise name a function type `F` for
+        // `expire_flows_partner`.
+        fn a<S>(_: &S) -> InnerFlowId {
+            unreachable!()
+        }
 
-        let p: Option<(&mut Self, _)> = if false {
-            Some((unreachable!(), a))
-        } else {
-            None
-        };
+        #[allow(unreachable_code)]
+        let p: Option<(&mut Self, _)> =
+            if false { Some((unreachable!(), a)) } else { None };
+
         self.expire_flows_partner(p, now);
     }
 
-    pub fn expire_flows_partner<F, T>(&mut self, mut partner: Option<(&mut FlowTable<T>, F)>, now: Moment)
-    where
+    pub fn expire_flows_partner<F, T>(
+        &mut self,
+        mut partner: Option<(&mut FlowTable<T>, F)>,
+        now: Moment,
+    ) where
         F: Fn(&S) -> InnerFlowId,
-        T: FlowState
+        T: FlowState,
     {
         let name_c = &self.name_c;
         let port_c = &self.port_c;

--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -204,7 +204,9 @@ impl<S: FlowState> FlowEntryInfo for FlowEntry<S> {
                     match (best_prio, child.eviction_priority(now)) {
                         (None, a) => best_prio = a,
                         (Some(_), None) => {}
-                        (Some(old), Some(new)) => best_prio = Some(new.min(old)),
+                        (Some(old), Some(new)) => {
+                            best_prio = Some(new.min(old))
+                        }
                     }
                 }
             }
@@ -355,7 +357,10 @@ impl<S: FlowState> FlowTable<S> {
                 // contention here.
                 let mut children = entry.lifetime.children.write();
                 children.retain(|el| el.0.upgrade().is_some());
-                entry.lifetime.n_children.store(children.len(), Ordering::Relaxed);
+                entry
+                    .lifetime
+                    .n_children
+                    .store(children.len(), Ordering::Relaxed);
                 if !children.is_empty() {
                     return true;
                 }

--- a/lib/opte/src/engine/layer.rs
+++ b/lib/opte/src/engine/layer.rs
@@ -243,7 +243,10 @@ impl LayerFlowTable {
     fn expire_flows(&mut self, now: Moment) {
         // Flow table in/out entries share a lifetime struct, so it's irrelevant
         // which of these tables we check first.
-        self.ft_out.expire_flows_partner(Some((&mut self.ft_in, LftOutEntry::extract_pair)), now);
+        self.ft_out.expire_flows_partner(
+            Some((&mut self.ft_in, LftOutEntry::extract_pair)),
+            now,
+        );
         self.count = self.ft_out.num_flows();
     }
 

--- a/lib/opte/src/engine/layer.rs
+++ b/lib/opte/src/engine/layer.rs
@@ -40,7 +40,9 @@ use crate::ddi::kstat::KStatProvider;
 use crate::ddi::kstat::KStatU64;
 use crate::ddi::mblk::MsgBlk;
 use crate::ddi::time::Moment;
+use crate::engine::flow_table::FLOW_DEF_TTL;
 use crate::engine::flow_table::FlowState;
+use crate::engine::flow_table::TtlDelegateTcp;
 use alloc::ffi::CString;
 use alloc::string::String;
 use alloc::string::ToString;
@@ -326,8 +328,18 @@ impl LayerFlowTable {
         Self {
             count: 0,
             limit,
-            ft_in: FlowTable::new(port, &format!("{layer}_in"), limit, None),
-            ft_out: FlowTable::new(port, &format!("{layer}_out"), limit, None),
+            ft_in: FlowTable::new(
+                port,
+                &format!("{layer}_in"),
+                limit,
+                Some(Arc::new(TtlDelegateTcp(FLOW_DEF_TTL))),
+            ),
+            ft_out: FlowTable::new(
+                port,
+                &format!("{layer}_out"),
+                limit,
+                Some(Arc::new(TtlDelegateTcp(FLOW_DEF_TTL))),
+            ),
         }
     }
 

--- a/lib/opte/src/engine/layer.rs
+++ b/lib/opte/src/engine/layer.rs
@@ -243,11 +243,7 @@ impl LayerFlowTable {
     fn expire_flows(&mut self, now: Moment) {
         // Flow table in/out entries share a lifetime struct, so it's irrelevant
         // which of these tables we check first.
-        let to_expire =
-            self.ft_out.expire_flows(now, LftOutEntry::extract_pair);
-        for flow in to_expire {
-            self.ft_in.expire(&flow);
-        }
+        self.ft_out.expire_flows_partner(Some((&mut self.ft_in, LftOutEntry::extract_pair)), now);
         self.count = self.ft_out.num_flows();
     }
 

--- a/lib/opte/src/engine/port/mod.rs
+++ b/lib/opte/src/engine/port/mod.rs
@@ -129,6 +129,7 @@ pub enum ProcessError {
     TcpFlow(TcpFlowStateError),
     BadEmitSpec,
     FlowTableFull { kind: &'static str, limit: u64 },
+    LftChildrenFull,
 }
 
 impl From<super::HdlPktError> for ProcessError {
@@ -544,7 +545,7 @@ pub enum DumpLayerError {
 // API version change until this is something that *can* actually be specified
 // on a per-port basis.
 pub trait FlowId:
-    fmt::Debug + Send + Sync + Copy + Eq + Ord + core::hash::Hash
+    fmt::Debug + Send + Sync + Copy + Eq + Ord + core::hash::Hash + 'static
 {
 }
 impl FlowId for InnerFlowId {}
@@ -2611,8 +2612,19 @@ impl<N: NetworkImpl> Port<N> {
                     match data.uft_in.add(*ufid_in, hte) {
                         Ok(v) => {
                             self.new_uft_kstat(In, data);
-                            associate_lfts_upstack(data, &v, Direction::In);
-                            Ok(InternalProcessResult::Modified)
+                            match associate_lfts_upstack(
+                                data,
+                                &v,
+                                Direction::In,
+                            ) {
+                                Ok(_) => Ok(InternalProcessResult::Modified),
+                                Err(OpteError::MaxCapacity(_)) => {
+                                    Err(ProcessError::LftChildrenFull)
+                                }
+                                Err(_) => unreachable!(
+                                    "UFT association can only fail due to capacity checks."
+                                ),
+                            }
                         }
                         Err(OpteError::MaxCapacity(limit)) => {
                             Err(ProcessError::FlowTableFull {
@@ -2652,8 +2664,15 @@ impl<N: NetworkImpl> Port<N> {
             match data.uft_in.add(*ufid_in, hte) {
                 Ok(v) => {
                     self.new_uft_kstat(In, data);
-                    associate_lfts_upstack(data, &v, Direction::In);
-                    Ok(InternalProcessResult::Modified)
+                    match associate_lfts_upstack(data, &v, Direction::In) {
+                        Ok(_) => Ok(InternalProcessResult::Modified),
+                        Err(OpteError::MaxCapacity(_)) => {
+                            Err(ProcessError::LftChildrenFull)
+                        }
+                        Err(_) => unreachable!(
+                            "UFT association can only fail due to capacity checks."
+                        ),
+                    }
                 }
                 Err(OpteError::MaxCapacity(limit)) => {
                     Err(ProcessError::FlowTableFull { kind: "UFT", limit })
@@ -2818,8 +2837,15 @@ impl<N: NetworkImpl> Port<N> {
                 match data.uft_out.add(flow_before, hte) {
                     Ok(v) => {
                         self.new_uft_kstat(Out, data);
-                        associate_lfts_upstack(data, &v, Direction::Out);
-                        Ok(InternalProcessResult::Modified)
+                        match associate_lfts_upstack(data, &v, Direction::Out) {
+                            Ok(_) => Ok(InternalProcessResult::Modified),
+                            Err(OpteError::MaxCapacity(_)) => {
+                                Err(ProcessError::LftChildrenFull)
+                            }
+                            Err(_) => unreachable!(
+                                "UFT association can only fail due to capacity checks."
+                            ),
+                        }
                     }
                     Err(OpteError::MaxCapacity(limit)) => {
                         Err(ProcessError::FlowTableFull { kind: "UFT", limit })
@@ -3217,7 +3243,7 @@ fn associate_lfts_upstack(
     _data: &mut PortData,
     uft: &Arc<FlowEntry<UftEntry<InnerFlowId>>>,
     dir: Direction,
-) {
+) -> Result<()> {
     // The goal here is to provide each LFT hit with two children where
     // possible. These are the UFT and, when it exists, the TCP flow entry.
     // What this means in practice is that while either is present, the LFTs
@@ -3231,7 +3257,7 @@ fn associate_lfts_upstack(
     // on the UFT to keep it a small cache without breaking flows.
     let uft_dyn: Arc<dyn FlowEntryInfo> = Arc::clone(uft) as _;
     for lft in &uft.state().parents {
-        lft.push_child(&uft_dyn);
+        lft.push_child(&uft_dyn)?;
     }
 
     // Currently, we're explicitly holding a write lock on the parent port,
@@ -3254,9 +3280,11 @@ fn associate_lfts_upstack(
             old_lft.remove_child(&tcp_dyn);
         }
         for new_lft in new_parent_slot {
-            new_lft.push_child(&tcp_dyn);
+            new_lft.push_child(&tcp_dyn)?;
         }
     }
+
+    Ok(())
 }
 
 impl core::fmt::Debug for TcpFlowEntryState {

--- a/lib/opte/src/engine/port/mod.rs
+++ b/lib/opte/src/engine/port/mod.rs
@@ -1171,13 +1171,13 @@ impl<N: NetworkImpl> Port<N> {
         // A TCP state entry or UFT may in turn reference any number of LFT
         // hits, so we visit those first to maximise the likelihood that we can
         // clear up as many entries as possible.
-        let _ = data.tcp_flows.expire_flows(now, |_| FLOW_ID_DEFAULT);
+        data.tcp_flows.expire_flows(now);
         self.stats.vals.tcp_flows.set(u64::from(data.tcp_flows.num_flows()));
 
-        let _ = data.uft_in.expire_flows(now, |_| FLOW_ID_DEFAULT);
+        data.uft_in.expire_flows(now);
         self.stats.vals.in_uft_flows.set(u64::from(data.uft_in.num_flows()));
 
-        let _ = data.uft_out.expire_flows(now, |_| FLOW_ID_DEFAULT);
+        data.uft_out.expire_flows(now);
         self.stats.vals.out_uft_flows.set(u64::from(data.uft_out.num_flows()));
 
         for l in &mut data.layers {

--- a/lib/opte/src/engine/port/mod.rs
+++ b/lib/opte/src/engine/port/mod.rs
@@ -1187,6 +1187,46 @@ impl<N: NetworkImpl> Port<N> {
         Ok(())
     }
 
+    /// Use the function `f` to probabilistically mark flows as being ready
+    /// for expiry by offsetting their timestamps into the past.
+    ///
+    /// `f` should return true for a flow which we want to mark (and mark its
+    /// children as) expirable.
+    #[cfg(any(feature = "std", test))]
+    pub fn inject_expiry(&self, mut f: impl FnMut() -> bool) {
+        use core::time::Duration;
+
+        let now = Moment::now();
+        let earlier = now - Duration::from_secs(61);
+        let earlierer = earlier - Duration::from_secs(61);
+
+        let data = self.data.write();
+        for dir in [Direction::In, Direction::Out] {
+            let map = match dir {
+                Direction::In => data.uft_in.iter(),
+                Direction::Out => data.uft_out.iter(),
+            };
+            for (_, entry) in map {
+                let tcp =
+                    entry.state().tcp_flow.as_ref().and_then(|v| v.upgrade());
+                if !f() {
+                    entry.hit_at(now);
+                    if let Some(tcp) = tcp {
+                        tcp.hit_at(now);
+                    }
+                    continue;
+                }
+                entry.hit_at(earlier);
+                if let Some(tcp) = tcp {
+                    tcp.hit_at(earlier);
+                }
+                for parent in &entry.state().parents {
+                    parent.inherit_last_hit_force(earlierer);
+                }
+            }
+        }
+    }
+
     /// Find a rule in the specified layer and return its id.
     ///
     /// Search for a matching rule in the specified layer that has the


### PR DESCRIPTION
XXX Expand

* UFT table entries have the wrong expiry policy, and TCP flows can
  thrash heavily rather than blocking insertion.
* Eviction should not delegate cleanup of child references to the
  periodic task.
* The number of child references on any FlowEntry should be limited to
  prevent unbounded growth -- we expect this to be 2 active children per
  hit LFT!