### PR TITLE
UFT tables should not attempt to delegate eviction score

### DIFF
--- a/lib/opte/src/engine/flow_table.rs
+++ b/lib/opte/src/engine/flow_table.rs
@@ -66,6 +66,12 @@ impl Ttl {
     }
 }
 
+/// An eviction policy table which makes TCP flow entries without live flowstate
+/// parents trivially evictable. When present, the TCP flow state will signal
+/// a value to be used in its place.
+#[derive(Clone, Copy, Debug)]
+pub struct TtlDelegateTcp(pub Ttl);
+
 /// A metric of how stale a flow entry is, used to determine whether
 /// any existing entry can be evicted to make room for a new one.
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Default)]
@@ -100,6 +106,20 @@ pub trait ExpiryPolicy<S: FlowState>: fmt::Debug + Send + Sync {
 impl<S: FlowState> ExpiryPolicy<S> for Ttl {
     fn is_expired(&self, entry: &FlowEntry<S>, now: Moment) -> bool {
         self.is_expired(entry.last_hit(), now)
+    }
+
+    fn eviction_priority(
+        &self,
+        _entry: &FlowEntry<S>,
+        _now: Moment,
+    ) -> Option<EvictionPriority> {
+        None
+    }
+}
+
+impl<S: FlowState> ExpiryPolicy<S> for TtlDelegateTcp {
+    fn is_expired(&self, entry: &FlowEntry<S>, now: Moment) -> bool {
+        self.0.is_expired(entry.last_hit(), now)
     }
 
     fn eviction_priority(

--- a/lib/opte/src/engine/layer.rs
+++ b/lib/opte/src/engine/layer.rs
@@ -40,7 +40,9 @@ use crate::ddi::kstat::KStatProvider;
 use crate::ddi::kstat::KStatU64;
 use crate::ddi::mblk::MsgBlk;
 use crate::ddi::time::Moment;
+use crate::engine::flow_table::FLOW_DEF_TTL;
 use crate::engine::flow_table::FlowState;
+use crate::engine::flow_table::TtlDelegateTcp;
 use alloc::ffi::CString;
 use alloc::string::String;
 use alloc::string::ToString;
@@ -326,8 +328,18 @@ impl LayerFlowTable {
         Self {
             count: 0,
             limit,
-            ft_in: FlowTable::new(port, &format!("{layer}_in"), limit, None),
-            ft_out: FlowTable::new(port, &format!("{layer}_out"), limit, None),
+            ft_in: FlowTable::new(
+                port,
+                &format!("{layer}_in"),
+                limit,
+                Some(Arc::new(TtlDelegateTcp(FLOW_DEF_TTL))),
+            ),
+            ft_out: FlowTable::new(
+                port,
+                &format!("{layer}_out"),
+                limit,
+                Some(Arc::new(TtlDelegateTcp(FLOW_DEF_TTL))),
+            ),
         }
     }
 


### PR DESCRIPTION
Only layers' flow table entries have parents, with the setup we have
today. One of the things we do which takes advantage of this is that for
a TCP flow, LFT entries will receive a high evictability score -- we do
so because one of these parents is an entry in the TCP flow table. If
the entry is absent, we know we have a disconnected LFT entry that can
be safely removed. If it is present, it will reduce the entry's
evictability with a better score.

The problem is that this logic was implemented directly on the `Ttl`
type, which we use by default. The UFTs then assign a maximum
evictability to any TCP flows, forcing them into having LRU eviction
because there is no child entry -- that's not the policy we want. (Yet,
at least.)

This fix moves that behaviour into a newtype and has the LFTs explcitly
opt into that behaviour.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>